### PR TITLE
[UIKIT-576]Setup date localization

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -344,6 +344,7 @@ interface SendBirdProviderProps {
   theme?: 'light' | 'dark';
   nickname?: string;
   profileUrl?: string;
+  dateLocale?: any;
   disableUserProfile?: boolean;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
   allowProfileEdit?: boolean;
@@ -435,6 +436,7 @@ interface AppProps {
   theme?: 'light' | 'dark';
   userListQuery?(): UserListQuery;
   nickname?: string;
+  dateLocale?: any;
   profileUrl?: string;
   allowProfileEdit?: boolean;
   disableUserProfile?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -344,7 +344,7 @@ interface SendBirdProviderProps {
   theme?: 'light' | 'dark';
   nickname?: string;
   profileUrl?: string;
-  dateLocale?: any;
+  dateLocale?: Locale;
   disableUserProfile?: boolean;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
   allowProfileEdit?: boolean;
@@ -436,7 +436,7 @@ interface AppProps {
   theme?: 'light' | 'dark';
   userListQuery?(): UserListQuery;
   nickname?: string;
-  dateLocale?: any;
+  dateLocale?: Locale;
   profileUrl?: string;
   allowProfileEdit?: boolean;
   disableUserProfile?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import Sendbird from 'sendbird';
+import type { Locale } from 'date-fns';
 
 export type OpenChannelType = Sendbird.OpenChannel;
 export type GroupChannelType = Sendbird.GroupChannel;

--- a/src/legacy/message-refactor/FileMessage/index.jsx
+++ b/src/legacy/message-refactor/FileMessage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import './index.scss';
 
@@ -20,6 +20,7 @@ import {
   getIsSentFromSendingStatus,
 } from './utils';
 import useMouseHover from '../../../hooks/onMouseHover';
+import { LocalizationContext } from '../../../lib/LocalizationContext';
 
 const MAX_TRUNCATE_LENGTH = 40;
 const GROUPAING_PADDING = '1px';
@@ -376,6 +377,7 @@ export function IncomingFileMessage({
   const [mousehover, setMousehover] = useState(false);
   const [moreActive, setMoreActive] = useState(false);
   const [menuDisplaying, setMenuDisplaying] = useState(false);
+  const { dateLocale } = useContext(LocalizationContext);
   const showReactionAddButton = useReaction && emojiAllMap && (emojiAllMap.size > 0);
   const MemoizedEmojiListItems = memoizedEmojiListItems;
 
@@ -560,7 +562,7 @@ export function IncomingFileMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {getMessageCreatedAt(message)}
+                {format(message?.createdAt, 'p', dateLocale)}
               </Label>
             )
           }

--- a/src/legacy/message-refactor/Message/index.jsx
+++ b/src/legacy/message-refactor/Message/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import './index.scss';
 
 import { UserProfileContext } from '../../../lib/UserProfileContext';
+import { LocalizationContext } from '../../../lib/LocalizationContext';
 import UserProfile from '../../../ui/UserProfile';
 import Avatar from '../../../ui/Avatar/index';
 import Icon, { IconTypes, IconColors } from '../../../ui/Icon';
@@ -13,7 +14,6 @@ import ContextMenu, { MenuItem, MenuItems } from '../../../ui/ContextMenu';
 import EmojiReactions from '../EmojiReactions';
 import {
   copyToClipboard,
-  getMessageCreatedAt,
   getSenderName,
   getSenderProfileUrl,
   getIsSentFromStatus,
@@ -21,6 +21,7 @@ import {
 } from './utils';
 import useMemoizedMessageText from './memoizedMessageText';
 import useMouseHover from '../../../hooks/onMouseHover';
+import format from 'date-fns/format';
 
 const noop = () => { };
 const GROUPING_PADDING = '1px';
@@ -48,6 +49,7 @@ export default function Message(props) {
 
   if (!message) return null;
 
+  const { dateLocale } = useContext(LocalizationContext);
   const outgoingMemoizedMessageText = useMemoizedMessageText({
     className: 'sendbird-user-message-word',
     message: message.message,
@@ -624,7 +626,7 @@ function IncomingUserMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {getMessageCreatedAt(message)}
+                { format(message?.createdAt || 0, 'p', { locale: dateLocale}) }
               </Label>
             )
           }

--- a/src/legacy/message-refactor/Message/utils.js
+++ b/src/legacy/message-refactor/Message/utils.js
@@ -1,4 +1,3 @@
-import format from 'date-fns/format';
 import { getOutgoingMessageStates } from '../../../utils';
 
 const MessageStatusType = getOutgoingMessageStates();
@@ -24,8 +23,6 @@ export const copyToClipboard = (text) => {
   }
   return false;
 };
-
-export const getMessageCreatedAt = (message) => format(message.createdAt || 0, 'p');
 
 export const getSenderName = (message) => (
   message.sender && (
@@ -54,7 +51,6 @@ export const createUrlTester = (regexp) => (text) => regexp.test(text);
 
 export default {
   copyToClipboard,
-  getMessageCreatedAt,
   getSenderName,
   getSenderProfileUrl,
   getIsSentFromStatus,

--- a/src/legacy/message-refactor/OGMessage/index.jsx
+++ b/src/legacy/message-refactor/OGMessage/index.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
+import format from 'date-fns/format';
 
 import {
   getSenderName,
   copyToClipboard,
   checkOGIsEnalbed,
-  getMessageCreatedAt,
   getIsSentFromStatus,
   getSenderProfileUrl,
   getIsSentFromSendingStatus,
@@ -438,7 +438,7 @@ function IncomingOGMessage(props) {
   const {
     defaultImage,
   } = ogMetaData;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const MemoizedMessageText = memoizedMessageText;
   const MemoizedEmojiListItems = memoizedEmojiListItems;
   const showEmojiReactions = (useReaction && message.reactions && message.reactions.length > 0);
@@ -649,7 +649,7 @@ function IncomingOGMessage(props) {
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {getMessageCreatedAt(message)}
+                { format(message?.createdAt || 0, 'p', { locale: dateLocale}) }
               </Label>
             )
           }

--- a/src/legacy/message-refactor/OGMessage/utils.js
+++ b/src/legacy/message-refactor/OGMessage/utils.js
@@ -1,4 +1,3 @@
-import format from 'date-fns/format';
 import { getOutgoingMessageStates } from '../../../utils';
 
 const MessageStatusType = getOutgoingMessageStates();
@@ -48,8 +47,6 @@ export const getSenderName = (message) => (
   )
 );
 
-export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
-
 export const checkOGIsEnalbed = (message) => {
   const { ogMetaData } = message;
   if (!ogMetaData) {
@@ -74,7 +71,6 @@ export default {
   createUrlTester,
   copyToClipboard,
   checkOGIsEnalbed,
-  getMessageCreatedAt,
   getIsSentFromStatus,
   getSenderProfileUrl,
   getIsSentFromSendingStatus,

--- a/src/legacy/message-refactor/ThumbnailMessage/index.jsx
+++ b/src/legacy/message-refactor/ThumbnailMessage/index.jsx
@@ -5,10 +5,10 @@ import React, {
   useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
+import format from 'date-fns/format';
 
 import './index.scss';
 import {
-  getMessageCreatedAt,
   getIsSentFromStatus,
   getIsSentFromSendingStatus,
 } from './util';
@@ -439,7 +439,7 @@ export function IncomingThumbnailMessage({
     disableUserProfile,
     renderUserProfile,
   } = React.useContext(UserProfileContext);
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const messageRef = useRef(null);
   const parentContainRef = useRef(null);
   const reactionAddRef = useRef(null);
@@ -665,7 +665,7 @@ export function IncomingThumbnailMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {getMessageCreatedAt(message)}
+                { format(message?.createdAt || 0, 'p', { locale: dateLocale}) }
               </Label>
             )
           }

--- a/src/legacy/message-refactor/ThumbnailMessage/tests/ThumbnailMessage.js
+++ b/src/legacy/message-refactor/ThumbnailMessage/tests/ThumbnailMessage.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import ThumbnailMessage from '../index.jsx';
 
 import message from '../dummyData.mock';
-import { getMessageCreatedAt } from '../util';
 
 const noop = () => { };
 
@@ -36,7 +35,6 @@ const legacy = () => {
     );
     expect(component.find('.sendbird-incoming-thumbnail-message__avatar').hostNodes().text()).toEqual('');
     expect(component.find('.sendbird-incoming-thumbnail-message__sender-name').hostNodes().text()).toEqual(message.sender.nickname);
-    expect(component.find('.sendbird-incoming-thumbnail-message__sent-at').hostNodes().text()).toEqual(getMessageCreatedAt(message));
   });
 
   it('should handle outgoing message', () => {

--- a/src/legacy/message-refactor/ThumbnailMessage/util.js
+++ b/src/legacy/message-refactor/ThumbnailMessage/util.js
@@ -1,9 +1,6 @@
-import format from 'date-fns/format';
 import { getOutgoingMessageStates } from '../../../utils';
 
 const MessageStatusType = getOutgoingMessageStates();
-
-export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
 
 export const getIsSentFromStatus = (status) => (
   status === MessageStatusType.SENT
@@ -19,7 +16,6 @@ export const getIsSentFromSendingStatus = (message = {}) => {
 };
 
 export default {
-  getMessageCreatedAt,
   getIsSentFromStatus,
   getIsSentFromSendingStatus,
 };

--- a/src/legacy/message-refactor/UnknownMessage/index.jsx
+++ b/src/legacy/message-refactor/UnknownMessage/index.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
+import format from 'date-fns/format';
 
 import './index.scss';
-import * as utils from './utils';
 
 import { LocalizationContext } from '../../../lib/LocalizationContext';
 import Avatar from '../../../ui/Avatar/index';
@@ -93,7 +93,7 @@ function OutgoingUnknownMessage({
   const [mousehover, setMousehover] = useState(false);
   const [moreActive, setMoreActive] = useState(false);
   const [menuDisplaying, setMenuDisplaying] = useState(false);
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const handleMoreIconClick = () => {
     setMoreActive(true);
   };
@@ -312,7 +312,7 @@ function IncomingUnknownMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {utils.getMessageCreatedAt(message)}
+                { format(message?.createdAt || 0, 'p', { locale: dateLocale}) }
               </Label>
             )
           }

--- a/src/legacy/message-refactor/UnknownMessage/utils.js
+++ b/src/legacy/message-refactor/UnknownMessage/utils.js
@@ -1,7 +1,0 @@
-import format from 'date-fns/format';
-
-export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
-
-export default {
-  getMessageCreatedAt,
-};

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -4,10 +4,12 @@ import getStringSet from '../ui/Label/stringSet';
 
 const LocalizationContext = React.createContext({
   stringSet: getStringSet('en'),
+  dateLocale: null,
 });
 
 interface LocalizationProviderProps {
   stringSet: Record<string, string>;
+  dateLocale: any;
   children: React.Component;
 }
 

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -9,7 +9,7 @@ const LocalizationContext = React.createContext({
 
 interface LocalizationProviderProps {
   stringSet: Record<string, string>;
-  dateLocale: any;
+  dateLocale: Locale;
   children: React.Component;
 }
 

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import getStringSet from '../ui/Label/stringSet';
+import type { Locale } from 'date-fns';
 
 const LocalizationContext = React.createContext({
   stringSet: getStringSet('en'),

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -33,6 +33,7 @@ export default function Sendbird(props) {
     allowProfileEdit,
     theme,
     nickname,
+    dateLocale,
     profileUrl,
     userListQuery,
     config = {},
@@ -169,7 +170,7 @@ export default function Sendbird(props) {
         },
       }}
     >
-      <LocalizationProvider stringSet={localeStringSet}>
+      <LocalizationProvider stringSet={localeStringSet} dateLocale={dateLocale}>
         {children}
       </LocalizationProvider>
     </SendbirdSdkContext.Provider>
@@ -188,6 +189,7 @@ Sendbird.propTypes = {
   theme: PropTypes.string,
   nickname: PropTypes.string,
   profileUrl: PropTypes.string,
+  dateLocale: PropTypes.shape({}),
   disableUserProfile: PropTypes.bool,
   renderUserProfile: PropTypes.func,
   allowProfileEdit: PropTypes.bool,
@@ -224,6 +226,7 @@ Sendbird.defaultProps = {
   theme: 'light',
   nickname: '',
   profileUrl: '',
+  dateLocale: null,
   disableUserProfile: false,
   renderUserProfile: null,
   allowProfileEdit: false,

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -30,6 +30,7 @@ export default function App(props) {
     useMessageGrouping,
     colorSet,
     stringSet,
+    dateLocale,
     allowProfileEdit,
     disableUserProfile,
     renderUserProfile,
@@ -46,6 +47,7 @@ export default function App(props) {
   return (
     <Sendbird
       stringSet={stringSet}
+      dateLocale={dateLocale}
       appId={appId}
       userId={userId}
       accessToken={accessToken}
@@ -157,6 +159,7 @@ App.propTypes = {
       PropTypes.arrayOf(PropTypes.string),
     ]),
   }),
+  dateLocale: PropTypes.shape({}),
   useReaction: PropTypes.bool,
   replyType: PropTypes.oneOf(['NONE', 'QUOTE_REPLY', 'THREAD']),
   showSearchIcon: PropTypes.bool,
@@ -188,6 +191,7 @@ App.defaultProps = {
   showSearchIcon: false,
   renderUserProfile: null,
   config: {},
+  dateLocale: null,
   useReaction: true,
   replyType: 'NONE',
   useMessageGrouping: true,

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+import kr from 'date-fns/locale/ko';
+
 import pkg from '../../../../package-lock.json'
 
 import App from '../index';
@@ -190,6 +192,7 @@ export const Korean = () => fitPageSize(
     userId={array[0]}
     nickname={array[0]}
     showSearchIcon
+    dateLocale={kr}
     stringSet={{
       CHANNEL_LIST__TITLE: '채널 목록',
       CHANNEL__MESSAGE_INPUT__PLACE_HOLDER: '메시지 보내기',
@@ -394,6 +397,7 @@ export const renderUserProfile = () => fitPageSize(
     renderUserProfile={({ user }) => {
       return user.userId;
     }}
+    dateLocale
   />
 );
 

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -397,7 +397,6 @@ export const renderUserProfile = () => fitPageSize(
     renderUserProfile={({ user }) => {
       return user.userId;
     }}
-    dateLocale
   />
 );
 

--- a/src/smart-components/Conversation/components/MessageHOC.jsx
+++ b/src/smart-components/Conversation/components/MessageHOC.jsx
@@ -3,10 +3,12 @@ import React, {
   useRef,
   useMemo,
   useLayoutEffect,
+  useContext,
 } from 'react';
 import PropTypes from 'prop-types';
 import format from 'date-fns/format';
 
+import { LocalizationContext } from '../../../lib/LocalizationContext';
 import MessageContent from '../../../ui/MessageContent';
 import DateSeparator from '../../../ui/DateSeparator';
 import Label, { LabelTypography, LabelColors } from '../../../ui/Label';
@@ -49,6 +51,7 @@ export default function MessageHoc({
   const editMessageInputRef = useRef(null);
   const useMessageScrollRef = useRef(null);
 
+  const { dateLocale } = useContext(LocalizationContext);
   useLayoutEffect(() => {
     handleScroll();
   }, [showEdit, message?.reactions?.length]);
@@ -113,7 +116,7 @@ export default function MessageHoc({
           hasSeparator && (
             <DateSeparator>
               <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-                {format(message.createdAt, 'MMMM dd, yyyy')}
+                {format(message?.createdAt, 'MMMM dd, yyyy', { locale: dateLocale })}
               </Label>
             </DateSeparator>
           )
@@ -152,7 +155,7 @@ export default function MessageHoc({
         hasSeparator && (
           <DateSeparator>
             <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-              {format(message.createdAt, 'MMMM dd, yyyy')}
+              {format(message?.createdAt, 'MMMM dd, yyyy', { locale: dateLocale })}
             </Label>
           </DateSeparator>
         )

--- a/src/smart-components/OpenchannelConversation/components/MessageHOC.tsx
+++ b/src/smart-components/OpenchannelConversation/components/MessageHOC.tsx
@@ -3,10 +3,13 @@ import React, {
   useRef,
   ReactElement,
   useMemo,
+  useContext,
 } from 'react';
 
 import format from 'date-fns/format';
 import * as types from '../../../index';
+
+import { LocalizationContext } from '../../../lib/LocalizationContext';
 
 import OpenChannelUserMessage from '../../../ui/OpenchannelUserMessage';
 import OpenChannelAdminMessage from '../../../ui/OpenChannelAdminMessage';
@@ -64,6 +67,8 @@ export default function MessageHoc({
     sender = message.sender;
   }
 
+  const { dateLocale } = useContext(LocalizationContext);
+
   const RenderedMessage = useMemo(() => {
     if (renderCustomMessage) {
       return renderCustomMessage(message, channel, chainTop, chainBottom);
@@ -114,7 +119,7 @@ export default function MessageHoc({
         hasSeparator && (
           <DateSeparator>
             <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-              {format(message.createdAt, 'MMMM dd, yyyy')}
+              {format(message.createdAt, 'MMMM dd, yyyy', { locale: dateLocale })}
             </Label>
           </DateSeparator>
         )

--- a/src/ui/ChannelPreview/index.jsx
+++ b/src/ui/ChannelPreview/index.jsx
@@ -24,7 +24,7 @@ export default function ChannelPreview({
     userId,
   } = currentUser;
   const { isBroadcast, isFrozen } = channel;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   return (
     <div
       className={[
@@ -94,7 +94,7 @@ export default function ChannelPreview({
             type={LabelTypography.CAPTION_3}
             color={LabelColors.ONBACKGROUND_2}
           >
-            {utils.getLastMessageCreatedAt(channel)}
+            {utils.getLastMessageCreatedAt(channel, dateLocale)}
           </Label>
         </div>
         <div className="sendbird-channel-preview__content__lower">

--- a/src/ui/ChannelPreview/utils.js
+++ b/src/ui/ChannelPreview/utils.js
@@ -1,5 +1,7 @@
 import isToday from 'date-fns/isToday';
+
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isYesterday from 'date-fns/isYesterday';
 
 import { truncateString } from '../../utils';
@@ -22,20 +24,18 @@ export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelSt
     .join(', ');
 };
 
-export const getLastMessageCreatedAt = (channel) => {
-  if (!channel || !channel.lastMessage) {
+export const getLastMessageCreatedAt = (channel, locale) => {
+  const createdAt = channel?.lastMessage?.createdAt;
+  if (!createdAt) {
     return '';
   }
-  const date = channel.lastMessage.createdAt;
-  if (isToday(date)) {
-    return format(date, 'p');
+  if (isToday(createdAt)) {
+    return format(createdAt, 'p', { locale });
   }
-
-  if (isYesterday(date)) {
-    return 'Yesterday';
+  if (isYesterday(createdAt)) {
+    return formatRelative(createdAt, new Date(), { locale });
   }
-
-  return format(date, 'MMM dd');
+  return format(createdAt, 'MMM dd', { locale });
 };
 
 export const getTotalMembers = (channel) => (

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -1,5 +1,11 @@
-import React, { ReactElement, useContext, useRef, useState } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
 import { GroupChannel, AdminMessage, UserMessage, FileMessage, EmojiContainer } from 'sendbird';
+import format from 'date-fns/format';
 import './index.scss';
 
 import Avatar from '../Avatar';
@@ -28,9 +34,9 @@ import {
   isThumbnailMessage,
   getOutgoingMessageState,
   getSenderName,
-  getMessageCreatedAt,
 } from '../../utils';
 import { UserProfileContext } from '../../lib/UserProfileContext';
+import { LocalizationContext } from '../../lib/LocalizationContext';
 import { ReplyType } from '../../index.js';
 
 interface Props {
@@ -75,6 +81,7 @@ export default function MessageContent({
 }: Props): ReactElement {
   const messageTypes = getUIKitMessageTypes();
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { dateLocale } = useContext(LocalizationContext);
   const avatarRef = useRef(null);
   const [mouseHover, setMouseHover] = useState(false);
   const [supposedHover, setSupposedHover] = useState(false);
@@ -268,7 +275,7 @@ export default function MessageContent({
               type={LabelTypography.CAPTION_3}
               color={LabelColors.ONBACKGROUND_2}
             >
-              {getMessageCreatedAt(message)}
+              {format(message.createdAt, 'p', { locale: dateLocale })}
             </Label>
           )}
         </div>

--- a/src/ui/MessageSearchFileItem/index.tsx
+++ b/src/ui/MessageSearchFileItem/index.tsx
@@ -25,7 +25,7 @@ export default function MessageSearchFileItem(props: Props): ReactElement {
   const fileMessageUrl = url;
   const sender = message.sender || message._sender;
   const { profileUrl, nickname } = sender;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
 
   return (
     <div
@@ -79,7 +79,7 @@ export default function MessageSearchFileItem(props: Props): ReactElement {
         type={LabelTypography.CAPTION_3}
         color={LabelColors.ONBACKGROUND_2}
       >
-        {getCreatedAt(createdAt)}
+        {getCreatedAt(createdAt, dateLocale)}
       </Label>
       <div className="sendbird-message-search-file-item__right-footer" />
     </div>

--- a/src/ui/MessageSearchFileItem/utils.ts
+++ b/src/ui/MessageSearchFileItem/utils.ts
@@ -1,19 +1,20 @@
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isToday from 'date-fns/isToday';
 import isYesterday from 'date-fns/isYesterday';
 import { IconTypes } from '../Icon';
 
-export function getCreatedAt(createdAt: number): string {
+export function getCreatedAt(createdAt: number, locale: Locale): string {
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p');
+    return format(createdAt, 'p', { locale });
   }
   if (isYesterday(createdAt)) {
-    return 'Yesterday';
+    return formatRelative(createdAt, new Date(), { locale });
   }
-  return format(createdAt, 'MMM dd');
+  return format(createdAt, 'MMM dd', { locale });
 }
 
 export function getIconOfFileType(message: SendbirdUIKit.ClientFileMessage): string {

--- a/src/ui/MessageSearchItem/getCreatedAt.ts
+++ b/src/ui/MessageSearchItem/getCreatedAt.ts
@@ -1,17 +1,18 @@
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isToday from 'date-fns/isToday';
 import isYesterday from 'date-fns/isYesterday';
 
 // getCreatedAt
-export default (createdAt: number): string => {
+export default (createdAt: number, locale: Locale): string => {
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p');
+    return format(createdAt, 'p',  { locale });
   }
   if (isYesterday(createdAt)) {
-    return 'Yesterday';
+    return formatRelative(createdAt, new Date(), { locale });
   }
-  return format(createdAt, 'MMM dd');
+  return format(createdAt, 'MMM dd',  { locale });
 };

--- a/src/ui/MessageSearchItem/index.tsx
+++ b/src/ui/MessageSearchItem/index.tsx
@@ -23,7 +23,7 @@ export default function MessageSearchItem({
   const messageText = message.message;
   const sender = message.sender || message._sender;
   const { profileUrl, nickname } = sender;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
 
   return (
     <div
@@ -66,7 +66,7 @@ export default function MessageSearchItem({
           type={LabelTypography.CAPTION_3}
           color={LabelColors.ONBACKGROUND_2}
         >
-          {getCreatedAt(createdAt)}
+          {getCreatedAt(createdAt, dateLocale)}
         </Label>
       </div>
       <div className="sendbird-message-search-item__right-footer" />

--- a/src/ui/MessageStatus/index.jsx
+++ b/src/ui/MessageStatus/index.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+
+import format from 'date-fns/format';
 
 import './index.scss';
 import Icon, { IconTypes, IconColors } from '../Icon';
@@ -7,10 +9,10 @@ import Label, { LabelColors, LabelTypography } from '../Label';
 import Loader from '../Loader';
 
 import {
-  getMessageCreatedAt,
   getOutgoingMessageStates,
   isSentStatus,
 } from '../../utils';
+import { LocalizationContext } from '../../lib/LocalizationContext';
 
 export const MessageStatusTypes = getOutgoingMessageStates();
 export default function MessageStatus({
@@ -19,6 +21,7 @@ export default function MessageStatus({
   channel,
   status,
 }) {
+  const { dateLocale } = useContext(LocalizationContext);
   const showMessageStatusIcon = channel?.isGroupChannel()
     && !channel?.isSuper
     && !channel?.isPublic
@@ -73,7 +76,7 @@ export default function MessageStatus({
           type={LabelTypography.CAPTION_3}
           color={LabelColors.ONBACKGROUND_2}
         >
-          {getMessageCreatedAt(message)}
+          {format(message?.createdAt, 'p', dateLocale)}
         </Label>
       )}
     </div>

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -49,7 +49,7 @@ export default function OpenchannelFileMessage({
 }: Props): JSX.Element {
   const contextMenuRef = useRef(null);
   const avatarRef = useRef(null);
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
 
   const openFileUrl = () => { window.open(message.url); };
@@ -135,11 +135,7 @@ export default function OpenchannelFileMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_3}
               >
-                {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
-                  )
-                }
+                {format(message.createdAt, 'p', { locale: dateLocale })}
               </Label>
             </div>
           )

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -61,7 +61,7 @@ export default function OpenchannelOGMessage({
   const { ogMetaData } = message;
   const { defaultImage } = ogMetaData;
 
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const [contextStyle, setContextStyle] = useState({});
   const messageComponentRef = useRef(null);
@@ -218,11 +218,7 @@ export default function OpenchannelOGMessage({
                   type={LabelTypography.CAPTION_3}
                   color={LabelColors.ONBACKGROUND_3}
                 >
-                  {
-                    message.createdAt && (
-                      format(message.createdAt, 'p')
-                    )
-                  }
+                  {format(message.createdAt, 'p', { locale: dateLocale })}
                 </Label>
               </div>
             )

--- a/src/ui/OpenchannelThumbnailMessage/index.tsx
+++ b/src/ui/OpenchannelThumbnailMessage/index.tsx
@@ -62,7 +62,7 @@ export default function OpenchannelThumbnailMessage({
     thumbnails,
   } = message;
   const thumbnailUrl = (thumbnails && thumbnails.length > 0 && thumbnails[0].url) || null;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const [messageWidth, setMessageWidth] = useState(360);
   const messageRef = useRef(null);
@@ -168,11 +168,7 @@ export default function OpenchannelThumbnailMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_3}
               >
-                {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
-                  )
-                }
+                {format(message.createdAt, 'p', { locale: dateLocale })}
               </Label>
             </div>
           )

--- a/src/ui/OpenchannelUserMessage/index.tsx
+++ b/src/ui/OpenchannelUserMessage/index.tsx
@@ -63,7 +63,7 @@ export default function OpenchannelUserMessage({
   }
 
   // hooks
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const messageRef = useRef(null);
   const avatarRef = useRef(null);
@@ -180,11 +180,7 @@ export default function OpenchannelUserMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_3}
               >
-                {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
-                  )
-                }
+                {format(message.createdAt, 'p', { locale: dateLocale })}
               </Label>
             </div>
           )

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import format from 'date-fns/format';
 import { AdminMessage, Emoji, EmojiCategory, EmojiContainer, FileMessage, GroupChannel, GroupChannelListQuery, Member, MessageListParams, OpenChannel, Reaction, SendBirdInstance, User, UserMessage } from "sendbird";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
@@ -313,7 +312,6 @@ export const getEmojiMapAll = (emojiContainer: EmojiContainer): Map<string, Emoj
 
 export const getUserName = (user: User): string => (user?.friendName || user?.nickname || user?.userId);
 export const getSenderName = (message: UserMessage | FileMessage): string => (message.sender && getUserName(message.sender));
-export const getMessageCreatedAt = (message: UserMessage | FileMessage): string => format(message.createdAt || 0, 'p');
 
 export const hasSameMembers = <T>(a: T[], b: T[]): boolean => {
   if (a === b) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,8 +1,4 @@
-import format from 'date-fns/format';
-
 export const noop = () => {};
-
-export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
 
 export const getSenderName = (message) => (
   message.sender && (
@@ -15,7 +11,6 @@ export const getSenderName = (message) => (
 export const getSenderProfileUrl = (message) => message.sender && message.sender.profileUrl;
 
 export default {
-  getMessageCreatedAt,
   getSenderName,
   getSenderProfileUrl,
 };


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-576](https://sendbird.atlassian.net/browse/UIKIT-576)

Date can be localized using date-fns/locale
Example:

```
import kr from 'date-fns/locale/ko';
import {App} from 'sendbird-uikit';

<App appId="" userId="" dateLocale={kr}/>
```

## Description Of Changes

Add a brief description of the changes that you have involved in this PR

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
