### PR TITLE
[UK-860] Fix issues of event filter and Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ release
 # misc
 .DS_Store
 .env
-.env.example
 .env.local
 .env.development.local
 .env.test.local

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ release
 # misc
 .DS_Store
 .env
+.env.example
 .env.local
 .env.development.local
 .env.test.local

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -3,7 +3,11 @@ import React, { useEffect, useState } from 'react';
 import pkg from '../../../../package-lock.json'
 
 import App from '../index';
+import Sendbird from '../../../lib/Sendbird';
+import ChannelList from '../../ChannelList';
+import Conversation from '../../Conversation';
 import { fitPageSize } from './utils';
+
 const appId = process.env.STORYBOOK_APP_ID;
 // const userId = 'leo.sub';
 const userId = 'sendbird';
@@ -159,6 +163,7 @@ const array = [
   `hoon${age}1`,
   `hoon${age}2`,
   `hoon${age}3`,
+  `eunseo${age}1`,
 ];
 const addProfile = null; // 'https://static.sendbird.com/sample/profiles/profile_12_512px.png';
 
@@ -186,6 +191,7 @@ export const user1 = () => fitPageSize(
     allowProfileEdit
     profileUrl={addProfile}
     config={{ logLevel: 'all' }}
+    queries={{}}
   />
 );
 export const user2 = () => fitPageSize(
@@ -215,6 +221,38 @@ export const user3 = () => fitPageSize(
     }}
   />
 );
