### PR TITLE
[UK-972] Get back the string set legacy

### DIFF
--- a/src/ui/Label/stringSet.js
+++ b/src/ui/Label/stringSet.js
@@ -90,6 +90,11 @@ const getStringSet = (lang = 'en') => {
       REPLYING_ATTACHMENT__FILE_TYPE__GIF: 'GIF',
       REPLYING_ATTACHMENT__FILE_TYPE__VIDEO: 'Video',
       REPLIED_TO: 'replied to',
+      // FIXME: get back legacy, remove after refactoring open channel messages
+      CONTEXT_MENU_DROPDOWN__COPY: 'Copy',
+      CONTEXT_MENU_DROPDOWN__EDIT: 'Edit',
+      CONTEXT_MENU_DROPDOWN__RESEND: 'Resend',
+      CONTEXT_MENU_DROPDOWN__DELETE: 'Delete',
     },
   };
   return stringSet[lang];


### PR DESCRIPTION
[UK-972](https://sendbird.atlassian.net/browse/UK-972)

## Description Of Changes

Get back the string set legacy for message menus of open channel

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
