### PR TITLE
Hotfix - donot use exports: 'named'

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,13 +38,11 @@ module.exports = ({
       dir: 'dist/cjs',
       format: 'cjs',
       sourcemap: true,
-      exports: 'named'
     },
     {
       dir: 'dist',
       format: 'esm',
       sourcemap: true,
-      exports: 'named'
     },
   ],
   external: [


### PR DESCRIPTION
This change was added during the rollup script
This is to reduce scope of the change