+
+const CustomApp = () => {
+  const [channelUrl, setChannelUrl] = useState('');
+  return (
+    <Sendbird
+      appId={appId}
+      userId={array[3]}
+      nickname={array[3]}
+      theme="dark"
+      showSearchIcon
+      allowProfileEdit
+      profileUrl={addProfile}
+      imageCompression={{
+        compressionRate: 0.5,
+        resizingWidth: 100,
+        resizingHeight: '100px',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'row', width: '100%', height: '100%' }}>
+        <ChannelList
+          onChannelSelect={(channel) => { setChannelUrl(channel.url) }}
+          queries={{ channelListQuery: { superChannelFilter: 'super' } }}
+        />
+        <Conversation
+          channelUrl={channelUrl}
+          // queries={{ messageListParams: { senderUserIds: ['eunseo601'] } }}
+        />
+      </div>
+    </Sendbird>
+  );
+};
+export const customer1 = () => fitPageSize(<CustomApp />);
 
 export const disableUserProfile = () => fitPageSize(
   <App

--- a/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
+++ b/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
@@ -1,7 +1,8 @@
-import mockData, { channel1, channel0 } from '../data.mock';
+import mockData, { channel1, channel0, users, creatingChannel } from '../data.mock';
 import * as actionTypes from '../actionTypes';
 import reducers from '../reducers';
 import initialState from '../initialState';
+const [user1, user2, user3] = users;
 
 describe('Channels-Reducers', () => {
   it('should set channels on INIT_CHANNELS_SUCCESS', () => {
@@ -13,7 +14,7 @@ describe('Channels-Reducers', () => {
     expect(nextState.initialized).toEqual(true);
     expect(nextState.allChannels).toEqual(mockData.allChannels);
     expect(nextState.currentChannel).toEqual(mockData.allChannels[0].url);
-  })
+  });
 
   it('should handle create new channel using CREATE_CHANNEL', () => {
     const nextState = reducers(mockData, {
@@ -23,7 +24,7 @@ describe('Channels-Reducers', () => {
 
     expect(nextState.allChannels[0].url).toEqual(mockData.allChannels[1].url);
     expect(nextState.currentChannel).toEqual(mockData.allChannels[1].url);
-  })
+  });
 
   it('should handle leave channel action LEAVE_CHANNEL_SUCCESS', () => {
     const channelUrl = "sendbird_group_channel_13883929_89ea0faddf24ba6328e95ff56b0b37960f400c83";
@@ -34,7 +35,7 @@ describe('Channels-Reducers', () => {
 
     expect(nextState.allChannels.length).toEqual(2);
     expect(nextState.allChannels.find(c => c.url === channelUrl)).toBeUndefined();
-  })
+  });
 
   it('should handle push changed channel to the top on ON_CHANNEL_CHANGED', () => {
     const lastMessage = "new last message";
@@ -49,7 +50,7 @@ describe('Channels-Reducers', () => {
     });
     expect(nextState.allChannels.length).toEqual(3);
     expect(nextState.allChannels[0].lastMessage.message).toEqual(lastMessage);
-  })
+  });
 
   it('should not be changed empty channel on ON_CHANNEL_CHANGED', () => {
     const emptyChannel = { ...channel0, lastMessage: null };
@@ -59,7 +60,7 @@ describe('Channels-Reducers', () => {
     });
     expect(nextState.allChannels.length).toEqual(3);
     expect(nextState.allChannels[0].lastMessage.message).toEqual(mockData.allChannels[0].lastMessage.message);
-  })
+  });
 
   it('should handle push changed channel to the top on ON_CHANNEL_CHANGED even when its not there', () => {
     const nextState = reducers(initialState, {
@@ -68,7 +69,7 @@ describe('Channels-Reducers', () => {
     });
     expect(nextState.allChannels.length).toEqual(1);
     expect(nextState.allChannels[0].url).toEqual(mockData.allChannels[0].url);
-  })
+  });
 
   it('should handle SET_CURRENT_CHANNEL', () => {
     const nextState = reducers(initialState, {
@@ -76,21 +77,21 @@ describe('Channels-Reducers', () => {
       payload: mockData.allChannels[0].url,
     });
     expect(nextState.currentChannel).toEqual(mockData.allChannels[0].url);
-  })
+  });
 
   it('should handle SHOW_CHANNEL_SETTINGS', () => {
     const nextState = reducers(initialState, {
       type: actionTypes.SHOW_CHANNEL_SETTINGS,
     });
     expect(nextState.showSettings).toEqual(true);
-  })
+  });
 
   it('should handle HIDE_CHANNEL_SETTINGS', () => {
     const nextState = reducers(initialState, {
       type: actionTypes.HIDE_CHANNEL_SETTINGS,
     });
     expect(nextState.showSettings).toEqual(false);
-  })
+  });
 
   it('should attach more channels on FETCH_CHANNELS_SUCCESS', () => {
     const nextState = reducers(mockData, {
@@ -103,7 +104,7 @@ describe('Channels-Reducers', () => {
       channel0,
       channel1,
     ]);
-  })
+  });
 
   it('should ignore already existing channels on attaching more channels on FETCH_CHANNELS_SUCCESS', () => {
     const nextState = reducers(mockData, {
@@ -115,5 +116,727 @@ describe('Channels-Reducers', () => {
       ...mockData.allChannels,
       channel1,
     ]);
-  })
-})
+  });
+
+  it('should set channelListQuery for filter', () => {
+    const channelListQuery = {
+      _searchFilter: {
+        search_fields: ['channel_name', 'member_nicknames'],
+        search_query: 'abcd',
+      },
+      _userIdsFilter: {
+        userIds: ['hoon001', 'hoon002'],
+        includeMode: false,
+        queryType: 'AND',
+      },
+      nicknameContainsFilter: 'honny',
+      channelNameContainsFilter: '1010',
+      memberStateFilter: 'all',
+      customTypesFilter: ['apple', 'banana'],
+      channelUrlsFilter: ['channel1010', 'channel1011'],
+      superChannelFilter: 'all' || 'super' || 'nonsuper' || 'broadcast_only',
+      publicChannelFilter: 'all' || 'public' || 'private',
+      customTypeStartsWithFilter: 'app',
+      unreadChannelFilter: 'all' || 'unread_message',
+      hiddenChannelFilter: 'unhidden_only' || 'hidden_only',
+      includeFrozen: true,
+    };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: channelListQuery },
+    });
+    const appliedQuery = appliedParamsState.channelListQuery;
+    expect(appliedQuery._searchFilter.search_fields).toEqual(channelListQuery._searchFilter.search_fields);
+    expect(appliedQuery._searchFilter.search_query).toEqual(channelListQuery._searchFilter.search_query);
+    expect(appliedQuery._userIdsFilter.userIds).toEqual(channelListQuery._userIdsFilter.userIds);
+    expect(appliedQuery._userIdsFilter.includeMode).toEqual(channelListQuery._userIdsFilter.includeMode);
+    expect(appliedQuery._userIdsFilter.queryType).toEqual(channelListQuery._userIdsFilter.queryType);
+    expect(appliedQuery.nicknameContainsFilter).toEqual(channelListQuery.nicknameContainsFilter);
+    expect(appliedQuery.channelNameContainsFilter).toEqual(channelListQuery.channelNameContainsFilter);
+    expect(appliedQuery.memberStateFilter).toEqual(channelListQuery.memberStateFilter);
+    expect(appliedQuery.customTypesFilter).toEqual(channelListQuery.customTypesFilter);
+    expect(appliedQuery.channelUrlsFilter).toEqual(channelListQuery.channelUrlsFilter);
+    expect(appliedQuery.superChannelFilter).toEqual(channelListQuery.superChannelFilter);
+    expect(appliedQuery.publicChannelFilter).toEqual(channelListQuery.publicChannelFilter);
+    expect(appliedQuery.customTypeStartsWithFilter).toEqual(channelListQuery.customTypeStartsWithFilter);
+    expect(appliedQuery.unreadChannelFilter).toEqual(channelListQuery.unreadChannelFilter);
+    expect(appliedQuery.hiddenChannelFilter).toEqual(channelListQuery.hiddenChannelFilter);
+    expect(appliedQuery.includeFrozen).toEqual(channelListQuery.includeFrozen);
+  });
+
+  it('should filter by searchFilter of channelListQuery', () => {
+    const channelListQuery = {
+      _searchFilter: { search_fields: ['member_nickname'], search_query: user1.nickname },
+    };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery },
+    });
+    expect(appliedParamsState.channelListQuery._searchFilter.search_query).toEqual(user1.nickname);
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const createdChannelState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: newChannel,
+    });
+    expect(createdChannelState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createdChannelState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+    const onUserLeftState = reducers(createdChannelState, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user2] },
+        isMe: true,
+      },
+    });
+    expect(onUserLeftState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onUserLeftState.allChannels.length).toEqual(createdChannelState.allChannels.length - 1);
+    const onUserJoinedState = reducers(onUserLeftState, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(onUserJoinedState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onUserJoinedState.allChannels.length).toEqual(onUserLeftState.allChannels.length + 1);
+
+    const paramsWithChannelNameState = reducers(onUserJoinedState, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: { _searchFilter: { ...channelListQuery._searchFilter, search_fields: ['channel_name'] } },
+      },
+    });
+    expect(paramsWithChannelNameState.channelListQuery._searchFilter.search_fields).toEqual(['channel_name']);
+    expect(paramsWithChannelNameState.channelListQuery._searchFilter.search_query).toEqual(user1.nickname);
+
+    const anotherUserJoinedState = reducers(paramsWithChannelNameState, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2, user3] },
+    });
+    expect(anotherUserJoinedState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(anotherUserJoinedState.allChannels.length).toEqual(paramsWithChannelNameState.allChannels.length - 1);
+    const onChannelChangedState = reducers(anotherUserJoinedState, {
+      type: actionTypes.ON_CHANNEL_CHANGED,
+      payload: { ...newChannel, name: `home party for ${user1.nickname}` },
+    });
+    expect(onChannelChangedState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onChannelChangedState.allChannels.length).toEqual(anotherUserJoinedState.allChannels.length + 1);
+  });
+
+  it.only('should filter by userIdsFilter of channelListQuery', () => {
+    const newChannel = { ...creatingChannel };
+    const exactUserIdsFilterState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: {
+          _userIdsFilter: { userIds: [user1.userId, user2.userId], includeMode: false },
+        },
+      }
+    });
+    expect(exactUserIdsFilterState.allChannels[0].url).not.toEqual(newChannel.url);
+    const includeORUserIdsFilterState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: {
+          _userIdsFilter: {
+            userIds: [user1.userId, user2.userId],
+            includeMode: true,
+            queryType: 'OR',
+          },
+        },
+      }
+    });
+    expect(includeORUserIdsFilterState.allChannels[0].url).not.toEqual(newChannel.url);
+    const includeANDUserIdsFilterState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: {
+          _userIdsFilter: {
+            userIds: [user1.userId, user2.userId],
+            includeMode: true,
+            queryType: 'AND',
+          },
+        },
+      }
+    });
+    expect(includeANDUserIdsFilterState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    // exact filter
+    const exactMembersOnExactState = reducers(exactUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(exactMembersOnExactState.allChannels[0].url).toEqual(newChannel.url);
+    expect(exactMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length + 1);
+    const overMembersOnExactState = reducers(exactUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1, user2, user3] },
+    });
+    expect(overMembersOnExactState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(overMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
+    const lessMembersOnExactState = reducers(exactUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1] },
+    });
+    expect(lessMembersOnExactState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(lessMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
+    // exact filter, member changed test
+    const memberLeftFromExactMembers = reducers(exactMembersOnExactState, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user1] },
+        isMe: false,
+      },
+    });
+    expect(memberLeftFromExactMembers.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(memberLeftFromExactMembers.allChannels.length).toEqual(exactMembersOnExactState.allChannels.length - 1);
+    const memberLeftFromOverMembers = reducers(overMembersOnExactState, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user1, user2] },
+        isMe: false,
+      }
+    });
+    expect(memberLeftFromOverMembers.allChannels[0].url).toEqual(newChannel.url);
+    expect(memberLeftFromOverMembers.allChannels.length).toEqual(overMembersOnExactState.allChannels.length + 1);
+    const memberJoinedToLessMembers = reducers(lessMembersOnExactState, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(memberJoinedToLessMembers.allChannels[0].url).toEqual(newChannel.url);
+    expect(memberJoinedToLessMembers.allChannels.length).toEqual(lessMembersOnExactState.allChannels.length + 1);
+
+    // include OR
+    const includeMembersOnIncludeOR = reducers(includeORUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(includeMembersOnIncludeOR.allChannels[0].url).toEqual(newChannel.url);
+    expect(includeMembersOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
+    const onlyMemberOnIncludeOR = reducers(includeORUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1] },
+    });
+    expect(onlyMemberOnIncludeOR.allChannels[0].url).toEqual(newChannel.url);
+    expect(onlyMemberOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
+    const incorrectMembersOnIncludeOR = reducers(includeORUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user3] },
+    });
+    expect(incorrectMembersOnIncludeOR.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(incorrectMembersOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length);
+    // includle OR, member changed
+    const memberLeftFromIncludeMembers = reducers(includeMembersOnIncludeOR, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user1] },
+        isMe: false,
+      }
+    });
+    expect(memberLeftFromIncludeMembers.allChannels[0].url).toEqual(newChannel.url);
+    expect(memberLeftFromIncludeMembers.allChannels.length).toEqual(includeMembersOnIncludeOR.allChannels.length);
+    const memberJoinedToIncludeMembers = reducers(includeMembersOnIncludeOR, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2, user3] },
+    });
+    expect(memberJoinedToIncludeMembers.allChannels[0].url).toEqual(newChannel.url);
+    expect(memberJoinedToIncludeMembers.allChannels.length).toEqual(includeMembersOnIncludeOR.allChannels.length);
+    const targetMemberJoinedToIncorrectMembers = reducers(incorrectMembersOnIncludeOR, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user3] },
+    });
+    expect(targetMemberJoinedToIncorrectMembers.allChannels[0].url).toEqual(newChannel.url);
+    expect(
+      targetMemberJoinedToIncorrectMembers.allChannels.length
+    ).toEqual(incorrectMembersOnIncludeOR.allChannels.length + 1);
+
+    // include AND
+    const includeMembersOnIncludeAND = reducers(includeANDUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(includeMembersOnIncludeAND.allChannels[0].url).toEqual(newChannel.url);
+    expect(includeMembersOnIncludeAND.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
+    const onlyMemberOnIncludeAND = reducers(includeANDUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1] },
+    });
+    expect(onlyMemberOnIncludeAND.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onlyMemberOnIncludeAND.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
+    const incorrectMembersOnIncludeAND = reducers(includeANDUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user3] },
+    });
+    expect(incorrectMembersOnIncludeOR.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(incorrectMembersOnIncludeOR.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
+    const overMembersOnIncludeAnd = reducers(includeANDUserIdsFilterState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, members: [user1, user2, user3]},
+    });
+    expect(overMembersOnIncludeAnd.allChannels[0].url).toEqual(newChannel.url);
+    expect(overMembersOnIncludeAnd.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
+    // include AND, member changed
+    const memberLeftFromIncludeAND = reducers(includeMembersOnIncludeAND, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user1] },
+        isMe: false,
+      }
+    });
+    expect(memberLeftFromIncludeAND.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(
+      memberLeftFromIncludeAND.allChannels.length
+    ).toEqual(includeMembersOnIncludeAND.allChannels.length - 1);
+    const memberJoinedToIncludeAND = reducers(includeMembersOnIncludeAND, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2, user3] },
+    });
+    expect(memberJoinedToIncludeAND.allChannels[0].url).toEqual(newChannel.url);
+    expect(memberJoinedToIncludeAND.allChannels.length).toEqual(includeMembersOnIncludeAND.allChannels.length);
+    const includeMemberJoinedToOnlyMemberAND = reducers(onlyMemberOnIncludeAND, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2] },
+    });
+    expect(includeMemberJoinedToOnlyMemberAND.allChannels[0].url).toEqual(newChannel.url);
+    expect(
+      includeMemberJoinedToOnlyMemberAND.allChannels.length
+    ).toEqual(onlyMemberOnIncludeAND.allChannels.length + 1);
+    const includeMemberJoinedToIncorrectMembersAND = reducers(incorrectMembersOnIncludeAND, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user3] },
+    });
+    expect(includeMemberJoinedToIncorrectMembersAND.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(
+      includeMemberJoinedToIncorrectMembersAND.allChannels.length
+    ).toEqual(incorrectMembersOnIncludeAND.allChannels.length);
+  });
+
+  it('should filter by nicknameContainsFilter of channelListQuery', () => {
+    const channelListQuery = { nicknameContainsFilter: 'honey' };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery },
+    });
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const onChannelCreateState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: newChannel,
+    });
+    expect(onChannelCreateState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+    const onUserLeftState = reducers(onChannelCreateState, {
+      type: actionTypes.ON_USER_LEFT,
+      payload: {
+        channel: { ...newChannel, members: [user1, user2] },
+        isMe: false,
+      },
+    });
+    expect(onUserLeftState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onUserLeftState.allChannels.length).toEqual(onChannelCreateState.allChannels.length - 1);
+    const onUserJoinedState = reducers(onUserLeftState, {
+      type: actionTypes.ON_USER_JOINED,
+      payload: { ...newChannel, members: [user1, user2, user3] },
+    });
+    expect(onUserJoinedState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onUserJoinedState.allChannels.length).toEqual(onUserLeftState.allChannels.length + 1);
+  });
+
+  it('should filter by channelNameContainsFilter of channelListQuery', () => {
+    const channelListQuery = { channelNameContainsFilter: 'home' };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: channelListQuery },
+    });
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const onChannelCreateState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: newChannel,
+    });
+    expect(onChannelCreateState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+    const onChannelChangedState = reducers(onChannelCreateState, {
+      type: actionTypes.ON_CHANNEL_CHANGED,
+      payload: { ...newChannel, name: 'party party' },
+    });
+    expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateState.allChannels.length - 1);
+  });
+
+  it('should filter by customTypesFilter of channelListQuery', () => {
+    const channelListQuery = { customTypesFilter: ['apple', 'banana'] };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery },
+    });
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const onChannelCreateState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: newChannel,
+    });
+    expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
+    const onChannelCreateWithCustomTypeState = reducers(onChannelCreateState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, customType: channelListQuery.customTypesFilter[0] },
+    });
+    expect(onChannelCreateWithCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
+    expect(
+      onChannelCreateWithCustomTypeState.allChannels.length
+    ).toEqual(onChannelCreateState.allChannels.length + 1);
+    const onChannelChangedState = reducers(onChannelCreateWithCustomTypeState, {
+      type: actionTypes.ON_CHANNEL_CHANGED,
+      payload: { ...newChannel, customType: 'cherry' },
+    });
+    expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateWithCustomTypeState.allChannels.length - 1);
+  });
+
+  it('should filter by customTypeStartsWithFilter of channelListQuery', () => {
+    const channelListQuery = { customTypeStartsWithFilter: 'app' };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery },
+    });
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const onChannelCreateState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+    });
+    expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
+    const onChannelCreateWithCustomTypeState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, customType: 'apple' }
+    });
+    expect(onChannelCreateWithCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
+    expect(onChannelCreateWithCustomTypeState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+    const onChannelChangedState = reducers(onChannelCreateWithCustomTypeState, {
+      type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'cherry' },
+    });
+    expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateWithCustomTypeState.allChannels.length - 1);
+    const onChannelChangedWithRightCustomTypeState = reducers(onChannelChangedState, {
+      type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'application' },
+    });
+    expect(onChannelChangedWithRightCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
+    expect(
+      onChannelChangedWithRightCustomTypeState.allChannels.length
+    ).toEqual(onChannelChangedState.allChannels.length + 1);
+  });
+
+  it('should filter by channelUrlsFilter of channelListQuery', () => {
+    const channelListQuery = { channelUrlsFilter: ['channel1010', 'channel1011'] };
+    const newChannel = { ...creatingChannel };
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery }
+    });
+    expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const onChannelCreateState = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, url: 'channel2020' },
+    });
+    expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
+    const onChannelCreateStateWithIncludedUrl = reducers(appliedParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, url: 'channel1010' },
+    });
+    expect(onChannelCreateStateWithIncludedUrl.allChannels[0].url).toEqual(newChannel.url);
+    expect(onChannelCreateStateWithIncludedUrl.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+  });
+
+  it('should filter by superChannelFilter of channelListQuery', () => {
+    const SuperChannelFilters = { All: 'all', SUPER: 'super', NONSUPER: 'nonsuper' };
+    const newChannel = { ...creatingChannel };
+    const allParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.All } },
+    });
+    const superParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.SUPER } },
+    });
+    const nonsuperParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.NONSUPER } },
+    });
+    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(superParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(nonsuperParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const createChannelOnAllState = reducers(allParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+    });
+    expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const createChannelOnSuperState = reducers(superParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+    });
+    expect(createChannelOnSuperState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(createChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length);
+    const createChannelOnNonsuperState = reducers(nonsuperParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+    });
+    expect(createChannelOnNonsuperState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length + 1);
+
+    const createSuperChannelOnAllState = reducers(allParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+    });
+    expect(createSuperChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createSuperChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const createSuperChannelOnSuperState = reducers(superParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+    });
+    expect(createSuperChannelOnSuperState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createSuperChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length + 1);
+    const createSuperChannelOnNonsuperState = reducers(nonsuperParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+    });
+    expect(createSuperChannelOnNonsuperState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(createSuperChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length);
+  });
+
+  it('should filter by publicChannelFilter of channelListQuery', () => {
+    const PublicChannelFilter = { ALL: 'all', PUBLIC: 'public', PRIVATE: 'private' };
+    const newChannel = { ...creatingChannel };
+    const allParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.ALL } },
+    });
+    const publicParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PUBLIC } },
+    });
+    const privateParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PRIVATE } },
+    });
+    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(publicParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(privateParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const createChannelOnAllState = reducers(allParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+    });
+    expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const createChannelOnPublicState = reducers(publicParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+    });
+    expect(createChannelOnPublicState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(createChannelOnPublicState.allChannels.length).toEqual(publicParamsState.allChannels.length);
+    const createChannelOnPrivate = reducers(privateParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+    });
+    expect(createChannelOnPrivate.allChannels[0].url).toEqual(newChannel.url);
+    expect(createChannelOnPrivate.allChannels.length).toEqual(privateParamsState.allChannels.length + 1);
+
+    const createPublicChannelOnAllState = reducers(allParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+    });
+    expect(createPublicChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createPublicChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const createPublicChannelOnPublicState = reducers(publicParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
+    });
+    expect(createPublicChannelOnPublicState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createPublicChannelOnPublicState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const createPublicChannelOnPrivateState = reducers(privateParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
+    });
+    expect(createPublicChannelOnPrivateState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(createPublicChannelOnPrivateState.allChannels.length).toEqual(privateParamsState.allChannels.length);
+  });
+
+  it('should filter by unreadChannelFilter of channelListQuery', () => {
+    const UnreadChannelFilter = { All: 'all', UNREAD_MESSAGE: 'unread_message' };
+    const newChannel = { ...creatingChannel };
+    const allParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { unreadChannelFilter: UnreadChannelFilter.All } },
+    });
+    const unreadParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: { unreadChannelFilter: UnreadChannelFilter.UNREAD_MESSAGE },
+      },
+    });
+    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(unreadParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const channelCreatedOnAllState = reducers(allParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+    });
+    expect(channelCreatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(channelCreatedOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+    const channelCreatedOnUnreadState = reducers(unreadParamsState, {
+      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+    });
+    expect(channelCreatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
+    expect(channelCreatedOnUnreadState.allChannels.length).toEqual(unreadParamsState.allChannels.length + 1);
+
+    const readUpdatedOnAllState = reducers(channelCreatedOnAllState, {
+      type: actionTypes.ON_READ_RECEIPT_UPDATED,
+      payload: { ...newChannel, unreadMessageCount: 0 },
+    });
+    expect(readUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(readUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
+    const unreadUpdatedOnAllState = reducers(channelCreatedOnAllState, {
+      type: actionTypes.ON_READ_RECEIPT_UPDATED,
+      payload: { ...newChannel, unreadParamsState: 1 },
+    });
+    expect(unreadUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+    expect(unreadUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
+    const readUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
+      type: actionTypes.ON_READ_RECEIPT_UPDATED,
+      payload: { ...newChannel, unreadMessageCount: 0 },
+    });
+    expect(readUpdatedOnUnreadState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(readUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length - 1);
+    const unreadUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
+      type: actionTypes.ON_READ_RECEIPT_UPDATED,
+      payload: { ...newChannel, unreadMessageCount: 1 },
+    });
+    expect(unreadUpdatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
+    expect(unreadUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length);
+  });
+
+  it('should filter by hiddenChannelFilter of channelListQuery', () => {
+    const HiddenChannelFilter = {
+      HIDDEN: 'hidden_only',
+      UNHIDDEN: 'unhidden_only',
+      HIDDEN_ALLOW_AUTO_UNHIDE: 'hidden_allow_auto_unhide',
+      HIDDEN_PREVENT_AUTO_UNHIDE: 'hidden_prevent_auto_unhide',
+    };
+    const newChannel = { ...creatingChannel };
+    const hiddenParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN } },
+    });
+    const unhiddenParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.UNHIDDEN } },
+    });
+    const autoUnhideParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+      },
+    });
+    const preventAutoUnhideParamsState = reducers(mockData, {
+      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+      payload: {
+        currentUserId: user1.userId,
+        channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+      },
+    });
+    expect(hiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(unhiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(autoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(preventAutoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+
+    const createChannelOnHiddenState = reducers(hiddenParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+    });
+    expect(createChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(createChannelOnHiddenState.allChannels.length).toEqual(hiddenParamsState.allChannels.length);
+    const createChannelOnUnhiddenState = reducers(unhiddenParamsState, {
+      type: actionTypes.CREATE_CHANNEL,
+      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+    });
+    expect(createChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
+    expect(createChannelOnUnhiddenState.allChannels.length).toEqual(unhiddenParamsState.allChannels.length + 1);
+
+    const hideChannelOnHiddenState = reducers(createChannelOnHiddenState, {
+      type: actionTypes.ON_CHANNEL_ARCHIVED,
+      payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
+    });
+    expect(hideChannelOnHiddenState.allChannels[0].url).toEqual(newChannel.url);
+    expect(hideChannelOnHiddenState.allChannels.length).toEqual(createChannelOnHiddenState.allChannels.length + 1);
+    const hideChannelOnUnhiddenState = reducers(createChannelOnUnhiddenState, {
+      type: actionTypes.ON_CHANNEL_ARCHIVED,
+      payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
+    });
+    expect(hideChannelOnUnhiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(hideChannelOnUnhiddenState.allChannels.length).toEqual(createChannelOnUnhiddenState.allChannels.length - 1);
+    const unhideChannelOnHiddenState = reducers(hideChannelOnHiddenState, {
+      type: actionTypes.ON_CHANNEL_CHANGED,
+      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+    });
+    expect(unhideChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(unhideChannelOnHiddenState.allChannels.length).toEqual(hideChannelOnHiddenState.allChannels.length - 1);
+    const unhideChannelOnUnhiddenState = reducers(hideChannelOnUnhiddenState, {
+      type: actionTypes.ON_CHANNEL_CHANGED,
+      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+    });
+    expect(unhideChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
+    expect(unhideChannelOnUnhiddenState.allChannels.length).toEqual(hideChannelOnUnhiddenState.allChannels.length + 1);
+
+    // hidden_allow_auto_unhide
+    // add an unhidden channel in state
+
+    const hideWithAllowAutoOnAllowAutoState = reducers(
+      {
+        ...autoUnhideParamsState,
+        allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
+      },
+      {
+        type: actionTypes.ON_CHANNEL_ARCHIVED,
+        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+      }
+    );
+    expect(hideWithAllowAutoOnAllowAutoState.allChannels[0].url).toEqual(newChannel.url);
+    expect(hideWithAllowAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length + 1);
+    const hideWithPreventAutoOnAllowAutoState = reducers(
+      {
+        ...autoUnhideParamsState,
+        allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
+      },
+      {
+        type: actionTypes.ON_CHANNEL_ARCHIVED,
+        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+      }
+    );
+    expect(hideWithPreventAutoOnAllowAutoState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(hideWithPreventAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length);
+    // hidden_prevent_auto_unhide
+    const hideWithAllowAutoOnPreventAutoState = reducers(
+      {
+        ...preventAutoUnhideParamsState,
+        allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
+      },
+      {
+        type: actionTypes.ON_CHANNEL_ARCHIVED,
+        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+      }
+    );
+    expect(hideWithAllowAutoOnPreventAutoState.allChannels[0].url).not.toEqual(newChannel.url);
+    expect(hideWithAllowAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length);
+    const hideWithPreventAutoOnPreventAutoState = reducers(
+      {
+        ...preventAutoUnhideParamsState,
+        allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
+      },
+      {
+        type: actionTypes.ON_CHANNEL_ARCHIVED,
+        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+      }
+    );
+    expect(hideWithPreventAutoOnPreventAutoState.allChannels[0].url).toEqual(newChannel.url);
+    expect(hideWithPreventAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length + 1)
+  });
+});

--- a/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
+++ b/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
@@ -165,6 +165,10 @@ describe('Channels-Reducers', () => {
   });
 
   it('should filter by searchFilter of channelListQuery', () => {
+    /**
+     * search_field is member_nickname > create channel inviting target member > target member leave
+     * > target member join > change search_field to channel_name > another member join > change channel name
+     */
     const channelListQuery = {
       _searchFilter: { search_fields: ['member_nickname'], search_query: user1.nickname },
     };
@@ -175,7 +179,6 @@ describe('Channels-Reducers', () => {
     });
     expect(appliedParamsState.channelListQuery._searchFilter.search_query).toEqual(user1.nickname);
     expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
     const createdChannelState = reducers(appliedParamsState, {
       type: actionTypes.CREATE_CHANNEL,
       payload: newChannel,
@@ -197,7 +200,6 @@ describe('Channels-Reducers', () => {
     });
     expect(onUserJoinedState.allChannels[0].url).toEqual(newChannel.url);
     expect(onUserJoinedState.allChannels.length).toEqual(onUserLeftState.allChannels.length + 1);
-
     const paramsWithChannelNameState = reducers(onUserJoinedState, {
       type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
       payload: {
@@ -207,7 +209,6 @@ describe('Channels-Reducers', () => {
     });
     expect(paramsWithChannelNameState.channelListQuery._searchFilter.search_fields).toEqual(['channel_name']);
     expect(paramsWithChannelNameState.channelListQuery._searchFilter.search_query).toEqual(user1.nickname);
-
     const anotherUserJoinedState = reducers(paramsWithChannelNameState, {
       type: actionTypes.ON_USER_JOINED,
       payload: { ...newChannel, members: [user1, user2, user3] },
@@ -222,7 +223,7 @@ describe('Channels-Reducers', () => {
     expect(onChannelChangedState.allChannels.length).toEqual(anotherUserJoinedState.allChannels.length + 1);
   });
 
-  it.only('should filter by userIdsFilter of channelListQuery', () => {
+  describe('filter by userIdsFilter of channelListQuery', () => {
     const newChannel = { ...creatingChannel };
     const exactUserIdsFilterState = reducers(mockData, {
       type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
@@ -263,157 +264,191 @@ describe('Channels-Reducers', () => {
     });
     expect(includeANDUserIdsFilterState.allChannels[0].url).not.toEqual(newChannel.url);
 
-    // exact filter
-    const exactMembersOnExactState = reducers(exactUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1, user2] },
+    describe('exact userIdsFilter', () => {
+      test('create channel inviting exact members > leave/join member', () => {
+        const createChannelState = reducers(exactUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1, user2] },
+        });
+        expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length + 1);
+        const memberLeftState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_LEFT,
+          payload: {
+            channel: { ...newChannel, members: [user1] },
+            isMe: false,
+          },
+        });
+        expect(memberLeftState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(memberLeftState.allChannels.length).toEqual(createChannelState.allChannels.length - 1);
+        const memberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user2, user3] },
+        });
+        expect(memberJoinedState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(memberJoinedState.allChannels.length).toEqual(createChannelState.allChannels.length - 1);
+      });
+      test('create channel inviting more members > leave member', () => {
+        const createChannelState = reducers(exactUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1, user2, user3] },
+        });
+        expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
+        const memberLeftState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_LEFT,
+          payload: {
+            channel: { ...newChannel, members: [user1, user2] },
+            isMe: false,
+          }
+        });
+        expect(memberLeftState.allChannels[0].url).toEqual(newChannel.url);
+        expect(memberLeftState.allChannels.length).toEqual(createChannelState.allChannels.length + 1);
+      });
+      test('create channel inviting less members > join member / join another member', () => {
+        const createChannelState = reducers(exactUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1] },
+        });
+        expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
+        const memberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user2] },
+        });
+        expect(memberJoinedState.allChannels[0].url).toEqual(newChannel.url);
+        expect(memberJoinedState.allChannels.length).toEqual(createChannelState.allChannels.length + 1);
+        const anotherMemberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user3] },
+        });
+        expect(anotherMemberJoinedState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(anotherMemberJoinedState.allChannels.length).toEqual(createChannelState.allChannels.length);
+      });
     });
