### PR TITLE
[UIKIT-1453] Do not call updateUserInfo when nickname and profileUrl are empty string

### DIFF
--- a/src/lib/dux/sdk/thunks.js
+++ b/src/lib/dux/sdk/thunks.js
@@ -66,7 +66,7 @@ export const handleConnection = ({
           userDispatcher({ type: INIT_USER, payload: user });
           // use nickname/profileUrl if provided
           // or set userID as nickname
-          if (nickname !== user.nickname || profileUrl !== user.profileUrl) {
+          if ((nickname !== user.nickname || profileUrl !== user.profileUrl) && (nickname !== '' || profileUrl !== '')) {
             newSdk.updateCurrentUserInfo(nickname || user.nickname, profileUrl || user.profileUrl)
               .then((namedUser) => {
                 userDispatcher({ type: UPDATE_USER_INFO, payload: namedUser });

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -204,9 +204,9 @@ export const user1 = () => fitPageSize(
     appId={appId}
     userId={array[0]}
     nickname={array[0]}
+    profileUrl={addProfile}
     showSearchIcon
     allowProfileEdit
-    profileUrl={addProfile}
     config={{ logLevel: 'all' }}
     queries={{}}
     replyType="QUOTE_REPLY"


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-1453](https://sendbird.atlassian.net/browse/UIKIT-1453)

## Description Of Changes

[UIKIT-1453] Do not call updateUserInfo when nickname and profileUrl are empty string

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)


[UIKIT-1453]: https://sendbird.atlassian.net/browse/UIKIT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