### PR TITLE
Fix: [v2] Exclude the optional param when locale is undefined in the dateFns utils

### DIFF
--- a/src/ui/ChannelPreview/utils.js
+++ b/src/ui/ChannelPreview/utils.js
@@ -26,16 +26,17 @@ export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelSt
 
 export const getLastMessageCreatedAt = (channel, locale) => {
   const createdAt = channel?.lastMessage?.createdAt;
+  const optionalParam = locale ? { locale } : null;
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p', { locale });
+    return format(createdAt, 'p', optionalParam);
   }
   if (isYesterday(createdAt)) {
-    return formatRelative(createdAt, new Date(), { locale });
+    return formatRelative(createdAt, new Date(), optionalParam);
   }
-  return format(createdAt, 'MMM dd', { locale });
+  return format(createdAt, 'MMM dd', optionalParam);
 };
 
 export const getTotalMembers = (channel) => (

--- a/src/ui/MessageSearchFileItem/utils.ts
+++ b/src/ui/MessageSearchFileItem/utils.ts
@@ -5,16 +5,17 @@ import isYesterday from 'date-fns/isYesterday';
 import { IconTypes } from '../Icon';
 
 export function getCreatedAt(createdAt: number, locale: Locale): string {
+  const optionalParam = locale ? { locale } : null;
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p', { locale });
+    return format(createdAt, 'p', optionalParam);
   }
   if (isYesterday(createdAt)) {
-    return formatRelative(createdAt, new Date(), { locale });
+    return formatRelative(createdAt, new Date(), optionalParam);
   }
-  return format(createdAt, 'MMM dd', { locale });
+  return format(createdAt, 'MMM dd', optionalParam);
 }
 
 export function getIconOfFileType(message: SendbirdUIKit.ClientFileMessage): string {

--- a/src/ui/MessageSearchItem/getCreatedAt.ts
+++ b/src/ui/MessageSearchItem/getCreatedAt.ts
@@ -5,14 +5,15 @@ import isYesterday from 'date-fns/isYesterday';
 
 // getCreatedAt
 export default (createdAt: number, locale: Locale): string => {
+  const optionalParam = locale ? { locale } : null;
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p',  { locale });
+    return format(createdAt, 'p', optionalParam);
   }
   if (isYesterday(createdAt)) {
-    return formatRelative(createdAt, new Date(), { locale });
+    return formatRelative(createdAt, new Date(), optionalParam);
   }
-  return format(createdAt, 'MMM dd',  { locale });
+  return format(createdAt, 'MMM dd', optionalParam);
 };


### PR DESCRIPTION
## For Internal Contributors

no ticket

## Description Of Changes

* Exclude the optional param when locale is undefined in the dateFns utils

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