-    expect(exactMembersOnExactState.allChannels[0].url).toEqual(newChannel.url);
-    expect(exactMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length + 1);
-    const overMembersOnExactState = reducers(exactUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1, user2, user3] },
+    describe('include OR userIdsFilter', () => {
+      test('create channel inviting exact members > leave/join member', () => {
+        const createChannelState = reducers(includeORUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1, user2] },
+        });
+        expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
+        const memberLeftState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_LEFT,
+          payload: {
+            channel: { ...newChannel, members: [user1] },
+            isMe: false,
+          }
+        });
+        expect(memberLeftState.allChannels[0].url).toEqual(newChannel.url);
+        expect(memberLeftState.allChannels.length).toEqual(createChannelState.allChannels.length);
+        const memberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user2, user3] },
+        });
+        expect(memberJoinedState.allChannels[0].url).toEqual(newChannel.url);
+        expect(memberJoinedState.allChannels.length).toEqual(createChannelState.allChannels.length);
+      });
+      test('create channel inviting less members', () => {
+        const createChannelState = reducers(includeORUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1] },
+        });
+        expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
+      })
+      test('create channel inviting incorrect members > target member joined', () => {
+        const createChannelState = reducers(includeORUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user3] },
+        });
+        expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length);
+        const targetMemberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user3] },
+        });
+        expect(targetMemberJoinedState.allChannels[0].url).toEqual(newChannel.url);
+        expect(
+          targetMemberJoinedState.allChannels.length
+        ).toEqual(createChannelState.allChannels.length + 1);
+      });
     });
