### PR TITLE
fix: localization parameter for some format calls

### DIFF
--- a/src/legacy/message-refactor/FileMessage/index.jsx
+++ b/src/legacy/message-refactor/FileMessage/index.jsx
@@ -562,7 +562,7 @@ export function IncomingFileMessage({
                 type={LabelTypography.CAPTION_3}
                 color={LabelColors.ONBACKGROUND_2}
               >
-                {format(message?.createdAt, 'p', dateLocale)}
+                {format(message?.createdAt, 'p', { locale: dateLocale })}
               </Label>
             )
           }

--- a/src/ui/MessageStatus/index.jsx
+++ b/src/ui/MessageStatus/index.jsx
@@ -76,7 +76,7 @@ export default function MessageStatus({
           type={LabelTypography.CAPTION_3}
           color={LabelColors.ONBACKGROUND_2}
         >
-          {format(message?.createdAt, 'p', dateLocale)}
+          {format(message?.createdAt, 'p', { locale: dateLocale })}
         </Label>
       )}
     </div>


### PR DESCRIPTION
localization parameter was not passed correctly to some
date-fn calls. Which caused some strings to be still in English

Refs:
* https://sendbird.atlassian.net/browse/UIKIT-1536
* https://sendbird.atlassian.net/browse/SBISSUE-7849
