### PR TITLE
[QU-305] Match width of message and emoji reactions

### DIFF
--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -9,9 +9,8 @@
   &.incoming { justify-content: flex-start; }
   &.outgoing { justify-content: flex-end; }
   .sendbird-message-content__middle {
-    .sendbird-message-content__middle__message-item-body.use-quote {
+    .sendbird-message-content__middle__body-container.use-quote {
       top: -8px;
-      width: fit-content;
     }
   }
 }
@@ -149,6 +148,10 @@
       &.outgoing { justify-content: flex-end }
       &.incoming { justify-content: flex-start }
     }
+
+    .sendbird-message-content__middle__body-container {
+      width: fit-content;
+    }
   }
 
   .sendbird-message-content__right {
@@ -164,6 +167,18 @@
         display: inline-flex;
       }
     }
+  }
+}
+
+.sendbird-message-content__middle__body-container {
+  position: relative;
+  width: fit-content;
+  .sendbird-message-content__middle__message-item-body {
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .sendbird-message-content-reactions {
+    width: 100%;
   }
 }
 

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -185,68 +185,71 @@ export default function MessageContent({
         {/* quote message */}
         {(useReplying) ? (
           <div className={getClassName(['sendbird-message-content__middle__quote-message', isByMe ? 'outgoing' : 'incoming'])}>
-          <QuoteMessage message={message} isByMe={isByMe} />
+            <QuoteMessage message={message} isByMe={isByMe} />
           </div>
-        ): null}
-        {/* message item body components */}
-        {isTextMessage(message as UserMessage) && (
-          <TextMessageItemBody
-            className={['sendbird-message-content__middle__message-item-body', useReplyingClassName]}
-            message={message as UserMessage}
-            isByMe={isByMe}
-            mouseHover={mouseHover}
-          />
-        )}
-        {(isOGMessage(message as UserMessage)) && (
-          <OGMessageItemBody
-            className={['sendbird-message-content__middle__message-item-body', useReplyingClassName]}
-            message={message as UserMessage}
-            isByMe={isByMe}
-            mouseHover={mouseHover}
-          />
-        )}
-        {(getUIKitMessageType((message as FileMessage)) === messageTypes.FILE) && (
-          <FileMessageItemBody
-            className={['sendbird-message-content__middle__message-item-body', useReplyingClassName]}
-            message={message as FileMessage}
-            isByMe={isByMe}
-            mouseHover={mouseHover}
-          />
-        )}
-        {(isThumbnailMessage(message as FileMessage)) && (
-          <ThumbnailMessageItemBody
-            className={['sendbird-message-content__middle__message-item-body', useReplyingClassName]}
-            message={message as FileMessage}
-            isByMe={isByMe}
-            mouseHover={mouseHover}
-            showFileViewer={showFileViewer}
-          />
-        )}
-        {(getUIKitMessageType((message as FileMessage)) === messageTypes.UNKNOWN) && (
-          <UnknownMessageItemBody
-            className={['sendbird-message-content__middle__message-item-body', useReplyingClassName]}
-            message={message}
-            isByMe={isByMe}
-            mouseHover={mouseHover}
-          />
-        )}
-        {/* reactions */}
-        {(useReaction && message?.reactions?.length > 0) && (
-          <div className={getClassName([
-            'sendbird-message-content-reactions',
-            (!isByMe || isThumbnailMessage(message as FileMessage) || isOGMessage(message as UserMessage)) ? '' : 'primary',
-            mouseHover ? 'mouse-hover' : '',
-          ])}>
-            <EmojiReactions
-              userId={userId}
+        ) : null}
+        {/* container: message item body + emoji reactions */}
+        <div className={getClassName(['sendbird-message-content__middle__body-container', useReplyingClassName])} >
+          {/* message item body components */}
+          {isTextMessage(message as UserMessage) && (
+            <TextMessageItemBody
+              className="sendbird-message-content__middle__message-item-body"
+              message={message as UserMessage}
+              isByMe={isByMe}
+              mouseHover={mouseHover}
+            />
+          )}
+          {(isOGMessage(message as UserMessage)) && (
+            <OGMessageItemBody
+              className="sendbird-message-content__middle__message-item-body"
+              message={message as UserMessage}
+              isByMe={isByMe}
+              mouseHover={mouseHover}
+            />
+          )}
+          {(getUIKitMessageType((message as FileMessage)) === messageTypes.FILE) && (
+            <FileMessageItemBody
+              className="sendbird-message-content__middle__message-item-body"
+              message={message as FileMessage}
+              isByMe={isByMe}
+              mouseHover={mouseHover}
+            />
+          )}
+          {(isThumbnailMessage(message as FileMessage)) && (
+            <ThumbnailMessageItemBody
+              className="sendbird-message-content__middle__message-item-body"
+              message={message as FileMessage}
+              isByMe={isByMe}
+              mouseHover={mouseHover}
+              showFileViewer={showFileViewer}
+            />
+          )}
+          {(getUIKitMessageType((message as FileMessage)) === messageTypes.UNKNOWN) && (
+            <UnknownMessageItemBody
+              className="sendbird-message-content__middle__message-item-body"
               message={message}
               isByMe={isByMe}
-              emojiContainer={emojiContainer}
-              memberNicknamesMap={nicknamesMap}
-              toggleReaction={toggleReaction}
+              mouseHover={mouseHover}
             />
-          </div>
-        )}
+          )}
+          {/* reactions */}
+          {(useReaction && message?.reactions?.length > 0) && (
+            <div className={getClassName([
+              'sendbird-message-content-reactions',
+              (!isByMe || isThumbnailMessage(message as FileMessage) || isOGMessage(message as UserMessage)) ? '' : 'primary',
+              mouseHover ? 'mouse-hover' : '',
+            ])}>
+              <EmojiReactions
+                userId={userId}
+                message={message}
+                isByMe={isByMe}
+                emojiContainer={emojiContainer}
+                memberNicknamesMap={nicknamesMap}
+                toggleReaction={toggleReaction}
+              />
+            </div>
+          )}
+        </div>
       </div>
       {/* right */}
       <div className={getClassName(['sendbird-message-content__right', chainTopClassName, useReactionClassName, useReplyingClassName])}>


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[QU-305](https://sendbird.atlassian.net/browse/QU-305)

## Description Of Changes

* Create container containing message item body and emoji reactions components to match width of them

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