-    expect(overMembersOnExactState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(overMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
-    const lessMembersOnExactState = reducers(exactUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1] },
-    });
-    expect(lessMembersOnExactState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(lessMembersOnExactState.allChannels.length).toEqual(exactUserIdsFilterState.allChannels.length);
-    // exact filter, member changed test
-    const memberLeftFromExactMembers = reducers(exactMembersOnExactState, {
-      type: actionTypes.ON_USER_LEFT,
-      payload: {
-        channel: { ...newChannel, members: [user1] },
-        isMe: false,
-      },
-    });
-    expect(memberLeftFromExactMembers.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(memberLeftFromExactMembers.allChannels.length).toEqual(exactMembersOnExactState.allChannels.length - 1);
-    const memberLeftFromOverMembers = reducers(overMembersOnExactState, {
-      type: actionTypes.ON_USER_LEFT,
-      payload: {
-        channel: { ...newChannel, members: [user1, user2] },
-        isMe: false,
-      }
-    });
-    expect(memberLeftFromOverMembers.allChannels[0].url).toEqual(newChannel.url);
-    expect(memberLeftFromOverMembers.allChannels.length).toEqual(overMembersOnExactState.allChannels.length + 1);
-    const memberJoinedToLessMembers = reducers(lessMembersOnExactState, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user2] },
-    });
-    expect(memberJoinedToLessMembers.allChannels[0].url).toEqual(newChannel.url);
-    expect(memberJoinedToLessMembers.allChannels.length).toEqual(lessMembersOnExactState.allChannels.length + 1);
 
-    // include OR
-    const includeMembersOnIncludeOR = reducers(includeORUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1, user2] },
+    describe('include AND userIdsFilter', () => {
+      test('create channel inviting exact members > leave/join member', () => {
+        const createChannelState = reducers(includeANDUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1, user2] },
+        });
+        expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
+        const memberLeftState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_LEFT,
+          payload: {
+            channel: { ...newChannel, members: [user1] },
+            isMe: false,
+          }
+        });
+        expect(memberLeftState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(
+          memberLeftState.allChannels.length
+        ).toEqual(createChannelState.allChannels.length - 1);
+        const memberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user2, user3] },
+        });
+        expect(memberJoinedState.allChannels[0].url).toEqual(newChannel.url);
+        expect(memberJoinedState.allChannels.length).toEqual(createChannelState.allChannels.length);
+      });
+      test('create channel inviting less members > target member joined', () => {
+        const createChannelState = reducers(includeANDUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1] },
+        });
+        expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
+        const includeMemberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user2] },
+        });
+        expect(includeMemberJoinedState.allChannels[0].url).toEqual(newChannel.url);
+        expect(
+          includeMemberJoinedState.allChannels.length
+        ).toEqual(createChannelState.allChannels.length + 1);
+      });
+      test('create channel inviting incorrect members > target member joined', () => {
+        const createChannelState = reducers(includeANDUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user3] },
+        });
+        expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
+        const memberJoinedState = reducers(createChannelState, {
+          type: actionTypes.ON_USER_JOINED,
+          payload: { ...newChannel, members: [user1, user3] },
+        });
+        expect(memberJoinedState.allChannels[0].url).not.toEqual(newChannel.url);
+        expect(
+          memberJoinedState.allChannels.length
+        ).toEqual(createChannelState.allChannels.length);
+      });
+      test('create channel inviting over members', () => {
+        const createChannelState = reducers(includeANDUserIdsFilterState, {
+          type: actionTypes.CREATE_CHANNEL,
+          payload: { ...newChannel, members: [user1, user2, user3] },
+        });
+        expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+        expect(createChannelState.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
+      });
     });
-    expect(includeMembersOnIncludeOR.allChannels[0].url).toEqual(newChannel.url);
-    expect(includeMembersOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
-    const onlyMemberOnIncludeOR = reducers(includeORUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1] },
-    });
-    expect(onlyMemberOnIncludeOR.allChannels[0].url).toEqual(newChannel.url);
-    expect(onlyMemberOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length + 1);
-    const incorrectMembersOnIncludeOR = reducers(includeORUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user3] },
-    });
-    expect(incorrectMembersOnIncludeOR.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(incorrectMembersOnIncludeOR.allChannels.length).toEqual(includeORUserIdsFilterState.allChannels.length);
-    // includle OR, member changed
-    const memberLeftFromIncludeMembers = reducers(includeMembersOnIncludeOR, {
-      type: actionTypes.ON_USER_LEFT,
-      payload: {
-        channel: { ...newChannel, members: [user1] },
-        isMe: false,
-      }
-    });
-    expect(memberLeftFromIncludeMembers.allChannels[0].url).toEqual(newChannel.url);
-    expect(memberLeftFromIncludeMembers.allChannels.length).toEqual(includeMembersOnIncludeOR.allChannels.length);
-    const memberJoinedToIncludeMembers = reducers(includeMembersOnIncludeOR, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user2, user3] },
-    });
-    expect(memberJoinedToIncludeMembers.allChannels[0].url).toEqual(newChannel.url);
-    expect(memberJoinedToIncludeMembers.allChannels.length).toEqual(includeMembersOnIncludeOR.allChannels.length);
-    const targetMemberJoinedToIncorrectMembers = reducers(incorrectMembersOnIncludeOR, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user3] },
-    });
-    expect(targetMemberJoinedToIncorrectMembers.allChannels[0].url).toEqual(newChannel.url);
-    expect(
-      targetMemberJoinedToIncorrectMembers.allChannels.length
-    ).toEqual(incorrectMembersOnIncludeOR.allChannels.length + 1);
-
-    // include AND
-    const includeMembersOnIncludeAND = reducers(includeANDUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1, user2] },
-    });
-    expect(includeMembersOnIncludeAND.allChannels[0].url).toEqual(newChannel.url);
-    expect(includeMembersOnIncludeAND.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
-    const onlyMemberOnIncludeAND = reducers(includeANDUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1] },
-    });
-    expect(onlyMemberOnIncludeAND.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(onlyMemberOnIncludeAND.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
-    const incorrectMembersOnIncludeAND = reducers(includeANDUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user3] },
-    });
-    expect(incorrectMembersOnIncludeOR.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(incorrectMembersOnIncludeOR.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length);
-    const overMembersOnIncludeAnd = reducers(includeANDUserIdsFilterState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, members: [user1, user2, user3]},
-    });
-    expect(overMembersOnIncludeAnd.allChannels[0].url).toEqual(newChannel.url);
-    expect(overMembersOnIncludeAnd.allChannels.length).toEqual(includeANDUserIdsFilterState.allChannels.length + 1);
-    // include AND, member changed
-    const memberLeftFromIncludeAND = reducers(includeMembersOnIncludeAND, {
-      type: actionTypes.ON_USER_LEFT,
-      payload: {
-        channel: { ...newChannel, members: [user1] },
-        isMe: false,
-      }
-    });
-    expect(memberLeftFromIncludeAND.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(
-      memberLeftFromIncludeAND.allChannels.length
-    ).toEqual(includeMembersOnIncludeAND.allChannels.length - 1);
-    const memberJoinedToIncludeAND = reducers(includeMembersOnIncludeAND, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user2, user3] },
-    });
-    expect(memberJoinedToIncludeAND.allChannels[0].url).toEqual(newChannel.url);
-    expect(memberJoinedToIncludeAND.allChannels.length).toEqual(includeMembersOnIncludeAND.allChannels.length);
-    const includeMemberJoinedToOnlyMemberAND = reducers(onlyMemberOnIncludeAND, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user2] },
-    });
-    expect(includeMemberJoinedToOnlyMemberAND.allChannels[0].url).toEqual(newChannel.url);
-    expect(
-      includeMemberJoinedToOnlyMemberAND.allChannels.length
-    ).toEqual(onlyMemberOnIncludeAND.allChannels.length + 1);
-    const includeMemberJoinedToIncorrectMembersAND = reducers(incorrectMembersOnIncludeAND, {
-      type: actionTypes.ON_USER_JOINED,
-      payload: { ...newChannel, members: [user1, user3] },
-    });
-    expect(includeMemberJoinedToIncorrectMembersAND.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(
-      includeMemberJoinedToIncorrectMembersAND.allChannels.length
-    ).toEqual(incorrectMembersOnIncludeAND.allChannels.length);
   });
 
   it('should filter by nicknameContainsFilter of channelListQuery', () => {
+    /**
+     * create channel inviting all members > target member left > target member joined
+     */
     const channelListQuery = { nicknameContainsFilter: 'honey' };
     const newChannel = { ...creatingChannel };
     const appliedParamsState = reducers(mockData, {
@@ -446,6 +481,9 @@ describe('Channels-Reducers', () => {
   });
 
   it('should filter by channelNameContainsFilter of channelListQuery', () => {
+    /**
+     * create channel > change channel name to not match
+     */
     const channelListQuery = { channelNameContainsFilter: 'home' };
     const newChannel = { ...creatingChannel };
     const appliedParamsState = reducers(mockData, {
@@ -468,7 +506,7 @@ describe('Channels-Reducers', () => {
     expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateState.allChannels.length - 1);
   });
 
-  it('should filter by customTypesFilter of channelListQuery', () => {
+  describe('filter by customTypesFilter of channelListQuery', () => {
     const channelListQuery = { customTypesFilter: ['apple', 'banana'] };
     const newChannel = { ...creatingChannel };
     const appliedParamsState = reducers(mockData, {
@@ -476,30 +514,39 @@ describe('Channels-Reducers', () => {
       payload: { currentUserId: user1.userId, channelListQuery },
     });
     expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
-    const onChannelCreateState = reducers(appliedParamsState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: newChannel,
+    test('create channel without customType > add customType', () => {
+      const createChannelState = reducers(appliedParamsState, {
+        type: actionTypes.CREATE_CHANNEL,
+        payload: newChannel,
+      });
+      expect(createChannelState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createChannelState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
+      const addCustomTypeState = reducers(createChannelState, {
+        type: actionTypes.ON_CHANNEL_CHANGED,
+        payload: { ...newChannel, customType: channelListQuery.customTypesFilter[0] },
+      });
+      expect(addCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
+      expect(addCustomTypeState.allChannels.length).toEqual(createChannelState.allChannels.length + 1);
     });
-    expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
-    const onChannelCreateWithCustomTypeState = reducers(onChannelCreateState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, customType: channelListQuery.customTypesFilter[0] },
+    test('create channel with customType > change customType to not match', () => {
+      const createChannelState = reducers(appliedParamsState, {
+        type: actionTypes.CREATE_CHANNEL,
+        payload: { ...newChannel, customType: channelListQuery.customTypesFilter[0] },
+      });
+      expect(createChannelState.allChannels[0].url).toEqual(newChannel.url);
+      expect(
+        createChannelState.allChannels.length
+      ).toEqual(appliedParamsState.allChannels.length + 1);
+      const onChannelChangedState = reducers(createChannelState, {
+        type: actionTypes.ON_CHANNEL_CHANGED,
+        payload: { ...newChannel, customType: 'cherry' },
+      });
+      expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(onChannelChangedState.allChannels.length).toEqual(createChannelState.allChannels.length - 1);
     });
-    expect(onChannelCreateWithCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
-    expect(
-      onChannelCreateWithCustomTypeState.allChannels.length
-    ).toEqual(onChannelCreateState.allChannels.length + 1);
-    const onChannelChangedState = reducers(onChannelCreateWithCustomTypeState, {
-      type: actionTypes.ON_CHANNEL_CHANGED,
-      payload: { ...newChannel, customType: 'cherry' },
-    });
-    expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateWithCustomTypeState.allChannels.length - 1);
   });
 
-  it('should filter by customTypeStartsWithFilter of channelListQuery', () => {
+  describe('filter by customTypeStartsWithFilter of channelListQuery', () => {
     const channelListQuery = { customTypeStartsWithFilter: 'app' };
     const newChannel = { ...creatingChannel };
     const appliedParamsState = reducers(mockData, {
@@ -508,28 +555,32 @@ describe('Channels-Reducers', () => {
     });
     expect(appliedParamsState.allChannels[0].url).not.toEqual(newChannel.url);
 
-    const onChannelCreateState = reducers(appliedParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+    test('create channel without customType', () => {
+      const onChannelCreateState = reducers(appliedParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+      });
+      expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
     });
-    expect(onChannelCreateState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length);
-    const onChannelCreateWithCustomTypeState = reducers(appliedParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, customType: 'apple' }
+    test('create channel with customType > change to not match > change to match', () => {
+      const onChannelCreateState = reducers(appliedParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, customType: 'apple' }
+      });
+      expect(onChannelCreateState.allChannels[0].url).toEqual(newChannel.url);
+      expect(onChannelCreateState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
+      const incorrectCustomTypeState = reducers(onChannelCreateState, {
+        type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'cherry' },
+      });
+      expect(incorrectCustomTypeState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(incorrectCustomTypeState.allChannels.length).toEqual(onChannelCreateState.allChannels.length - 1);
+      const correctCustomTypeState = reducers(incorrectCustomTypeState, {
+        type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'application' },
+      });
+      expect(correctCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
+      expect(
+        correctCustomTypeState.allChannels.length
+      ).toEqual(incorrectCustomTypeState.allChannels.length + 1);
     });
-    expect(onChannelCreateWithCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
-    expect(onChannelCreateWithCustomTypeState.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
-    const onChannelChangedState = reducers(onChannelCreateWithCustomTypeState, {
-      type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'cherry' },
-    });
-    expect(onChannelChangedState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(onChannelChangedState.allChannels.length).toEqual(onChannelCreateWithCustomTypeState.allChannels.length - 1);
-    const onChannelChangedWithRightCustomTypeState = reducers(onChannelChangedState, {
-      type: actionTypes.ON_CHANNEL_CHANGED, payload: { ...newChannel, customType: 'application' },
-    });
-    expect(onChannelChangedWithRightCustomTypeState.allChannels[0].url).toEqual(newChannel.url);
-    expect(
-      onChannelChangedWithRightCustomTypeState.allChannels.length
-    ).toEqual(onChannelChangedState.allChannels.length + 1);
   });
 
   it('should filter by channelUrlsFilter of channelListQuery', () => {
@@ -555,165 +606,175 @@ describe('Channels-Reducers', () => {
     expect(onChannelCreateStateWithIncludedUrl.allChannels.length).toEqual(appliedParamsState.allChannels.length + 1);
   });
 
-  it('should filter by superChannelFilter of channelListQuery', () => {
+  describe('filter by superChannelFilter of channelListQuery', () => {
     const SuperChannelFilters = { All: 'all', SUPER: 'super', NONSUPER: 'nonsuper' };
     const newChannel = { ...creatingChannel };
-    const allParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.All } },
+    test('superChannelFilter is All', () => {
+      const allParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.All } },
+      });
+      expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnAllState = reducers(allParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+      });
+      expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+      const createSuperChannelOnAllState = reducers(allParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+      });
+      expect(createSuperChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createSuperChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
     });
-    const superParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.SUPER } },
+    test('superChannelFilter is SUPER', () => {
+      const superParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.SUPER } },
+      });
+      expect(superParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnSuperState = reducers(superParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+      });
+      expect(createChannelOnSuperState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length);
+      const createSuperChannelOnSuperState = reducers(superParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+      });
+      expect(createSuperChannelOnSuperState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createSuperChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length + 1);
     });
-    const nonsuperParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.NONSUPER } },
+    test('superChannelFilter is NONSUPER', () => {
+      const nonsuperParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { superChannelFilter: SuperChannelFilters.NONSUPER } },
+      });
+      expect(nonsuperParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnNonsuperState = reducers(nonsuperParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
+      });
+      expect(createChannelOnNonsuperState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length + 1);
+      const createSuperChannelOnNonsuperState = reducers(nonsuperParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
+      });
+      expect(createSuperChannelOnNonsuperState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createSuperChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length);
     });
-    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(superParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(nonsuperParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
-    const createChannelOnAllState = reducers(allParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
-    });
-    expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const createChannelOnSuperState = reducers(superParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
-    });
-    expect(createChannelOnSuperState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(createChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length);
-    const createChannelOnNonsuperState = reducers(nonsuperParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: false },
-    });
-    expect(createChannelOnNonsuperState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length + 1);
-
-    const createSuperChannelOnAllState = reducers(allParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
-    });
-    expect(createSuperChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createSuperChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const createSuperChannelOnSuperState = reducers(superParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
-    });
-    expect(createSuperChannelOnSuperState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createSuperChannelOnSuperState.allChannels.length).toEqual(superParamsState.allChannels.length + 1);
-    const createSuperChannelOnNonsuperState = reducers(nonsuperParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isSuper: true },
-    });
-    expect(createSuperChannelOnNonsuperState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(createSuperChannelOnNonsuperState.allChannels.length).toEqual(nonsuperParamsState.allChannels.length);
   });
 
-  it('should filter by publicChannelFilter of channelListQuery', () => {
+  describe('filter by publicChannelFilter of channelListQuery', () => {
     const PublicChannelFilter = { ALL: 'all', PUBLIC: 'public', PRIVATE: 'private' };
     const newChannel = { ...creatingChannel };
-    const allParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.ALL } },
+    test('publicChannelFilter is ALL', () => {
+      const allParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.ALL } },
+      });
+      expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnAllState = reducers(allParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+      });
+      expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+      const createPublicChannelOnAllState = reducers(allParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+      });
+      expect(createPublicChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createPublicChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
     });
-    const publicParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PUBLIC } },
+    test('publicChannelFilter is PUBLIC', () => {
+      const publicParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PUBLIC } },
+      });
+      expect(publicParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnPublicState = reducers(publicParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+      });
+      expect(createChannelOnPublicState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createChannelOnPublicState.allChannels.length).toEqual(publicParamsState.allChannels.length);
+      const createPublicChannelOnPublicState = reducers(publicParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
+      });
+      expect(createPublicChannelOnPublicState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createPublicChannelOnPublicState.allChannels.length).toEqual(publicParamsState.allChannels.length + 1);
     });
-    const privateParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PRIVATE } },
+    test('publicChannelFilter is PRIVATE', () => {
+      const privateParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { publicChannelFilter: PublicChannelFilter.PRIVATE } },
+      });
+      expect(privateParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnPrivate = reducers(privateParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
+      });
+      expect(createChannelOnPrivate.allChannels[0].url).toEqual(newChannel.url);
+      expect(createChannelOnPrivate.allChannels.length).toEqual(privateParamsState.allChannels.length + 1);
+      const createPublicChannelOnPrivateState = reducers(privateParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
+      });
+      expect(createPublicChannelOnPrivateState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createPublicChannelOnPrivateState.allChannels.length).toEqual(privateParamsState.allChannels.length);
     });
-    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(publicParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(privateParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
-    const createChannelOnAllState = reducers(allParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
-    });
-    expect(createChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const createChannelOnPublicState = reducers(publicParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
-    });
-    expect(createChannelOnPublicState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(createChannelOnPublicState.allChannels.length).toEqual(publicParamsState.allChannels.length);
-    const createChannelOnPrivate = reducers(privateParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
-    });
-    expect(createChannelOnPrivate.allChannels[0].url).toEqual(newChannel.url);
-    expect(createChannelOnPrivate.allChannels.length).toEqual(privateParamsState.allChannels.length + 1);
-
-    const createPublicChannelOnAllState = reducers(allParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: false }
-    });
-    expect(createPublicChannelOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createPublicChannelOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const createPublicChannelOnPublicState = reducers(publicParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
-    });
-    expect(createPublicChannelOnPublicState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createPublicChannelOnPublicState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const createPublicChannelOnPrivateState = reducers(privateParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: { ...newChannel, isPublic: true }
-    });
-    expect(createPublicChannelOnPrivateState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(createPublicChannelOnPrivateState.allChannels.length).toEqual(privateParamsState.allChannels.length);
   });
 
