### PR TITLE
Fix: [v3] Appear MessageStatus in Safari

### DIFF
--- a/src/ui/MessageStatus/__tests__/__snapshots__/MessageStatus.spec.js.snap
+++ b/src/ui/MessageStatus/__tests__/__snapshots__/MessageStatus.spec.js.snap
@@ -4,6 +4,23 @@ exports[`MessageStatus should do a snapshot test of the MessageStatus DOM 1`] = 
 <div
   className="example-text sendbird-message-status"
 >
+  <div
+    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-done sendbird-icon-color--sent"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    style={
+      Object {
+        "height": "16px",
+        "minHeight": "16px",
+        "minWidth": "16px",
+        "width": "16px",
+      }
+    }
+    tabIndex="0"
+  >
+    <test-file-stub />
+  </div>
   <span
     className="sendbird-message-status__text sendbird-label sendbird-label--caption-3 sendbird-label--color-onbackground-2"
   >
@@ -15,11 +32,47 @@ exports[`MessageStatus should do a snapshot test of the MessageStatus DOM 1`] = 
 exports[`MessageStatus should do a snapshot test of the failed MessageStatus DOM when isResendable: false 1`] = `
 <div
   className="example-text sendbird-message-status"
-/>
+>
+  <div
+    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-error sendbird-icon-color--error"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    style={
+      Object {
+        "height": "16px",
+        "minHeight": "16px",
+        "minWidth": "16px",
+        "width": "16px",
+      }
+    }
+    tabIndex="0"
+  >
+    <test-file-stub />
+  </div>
+</div>
 `;
 
 exports[`MessageStatus should do a snapshot test of the failed MessageStatus DOM when isResendable: true 1`] = `
 <div
   className="example-text sendbird-message-status"
-/>
+>
+  <div
+    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-error sendbird-icon-color--error"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    style={
+      Object {
+        "height": "16px",
+        "minHeight": "16px",
+        "minWidth": "16px",
+        "width": "16px",
+      }
+    }
+    tabIndex="0"
+  >
+    <test-file-stub />
+  </div>
+</div>
 `;

--- a/src/ui/MessageStatus/index.jsx
+++ b/src/ui/MessageStatus/index.jsx
@@ -43,31 +43,27 @@ export default function MessageStatus({
         'sendbird-message-status',
       ].join(' ')}
     >
-      {(showMessageStatusIcon) && (
-        <div>
-          {(status === MessageStatusTypes.PENDING) ? (
-            <Loader
-              className="sendbird-message-status__icon"
-              width="16px"
-              height="16px"
-            >
-              <Icon
-                type={IconTypes.SPINNER}
-                fillColor={IconColors.PRIMARY}
-                width="16px"
-                height="16px"
-              />
-            </Loader>
-          ) : (
-            <Icon
-              className="sendbird-message-status__icon"
-              type={iconType[status] || IconTypes.ERROR}
-              fillColor={iconColor[status]}
-              width="16px"
-              height="16px"
-            />
-          )}
-        </div>
+      {(status === MessageStatusTypes.PENDING) ? (
+        <Loader
+          className={`sendbird-message-status__icon ${showMessageStatusIcon ? '' : 'hide-icon'}`}
+          width="16px"
+          height="16px"
+        >
+          <Icon
+            type={IconTypes.SPINNER}
+            fillColor={IconColors.PRIMARY}
+            width="16px"
+            height="16px"
+          />
+        </Loader>
+      ) : (
+        <Icon
+          className={`sendbird-message-status__icon ${showMessageStatusIcon ? '' : 'hide-icon'}`}
+          type={iconType[status] || IconTypes.ERROR}
+          fillColor={iconColor[status]}
+          width="16px"
+          height="16px"
+        />
       )}
       {isSentStatus(status) && (
         <Label

--- a/src/ui/MessageStatus/index.scss
+++ b/src/ui/MessageStatus/index.scss
@@ -2,20 +2,23 @@
 
 .sendbird-message-status {
   position: relative;
-  display: inline-flex;
-  flex-direction: row;
+  display: inline-block;
   width: 100%;
   height: 100%;
 
   .sendbird-message-status__icon {
     position: relative;
-    display: inline-flex;
+    display: inline-block;
+    top: 4px;
+
+    &.hide-icon {
+      display: none;
+    }
   }
 
   .sendbird-message-status__text {
     position: relative;
-    display: inline-flex;
-    margin-top: 4px;
+    display: inline-block;
     margin-left: 4px;
 
     .sendbird-message-status__text__try-again {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-1577](https://sendbird.atlassian.net/browse/UIKIT-1577)

## Description Of Changes

* Hide message status component using CSS instead of flag

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
