### PR TITLE
Fix: Appear message status icon in safari

### DIFF
--- a/src/svgs/icon-add.svg
+++ b/src/svgs/icon-add.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-arrow-left.svg
+++ b/src/svgs/icon-arrow-left.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-attach.svg
+++ b/src/svgs/icon-attach.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-ban.svg
+++ b/src/svgs/icon-ban.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-broadcast.svg
+++ b/src/svgs/icon-broadcast.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-camera.svg
+++ b/src/svgs/icon-camera.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-channels.svg
+++ b/src/svgs/icon-channels.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-chat-filled.svg
+++ b/src/svgs/icon-chat-filled.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-chat.svg
+++ b/src/svgs/icon-chat.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-chevron-down.svg
+++ b/src/svgs/icon-chevron-down.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-chevron-right.svg
+++ b/src/svgs/icon-chevron-right.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-close.svg
+++ b/src/svgs/icon-close.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-collapse.svg
+++ b/src/svgs/icon-collapse.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-copy.svg
+++ b/src/svgs/icon-copy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-create.svg
+++ b/src/svgs/icon-create.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-delete.svg
+++ b/src/svgs/icon-delete.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-disconnected.svg
+++ b/src/svgs/icon-disconnected.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-document.svg
+++ b/src/svgs/icon-document.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-done-all.svg
+++ b/src/svgs/icon-done-all.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-done.svg
+++ b/src/svgs/icon-done.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-download.svg
+++ b/src/svgs/icon-download.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-emoji-more.svg
+++ b/src/svgs/icon-emoji-more.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-error.svg
+++ b/src/svgs/icon-error.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-expand.svg
+++ b/src/svgs/icon-expand.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-file-audio.svg
+++ b/src/svgs/icon-file-audio.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-file-document.svg
+++ b/src/svgs/icon-file-document.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-freeze.svg
+++ b/src/svgs/icon-freeze.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-gif.svg
+++ b/src/svgs/icon-gif.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-info.svg
+++ b/src/svgs/icon-info.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-leave.svg
+++ b/src/svgs/icon-leave.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-members.svg
+++ b/src/svgs/icon-members.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-message.svg
+++ b/src/svgs/icon-message.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-moderations.svg
+++ b/src/svgs/icon-moderations.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-more.svg
+++ b/src/svgs/icon-more.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-mute.svg
+++ b/src/svgs/icon-mute.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-notifications-off-filled.svg
+++ b/src/svgs/icon-notifications-off-filled.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-notifications.svg
+++ b/src/svgs/icon-notifications.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-operator.svg
+++ b/src/svgs/icon-operator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-photo.svg
+++ b/src/svgs/icon-photo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-play.svg
+++ b/src/svgs/icon-play.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-plus.svg
+++ b/src/svgs/icon-plus.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-question.svg
+++ b/src/svgs/icon-question.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-refresh.svg
+++ b/src/svgs/icon-refresh.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-remove.svg
+++ b/src/svgs/icon-remove.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-search.svg
+++ b/src/svgs/icon-search.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-send.svg
+++ b/src/svgs/icon-send.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-settings-filled.svg
+++ b/src/svgs/icon-settings-filled.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-spinner.svg
+++ b/src/svgs/icon-spinner.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-supergroup.svg
+++ b/src/svgs/icon-supergroup.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-thumbnail-none.svg
+++ b/src/svgs/icon-thumbnail-none.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/svgs/icon-user.svg
+++ b/src/svgs/icon-user.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 100%; width: 100%;">
     <g fill="none" fill-rule="evenodd">
         <g fill="#000">
             <g>

--- a/src/ui/MessageStatus/index.jsx
+++ b/src/ui/MessageStatus/index.jsx
@@ -44,30 +44,28 @@ export default function MessageStatus({
       ].join(' ')}
     >
       {(showMessageStatusIcon) && (
-        <div>
-          {(status === MessageStatusTypes.PENDING) ? (
-            <Loader
-              className="sendbird-message-status__icon"
-              width="16px"
-              height="16px"
-            >
-              <Icon
-                type={IconTypes.SPINNER}
-                fillColor={IconColors.PRIMARY}
-                width="16px"
-                height="16px"
-              />
-            </Loader>
-          ) : (
+        (status === MessageStatusTypes.PENDING) ? (
+          <Loader
+            className="sendbird-message-status__icon"
+            width="16px"
+            height="16px"
+          >
             <Icon
-              className="sendbird-message-status__icon"
-              type={iconType[status] || IconTypes.ERROR}
-              fillColor={iconColor[status]}
+              type={IconTypes.SPINNER}
+              fillColor={IconColors.PRIMARY}
               width="16px"
               height="16px"
             />
-          )}
-        </div>
+          </Loader>
+        ) : (
+          <Icon
+            className="sendbird-message-status__icon"
+            type={iconType[status] || IconTypes.ERROR}
+            fillColor={iconColor[status]}
+            width="16px"
+            height="16px"
+          />
+        )
       )}
       {isSentStatus(status) && (
         <Label

--- a/src/ui/MessageStatus/index.scss
+++ b/src/ui/MessageStatus/index.scss
@@ -15,7 +15,7 @@
   .sendbird-message-status__text {
     position: relative;
     display: inline-flex;
-    margin-top: 4px;
+    margin-top: 2px;
     margin-left: 4px;
 
     .sendbird-message-status__text__try-again {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-1490](https://sendbird.atlassian.net/browse/UIKIT-1490)

## Description Of Changes

* Set height and width value of every SVG icon
* Remove meanless div tag from message status component
* Reduce margin-top of message status text

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
