### PR TITLE
Fix: [v2] Appear MessageStatus component in Safari

### DIFF
--- a/src/ui/MessageStatus/index.scss
+++ b/src/ui/MessageStatus/index.scss
@@ -3,19 +3,18 @@
 .sendbird-message-status {
   position: relative;
   display: inline-block;
-  flex-direction: row;
   width: 100%;
   height: 100%;
 
   .sendbird-message-status__icon {
     position: relative;
     display: inline-block;
+    top: 4px;
   }
 
   .sendbird-message-status__text {
     position: relative;
     display: inline-block;
-    margin-top: 2px;
     margin-left: 4px;
 
     .sendbird-message-status__text__try-again {

--- a/src/ui/MessageStatus/index.scss
+++ b/src/ui/MessageStatus/index.scss
@@ -2,19 +2,19 @@
 
 .sendbird-message-status {
   position: relative;
-  display: inline-flex;
+  display: inline-block;
   flex-direction: row;
   width: 100%;
   height: 100%;
 
   .sendbird-message-status__icon {
     position: relative;
-    display: inline-flex;
+    display: inline-block;
   }
 
   .sendbird-message-status__text {
     position: relative;
-    display: inline-flex;
+    display: inline-block;
     margin-top: 2px;
     margin-left: 4px;
 


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-1577](https://sendbird.atlassian.net/browse/UIKIT-1577)

## Description Of Changes

* Fix the issue that inline-flex causes disappearing component in Safari

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