-  it('should filter by unreadChannelFilter of channelListQuery', () => {
+  describe('filter by unreadChannelFilter of channelListQuery', () => {
     const UnreadChannelFilter = { All: 'all', UNREAD_MESSAGE: 'unread_message' };
     const newChannel = { ...creatingChannel };
-    const allParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { unreadChannelFilter: UnreadChannelFilter.All } },
+    test('unreadChannelFilter is ALL', () => {
+      const allParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { unreadChannelFilter: UnreadChannelFilter.All } },
+      });
+      expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const channelCreatedOnAllState = reducers(allParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+      });
+      expect(channelCreatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(channelCreatedOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
+      const readUpdatedOnAllState = reducers(channelCreatedOnAllState, {
+        type: actionTypes.ON_READ_RECEIPT_UPDATED,
+        payload: { ...newChannel, unreadMessageCount: 0 },
+      });
+      expect(readUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(readUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
+      const unreadUpdatedOnAllState = reducers(channelCreatedOnAllState, {
+        type: actionTypes.ON_READ_RECEIPT_UPDATED,
+        payload: { ...newChannel, unreadParamsState: 1 },
+      });
+      expect(unreadUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
+      expect(unreadUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
     });
-    const unreadParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: {
-        currentUserId: user1.userId,
-        channelListQuery: { unreadChannelFilter: UnreadChannelFilter.UNREAD_MESSAGE },
-      },
+    test('unreadChannelFilter is UNREAD_MESSAGE', () => {
+      const unreadParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: {
+          currentUserId: user1.userId,
+          channelListQuery: { unreadChannelFilter: UnreadChannelFilter.UNREAD_MESSAGE },
+        },
+      });
+      expect(unreadParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const channelCreatedOnUnreadState = reducers(unreadParamsState, {
+        type: actionTypes.CREATE_CHANNEL, payload: newChannel,
+      });
+      expect(channelCreatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
+      expect(channelCreatedOnUnreadState.allChannels.length).toEqual(unreadParamsState.allChannels.length + 1);
+      const readUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
+        type: actionTypes.ON_READ_RECEIPT_UPDATED,
+        payload: { ...newChannel, unreadMessageCount: 0 },
+      });
+      expect(readUpdatedOnUnreadState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(readUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length - 1);
+      const unreadUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
+        type: actionTypes.ON_READ_RECEIPT_UPDATED,
+        payload: { ...newChannel, unreadMessageCount: 1 },
+      });
+      expect(unreadUpdatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
+      expect(unreadUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length);
     });
-    expect(allParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(unreadParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
-    const channelCreatedOnAllState = reducers(allParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
-    });
-    expect(channelCreatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(channelCreatedOnAllState.allChannels.length).toEqual(allParamsState.allChannels.length + 1);
-    const channelCreatedOnUnreadState = reducers(unreadParamsState, {
-      type: actionTypes.CREATE_CHANNEL, payload: newChannel,
-    });
-    expect(channelCreatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
-    expect(channelCreatedOnUnreadState.allChannels.length).toEqual(unreadParamsState.allChannels.length + 1);
-
-    const readUpdatedOnAllState = reducers(channelCreatedOnAllState, {
-      type: actionTypes.ON_READ_RECEIPT_UPDATED,
-      payload: { ...newChannel, unreadMessageCount: 0 },
-    });
-    expect(readUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(readUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
-    const unreadUpdatedOnAllState = reducers(channelCreatedOnAllState, {
-      type: actionTypes.ON_READ_RECEIPT_UPDATED,
-      payload: { ...newChannel, unreadParamsState: 1 },
-    });
-    expect(unreadUpdatedOnAllState.allChannels[0].url).toEqual(newChannel.url);
-    expect(unreadUpdatedOnAllState.allChannels.length).toEqual(channelCreatedOnAllState.allChannels.length);
-    const readUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
-      type: actionTypes.ON_READ_RECEIPT_UPDATED,
-      payload: { ...newChannel, unreadMessageCount: 0 },
-    });
-    expect(readUpdatedOnUnreadState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(readUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length - 1);
-    const unreadUpdatedOnUnreadState = reducers(channelCreatedOnUnreadState, {
-      type: actionTypes.ON_READ_RECEIPT_UPDATED,
-      payload: { ...newChannel, unreadMessageCount: 1 },
-    });
-    expect(unreadUpdatedOnUnreadState.allChannels[0].url).toEqual(newChannel.url);
-    expect(unreadUpdatedOnUnreadState.allChannels.length).toEqual(channelCreatedOnUnreadState.allChannels.length);
   });
 
-  it('should filter by hiddenChannelFilter of channelListQuery', () => {
+  describe('filter by hiddenChannelFilter of channelListQuery', () => {
     const HiddenChannelFilter = {
       HIDDEN: 'hidden_only',
       UNHIDDEN: 'unhidden_only',
@@ -721,122 +782,123 @@ describe('Channels-Reducers', () => {
       HIDDEN_PREVENT_AUTO_UNHIDE: 'hidden_prevent_auto_unhide',
     };
     const newChannel = { ...creatingChannel };
-    const hiddenParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN } },
-    });
-    const unhiddenParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.UNHIDDEN } },
-    });
-    const autoUnhideParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: {
-        currentUserId: user1.userId,
-        channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
-      },
-    });
-    const preventAutoUnhideParamsState = reducers(mockData, {
-      type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
-      payload: {
-        currentUserId: user1.userId,
-        channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
-      },
-    });
-    expect(hiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(unhiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(autoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(preventAutoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
-
-    const createChannelOnHiddenState = reducers(hiddenParamsState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
-    });
-    expect(createChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(createChannelOnHiddenState.allChannels.length).toEqual(hiddenParamsState.allChannels.length);
-    const createChannelOnUnhiddenState = reducers(unhiddenParamsState, {
-      type: actionTypes.CREATE_CHANNEL,
-      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
-    });
-    expect(createChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
-    expect(createChannelOnUnhiddenState.allChannels.length).toEqual(unhiddenParamsState.allChannels.length + 1);
-
-    const hideChannelOnHiddenState = reducers(createChannelOnHiddenState, {
-      type: actionTypes.ON_CHANNEL_ARCHIVED,
-      payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
-    });
-    expect(hideChannelOnHiddenState.allChannels[0].url).toEqual(newChannel.url);
-    expect(hideChannelOnHiddenState.allChannels.length).toEqual(createChannelOnHiddenState.allChannels.length + 1);
-    const hideChannelOnUnhiddenState = reducers(createChannelOnUnhiddenState, {
-      type: actionTypes.ON_CHANNEL_ARCHIVED,
-      payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
-    });
-    expect(hideChannelOnUnhiddenState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(hideChannelOnUnhiddenState.allChannels.length).toEqual(createChannelOnUnhiddenState.allChannels.length - 1);
-    const unhideChannelOnHiddenState = reducers(hideChannelOnHiddenState, {
-      type: actionTypes.ON_CHANNEL_CHANGED,
-      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
-    });
-    expect(unhideChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(unhideChannelOnHiddenState.allChannels.length).toEqual(hideChannelOnHiddenState.allChannels.length - 1);
-    const unhideChannelOnUnhiddenState = reducers(hideChannelOnUnhiddenState, {
-      type: actionTypes.ON_CHANNEL_CHANGED,
-      payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
-    });
-    expect(unhideChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
-    expect(unhideChannelOnUnhiddenState.allChannels.length).toEqual(hideChannelOnUnhiddenState.allChannels.length + 1);
-
-    // hidden_allow_auto_unhide
-    // add an unhidden channel in state
-
-    const hideWithAllowAutoOnAllowAutoState = reducers(
-      {
-        ...autoUnhideParamsState,
-        allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
-      },
-      {
+    test('hiddenChannelFilter is HIDDEN', () => {
+      const hiddenParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN } },
+      });
+      expect(hiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnHiddenState = reducers(hiddenParamsState, {
+        type: actionTypes.CREATE_CHANNEL,
+        payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+      });
+      expect(createChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(createChannelOnHiddenState.allChannels.length).toEqual(hiddenParamsState.allChannels.length);
+      const hideChannelOnHiddenState = reducers(createChannelOnHiddenState, {
         type: actionTypes.ON_CHANNEL_ARCHIVED,
-        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
-      }
-    );
-    expect(hideWithAllowAutoOnAllowAutoState.allChannels[0].url).toEqual(newChannel.url);
-    expect(hideWithAllowAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length + 1);
-    const hideWithPreventAutoOnAllowAutoState = reducers(
-      {
-        ...autoUnhideParamsState,
-        allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
-      },
-      {
+        payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
+      });
+      expect(hideChannelOnHiddenState.allChannels[0].url).toEqual(newChannel.url);
+      expect(hideChannelOnHiddenState.allChannels.length).toEqual(createChannelOnHiddenState.allChannels.length + 1);
+      const unhideChannelOnHiddenState = reducers(hideChannelOnHiddenState, {
+        type: actionTypes.ON_CHANNEL_CHANGED,
+        payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+      });
+      expect(unhideChannelOnHiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(unhideChannelOnHiddenState.allChannels.length).toEqual(hideChannelOnHiddenState.allChannels.length - 1);
+    });
+    test('hiddenChannelFilter is UNHIDDEN', () => {
+      const unhiddenParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: { currentUserId: user1.userId, channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.UNHIDDEN } },
+      });
+      expect(unhiddenParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const createChannelOnUnhiddenState = reducers(unhiddenParamsState, {
+        type: actionTypes.CREATE_CHANNEL,
+        payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+      });
+      expect(createChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
+      expect(createChannelOnUnhiddenState.allChannels.length).toEqual(unhiddenParamsState.allChannels.length + 1);
+      const hideChannelOnUnhiddenState = reducers(createChannelOnUnhiddenState, {
         type: actionTypes.ON_CHANNEL_ARCHIVED,
-        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
-      }
-    );
-    expect(hideWithPreventAutoOnAllowAutoState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(hideWithPreventAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length);
-    // hidden_prevent_auto_unhide
-    const hideWithAllowAutoOnPreventAutoState = reducers(
-      {
-        ...preventAutoUnhideParamsState,
-        allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
-      },
-      {
-        type: actionTypes.ON_CHANNEL_ARCHIVED,
-        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
-      }
-    );
-    expect(hideWithAllowAutoOnPreventAutoState.allChannels[0].url).not.toEqual(newChannel.url);
-    expect(hideWithAllowAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length);
-    const hideWithPreventAutoOnPreventAutoState = reducers(
-      {
-        ...preventAutoUnhideParamsState,
-        allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
-      },
-      {
-        type: actionTypes.ON_CHANNEL_ARCHIVED,
-        payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
-      }
-    );
-    expect(hideWithPreventAutoOnPreventAutoState.allChannels[0].url).toEqual(newChannel.url);
-    expect(hideWithPreventAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length + 1)
+        payload: { ...newChannel, isHidden: true, hiddenState: 'hidden_only' },
+      });
+      expect(hideChannelOnUnhiddenState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(hideChannelOnUnhiddenState.allChannels.length).toEqual(createChannelOnUnhiddenState.allChannels.length - 1);
+      const unhideChannelOnUnhiddenState = reducers(hideChannelOnUnhiddenState, {
+        type: actionTypes.ON_CHANNEL_CHANGED,
+        payload: { ...newChannel, isHidden: false, hiddenState: 'unhidden' },
+      });
+      expect(unhideChannelOnUnhiddenState.allChannels[0].url).toEqual(newChannel.url);
+      expect(unhideChannelOnUnhiddenState.allChannels.length).toEqual(hideChannelOnUnhiddenState.allChannels.length + 1);
+    });
+    test('hiddenChannelFilter is HIDDEN_ALLOW_AUTO_UNHIDE', () => {
+      const autoUnhideParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: {
+          currentUserId: user1.userId,
+          channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+        },
+      });
+      expect(autoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const hideWithAllowAutoOnAllowAutoState = reducers(
+        {
+          ...autoUnhideParamsState,
+          allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
+        },
+        {
+          type: actionTypes.ON_CHANNEL_ARCHIVED,
+          payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+        }
+      );
+      expect(hideWithAllowAutoOnAllowAutoState.allChannels[0].url).toEqual(newChannel.url);
+      expect(hideWithAllowAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length + 1);
+      const hideWithPreventAutoOnAllowAutoState = reducers(
+        {
+          ...autoUnhideParamsState,
+          allChannels: [{ ...newChannel, isHidden: false }, ...autoUnhideParamsState.allChannels],
+        },
+        {
+          type: actionTypes.ON_CHANNEL_ARCHIVED,
+          payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+        }
+      );
+      expect(hideWithPreventAutoOnAllowAutoState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(hideWithPreventAutoOnAllowAutoState.allChannels.length).toEqual(autoUnhideParamsState.allChannels.length);
+    });
+    test('hiddenChannelFilter is HIDDEN_PREVENT_AUTO_UNHIDE', () => {
+      const preventAutoUnhideParamsState = reducers(mockData, {
+        type: actionTypes.CHANNEL_LIST_PARAMS_UPDATED,
+        payload: {
+          currentUserId: user1.userId,
+          channelListQuery: { hiddenChannelFilter: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+        },
+      });
+      expect(preventAutoUnhideParamsState.allChannels[0].url).not.toEqual(newChannel.url);
+      const hideWithAllowAutoOnPreventAutoState = reducers(
+        {
+          ...preventAutoUnhideParamsState,
+          allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
+        },
+        {
+          type: actionTypes.ON_CHANNEL_ARCHIVED,
+          payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_ALLOW_AUTO_UNHIDE },
+        }
+      );
+      expect(hideWithAllowAutoOnPreventAutoState.allChannels[0].url).not.toEqual(newChannel.url);
+      expect(hideWithAllowAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length);
+      const hideWithPreventAutoOnPreventAutoState = reducers(
+        {
+          ...preventAutoUnhideParamsState,
+          allChannels: [{ ...newChannel, isHidden: false }, ...preventAutoUnhideParamsState.allChannels],
+        },
+        {
+          type: actionTypes.ON_CHANNEL_ARCHIVED,
+          payload: { ...newChannel, isHidden: true, hiddenState: HiddenChannelFilter.HIDDEN_PREVENT_AUTO_UNHIDE },
+        }
+      );
+      expect(hideWithPreventAutoOnPreventAutoState.allChannels[0].url).toEqual(newChannel.url);
+      expect(hideWithPreventAutoOnPreventAutoState.allChannels.length).toEqual(preventAutoUnhideParamsState.allChannels.length + 1);
+    });
   });
 });

--- a/src/smart-components/ChannelList/dux/data.mock.js
+++ b/src/smart-components/ChannelList/dux/data.mock.js
@@ -66,7 +66,7 @@ export default {
         "channelUrl": "sendbird_group_channel_13883929_89ea0faddf24ba6328e95ff56b0b37960f400c83",
         "data": "",
         "customType": "",
-        "createdAt": 1579767478896,
+        "createdAt": 1003,
         "updatedAt": 0,
         "channelType": "group",
         "metaArrays": [],
@@ -124,7 +124,7 @@ export default {
       "channelType": "group",
       "name": "",
       "coverUrl": "",
-      "createdAt": 1581326202000,
+      "createdAt": 1002,
       "data": "",
       "customType": "",
       "isFrozen": false,
@@ -243,7 +243,7 @@ export default {
         "isBlockingMe": false
       }],
       "memberMap": {},
-      "lastMessage": null,
+      "lastMessage": { createdAt: 1001 },
       "memberCount": 2,
       "joinedMemberCount": 2,
       "cachedReadReceiptStatus": {
@@ -388,4 +388,26 @@ export const channel1 = {
   "myRole": "none",
   "myMutedState": "unmuted",
   "invitedAt": 1518733880178
+};
+
+export const users = [
+  {
+    userId: 'hoon001',
+    nickname: 'hoon',
+  },
+  {
+    userId: 'hoon002',
+    nickname: '훈',
+  },
+  {
+    userId: 'hoon003',
+    nickname: 'honey',
+  },
+];
+export const creatingChannel = {
+  url: 'channel1010',
+  name: 'home party',
+  members: users,
+  lastMessage: { createdAt: 1004 },
+  customType: '',
 };

--- a/src/smart-components/ChannelList/dux/reducers.js
+++ b/src/smart-components/ChannelList/dux/reducers.js
@@ -40,7 +40,7 @@ export default function reducer(state, action) {
         if (filterChannelListParams(state.channelListQuery, channel, state.currentUserId)) {
           return {
             ...state,
-            ...getChannelsWithUpsertedChannel(state.allChannels, channel),
+            allChannels: getChannelsWithUpsertedChannel(state.allChannels, channel),
           };
         }
         return {
@@ -123,17 +123,10 @@ export default function reducer(state, action) {
       if (!channel.lastMessage) return state;
       if (state.channelListQuery) {
         if (filterChannelListParams(state.channelListQuery, channel, state.currentUserId)) {
-          // if its only an unread message count change, dont push to top
-          if (unreadMessageCount === 0) {
-            const currentChannel = allChannels.find(({ url }) => url === channel.url);
-            const currentUnreadCount = currentChannel && currentChannel.unreadMessageCount;
-            if (currentUnreadCount === 0) {
-              return {
-                ...state,
-                allChannels: getChannelsWithUpsertedChannel(allChannels, channel),
-              };
-            }
-          }
+          return {
+            ...state,
+            allChannels: getChannelsWithUpsertedChannel(allChannels, channel),
+          };
         }
         return {
           ...state,

--- a/src/smart-components/Conversation/dux/__tests__/reducers.spec.js
+++ b/src/smart-components/Conversation/dux/__tests__/reducers.spec.js
@@ -262,23 +262,23 @@ describe('Messages-Reducers', () => {
     expect(nextState.emojiContainer).toEqual(emojiContainer);
   });
 
-  it('should filter by MESSAGE_LIST_PARAMS_CHANGED when ON_MESSAGE_RECEIVED', () => {
+  describe('filter by messageType of messageListParams when message received', () => {
     const mockData = generateMockChannel();
-    // MessageType
-    const testMessageType = (paramsMessageType = '', messageMessageType = []) => {
+    const messageTypes = { ADMIN: 'admin', USER: 'user', FILE: 'file' };
+    test('messageType filter is ADMIN', () => {
       const appliedParamsState = reducers(mockData, {
         type: actionTypes.MESSAGE_LIST_PARAMS_CHANGED,
-        payload: { messageType: paramsMessageType },
+        payload: { messageType: messageTypes.ADMIN },
       });
-      expect(appliedParamsState.messageListParams.messageType).toEqual(paramsMessageType);
-      messageMessageType.forEach((messageType) => {
+      expect(appliedParamsState.messageListParams.messageType).toEqual(messageTypes.ADMIN);
+      ['admin', 'user', 'file'].forEach((messageType) => {
         const receivedMessage = generateMockMessage(1010);
         receivedMessage.messageType = messageType;
         const receivedMessageState = reducers(appliedParamsState, {
           type: actionTypes.ON_MESSAGE_RECEIVED,
           payload: { message: receivedMessage, channel: { url: mockMessage1.channelUrl } },
         });
-        if (paramsMessageType === messageType) {
+        if (messageTypes.ADMIN === messageType) {
           expect(
             receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
           ).toEqual(receivedMessage.messageId);
@@ -288,26 +288,21 @@ describe('Messages-Reducers', () => {
           ).not.toEqual(receivedMessage.messageId);
         }
       });
-    };
-    testMessageType('admin', ['admin', 'user', 'file']);
-    testMessageType('user', ['admin', 'user', 'file']);
-    testMessageType('file', ['admin', 'user', 'file']);
-
-    // CustomType
-    const testCustomType = (paramsCustomTypes = [], messageCustomTypeList = []) => {
+    });
+    test('messageType filter is USER', () => {
       const appliedParamsState = reducers(mockData, {
         type: actionTypes.MESSAGE_LIST_PARAMS_CHANGED,
-        payload: { customTypes: paramsCustomTypes },
+        payload: { messageType: messageTypes.USER },
       });
-      expect(appliedParamsState.messageListParams.customTypes).toEqual(paramsCustomTypes);
-      messageCustomTypeList.forEach((customType) => {
+      expect(appliedParamsState.messageListParams.messageType).toEqual(messageTypes.USER);
+      ['admin', 'user', 'file'].forEach((messageType) => {
         const receivedMessage = generateMockMessage(1010);
-        receivedMessage.customType = customType;
+        receivedMessage.messageType = messageType;
         const receivedMessageState = reducers(appliedParamsState, {
           type: actionTypes.ON_MESSAGE_RECEIVED,
           payload: { message: receivedMessage, channel: { url: mockMessage1.channelUrl } },
         });
-        if (paramsCustomTypes.some((paramsCustomType) => paramsCustomType === customType)) {
+        if (messageTypes.USER === messageType) {
           expect(
             receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
           ).toEqual(receivedMessage.messageId);
@@ -317,24 +312,21 @@ describe('Messages-Reducers', () => {
           ).not.toEqual(receivedMessage.messageId);
         }
       });
-    };
-    testCustomType(['a', 'b', 'c'], ['a', 'd']);
-
-    // SenderUserIds
-    const testSenderUserIds = (paramsSenderUserIds = [], messageSenderIds = []) => {
+    });
+    test('messageType filter is FILE', () => {
       const appliedParamsState = reducers(mockData, {
         type: actionTypes.MESSAGE_LIST_PARAMS_CHANGED,
-        payload: { senderUserIds: paramsSenderUserIds },
+        payload: { messageType: messageTypes.FILE },
       });
-      expect(appliedParamsState.messageListParams.senderUserIds).toEqual(paramsSenderUserIds);
-      messageSenderIds.forEach((messageSenderId) => {
+      expect(appliedParamsState.messageListParams.messageType).toEqual(messageTypes.FILE);
+      ['admin', 'user', 'file'].forEach((messageType) => {
         const receivedMessage = generateMockMessage(1010);
-        receivedMessage.sender = { userId: messageSenderId };
+        receivedMessage.messageType = messageType;
         const receivedMessageState = reducers(appliedParamsState, {
           type: actionTypes.ON_MESSAGE_RECEIVED,
           payload: { message: receivedMessage, channel: { url: mockMessage1.channelUrl } },
         });
-        if (paramsSenderUserIds.some((paramsSenderUserId) => paramsSenderUserId === messageSenderId)) {
+        if (messageTypes.FILE === messageType) {
           expect(
             receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
           ).toEqual(receivedMessage.messageId);
@@ -344,16 +336,69 @@ describe('Messages-Reducers', () => {
           ).not.toEqual(receivedMessage.messageId);
         }
       });
-    };
-    testSenderUserIds(['mark-1', 'mark-2', 'mark-3'], ['mark-1', 'mark-3', 'mark-4']);
+    });
+  });
+
+  it('should filter by customType of messageListParams when message received', () => {
+    const mockData = generateMockChannel();
+    const paramsCustomTypes = ['a', 'b', 'c'];
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.MESSAGE_LIST_PARAMS_CHANGED,
+      payload: { customTypes: paramsCustomTypes },
+    });
+    expect(appliedParamsState.messageListParams.customTypes).toEqual(paramsCustomTypes);
+    ['a', 'd'].forEach((customType) => {
+      const receivedMessage = generateMockMessage(1010);
+      receivedMessage.customType = customType;
+      const receivedMessageState = reducers(appliedParamsState, {
+        type: actionTypes.ON_MESSAGE_RECEIVED,
+        payload: { message: receivedMessage, channel: { url: mockMessage1.channelUrl } },
+      });
+      if (paramsCustomTypes.some((paramsCustomType) => paramsCustomType === customType)) {
+        expect(
+          receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
+        ).toEqual(receivedMessage.messageId);
+      } else {
+        expect(
+          receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
+        ).not.toEqual(receivedMessage.messageId);
+      }
+    });
+  });
+
+  it('should filter by senderUserIds of messageListParams when message received', () => {
+    const mockData = generateMockChannel();
+    const paramsSenderUserIds = ['mark-1', 'mark-2', 'mark-3'];
+    const appliedParamsState = reducers(mockData, {
+      type: actionTypes.MESSAGE_LIST_PARAMS_CHANGED,
+      payload: { senderUserIds: paramsSenderUserIds },
+    });
+    expect(appliedParamsState.messageListParams.senderUserIds).toEqual(paramsSenderUserIds);
+    ['mark-1', 'mark-4'].forEach((messageSenderId) => {
+      const receivedMessage = generateMockMessage(1010);
+      receivedMessage.sender = { userId: messageSenderId };
+      const receivedMessageState = reducers(appliedParamsState, {
+        type: actionTypes.ON_MESSAGE_RECEIVED,
+        payload: { message: receivedMessage, channel: { url: mockMessage1.channelUrl } },
+      });
+      if (paramsSenderUserIds.some((paramsSenderUserId) => paramsSenderUserId === messageSenderId)) {
+        expect(
+          receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
+        ).toEqual(receivedMessage.messageId);
+      } else {
+        expect(
+          receivedMessageState.allMessages[receivedMessageState.allMessages.length - 1].messageId
+        ).not.toEqual(receivedMessage.messageId);
+      }
+    });
   });
 
   it('should filter by MESSAGE_LIST_PARAMS_CHANGED when ON_MESSAGE_UPDATED', () => {
     const mockData = generateMockChannel();
-    const messageId = 1010;
+    const changingMessage = uuid();
     const updatingMessage = {
       ...mockData.allMessages[0],
-      messageId: messageId,
+      messageId: 1010,
       messageType: 'user',
       customType: 'apple',
       sender: { userId: 'John' },
@@ -373,7 +418,6 @@ describe('Messages-Reducers', () => {
     expect(appliedParamsState.messageListParams.customTypes).toEqual(['apple', 'banana']);
     expect(appliedParamsState.messageListParams.senderUserIds).toEqual(['John', 'Mark']);
 
-    const changingMessage = uuid();
     const updatedMessageState = reducers(appliedParamsState, {
       type: actionTypes.ON_MESSAGE_UPDATED,
       payload: {
@@ -414,5 +458,34 @@ describe('Messages-Reducers', () => {
     });
     expect(updatedWrongWithSenderIdState.allMessages.map((message) => message.messageId)).not.toContain(updatingMessage.messageId);
     expect(updatedWrongWithSenderIdState.allMessages[0].messageId).toEqual(appliedParamsState.allMessages[1].messageId);
+  });
+
+  it('should not update with coming message when received message already exsits', () => {
+    const mockData = generateMockChannel();
+    const changingMessage = uuid();
+    const updatingMessage = {
+      ...mockData.allMessages[0],
+      messageId: 1010,
+      messageType: 'user',
+      customType: 'apple',
+      sender: { userId: 'John' },
+      isUserMessage: () => true,
+    };
+    const onMessageUpdatedState = reducers(
+      {
+        ...mockData,
+        allMessages: [updatingMessage, ...mockData.allMessages],
+      },
+      {
+        type: actionTypes.ON_MESSAGE_RECEIVED,
+        payload: {
+          channel: { url: mockMessage1.channelUrl },
+          message: { ...updatingMessage, message: changingMessage },
+        },
+      }
+    );
+    expect(onMessageUpdatedState.allMessages[0].messageId).toEqual(updatingMessage.messageId);
+    expect(onMessageUpdatedState.allMessages[0].message).toEqual(updatingMessage.message);
+    expect(onMessageUpdatedState.allMessages[0].message).not.toEqual(changingMessage);
   });
 });

--- a/src/smart-components/Conversation/dux/__tests__/reducers.spec.js
+++ b/src/smart-components/Conversation/dux/__tests__/reducers.spec.js
@@ -3,7 +3,6 @@ import * as actionTypes from '../actionTypes';
 import reducers from '../reducers';
 import initialState from '../initialState';
 import uuid from '../../../../utils/uuid';
-import { expect } from '@jest/globals';
 
 const randomBoolean = () => Math.random() >= 0.5;
 describe('Messages-Reducers', () => {

--- a/src/smart-components/Conversation/dux/data.mock.js
+++ b/src/smart-components/Conversation/dux/data.mock.js
@@ -100,7 +100,6 @@ export const generateMockChannel = () => ({
       "_preferredLanguages": null,
       "isBlockedByMe": false
     },
-
     "reqId": "1582004210491",
     "translations": {},
     "requestState": "succeeded",
@@ -127,6 +126,7 @@ export const generateMockMessage = (id) => {
     "mentionedUsers": [],
     "message": "146",
     "_sender": {},
+    sender: {},
     "reqId": "1582004949355",
     "translations": {},
     "requestState": "succeeded",
@@ -136,6 +136,7 @@ export const generateMockMessage = (id) => {
       // mock for SDK
       mockMessage.reactions = reactionEvent.reactions;
     },
+    isUserMessage: () => true,
   };
   return mockMessage;
 }

--- a/src/smart-components/Conversation/dux/reducers.js
+++ b/src/smart-components/Conversation/dux/reducers.js
@@ -180,12 +180,15 @@ export default function reducer(state, action) {
       const { currentGroupChannel = {}, unreadSince } = state;
       const currentGroupChannelUrl = currentGroupChannel.url;
 
-      if (!compareIds(channel.url, currentGroupChannelUrl)
-        || (!(state.allMessages.map((msg) => msg.messageId).indexOf(message.messageId) < 0))
-        // Excluded overlapping messages
-        || (state.messageListParams && !filterMessageListParams(state.messageListParams, message))
-        // Filter by userFilledQuery
-      ) {
+      if (!compareIds(channel.url, currentGroupChannelUrl)) {
+        return state;
+      }
+      // Excluded overlapping messages
+      if (state.allMessages.some((msg) => msg.messageId === message.messageId)) {
+        return state;
+      }
+      // Filter by userFilledQuery
+      if (state.messageListParams && !filterMessageListParams(state.messageListParams, message)) {
         return state;
       }
 
@@ -217,7 +220,7 @@ export default function reducer(state, action) {
         return {
           ...state,
           allMessages: state.allMessages.filter((m) => (
-            !compareIds(m.messageId, action.payload)
+            !compareIds(m.messageId, action.payload.message.messageId)
           )),
         };
       }

--- a/src/smart-components/Conversation/dux/reducers.js
+++ b/src/smart-components/Conversation/dux/reducers.js
@@ -220,7 +220,7 @@ export default function reducer(state, action) {
         return {
           ...state,
           allMessages: state.allMessages.filter((m) => (
-            !compareIds(m.messageId, action.payload.message.messageId)
+            !compareIds(m.messageId, message?.messageId)
           )),
         };
       }

--- a/src/utils/__tests__/utils.spec.js
+++ b/src/utils/__tests__/utils.spec.js
@@ -1,0 +1,19 @@
+import { binarySearch } from '../index';
+
+describe('Global-utils', () => {
+  it('should find right index with binarySearch', () => {
+    const criterionArray = [99, 88, 77, 66, 55, 44, 33, 22, 11, 0];
+
+    const targetIndex1 = binarySearch(criterionArray, 100);
+    expect(targetIndex1).toEqual(0);
+    const targetIndex2 = binarySearch(criterionArray, 1);
+    expect(targetIndex2).toEqual(criterionArray.length - 1);
+
+    criterionArray.forEach((value, index) => {
+      const targetIndex = binarySearch(criterionArray, value);
+      expect(targetIndex).toEqual(index);
+      const targetIndexPlusOne = binarySearch(criterionArray, value + 1);
+      expect(targetIndexPlusOne).toEqual(index);
+    });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -391,7 +391,7 @@ export const filterChannelListParams = (params: SDKChannelListParamsPrivateProps
       if (!userIds.includes(currentUserId)) {
         userIds.push(currentUserId); // add the caller's userId if not added already.
       }
-      if (channel.members.length !== userIds.length) {
+      if (channel.members.length > userIds.length) {
         return false; // userIds may contain one or more non-member(s).
       }
       if (!hasSameMembers(userIds, memberIds)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -529,7 +529,7 @@ export const filterChannelListParams = (params: SDKChannelListParamsPrivateProps
   return true;
 };
 
-const binarySearch = (list: Array<number>, number: number): number => {// [100, 99, 98, 97, ...]
+export const binarySearch = (list: Array<number>, number: number): number => {// [100, 99, 98, 97, ...]
   const pivot = Math.floor(list.length / 2);
   if (list[pivot] === number) {
     return pivot;
@@ -537,15 +537,9 @@ const binarySearch = (list: Array<number>, number: number): number => {// [100, 
   const leftList = list.slice(0, pivot);
   const rightList = list.slice(pivot + 1, list.length);
   if (list[pivot] > number) {
-    if (rightList.length === 0) {
-      return pivot + 1;
-    }
-    return pivot + binarySearch(rightList, number);
+    return pivot + 1 + (rightList.length === 0 ? 0 : binarySearch(rightList, number));
   } else {
-    if (leftList.length === 0) {
-      return pivot;
-    }
-    return binarySearch(leftList, number);
+    return (leftList.length === 0) ? pivot : binarySearch(leftList, number);
   }
 };
 // This is required when channel is displayed on channel list by filter


### PR DESCRIPTION
## Jira Ticket
[UK-860](https://sendbird.atlassian.net/browse/UK-860)

## Description Of Changes

- Do not check readMessageCount condition when channelListQuery exist
- Fix issue in CREATE_CHANNEL / create channel because of object destruction in reducers
- Fix messageId comparison in on message updated
- Fix binarySearch when targetIndex is 0 before it pushes the target item to the second position
- Add tests for events filter

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)

Add tests