### PR TITLE
Feature - Setup date localization 

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import Sendbird from 'sendbird';
+import type { Locale } from 'date-fns';
 
 import AppProps from './smart-components/App/types';
 import * as SendbirdTypes from './types';
@@ -348,6 +349,7 @@ interface SendBirdProviderProps {
   theme?: 'light' | 'dark';
   nickname?: string;
   profileUrl?: string;
+  dateLocale?: Locale;
   disableUserProfile?: boolean;
   renderUserProfile?: (props: SendbirdTypes.RenderUserProfileProps) => React.ReactNode;
   allowProfileEdit?: boolean;

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -24,6 +24,11 @@ const LocalizationProvider = (props: LocalizationProviderProps): React.ReactNode
   );
 };
 
-const useLocalization = () => React.useContext(LocalizationContext);
+export type UseLocalizationType = () => {
+  stringSet: Record<string, string>;
+  dateLocale: globalThis.Locale;
+};
+
+const useLocalization: UseLocalizationType = () => React.useContext(LocalizationContext);
 
 export { LocalizationContext, LocalizationProvider, useLocalization };

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 
 import getStringSet from '../ui/Label/stringSet';
+import type { Locale } from 'date-fns';
+import en from 'date-fns/locale/en-US';
 
 const LocalizationContext = React.createContext({
   stringSet: getStringSet('en'),
+  dateLocale: en,
 });
 
 interface LocalizationProviderProps {
   stringSet: Record<string, string>;
+  dateLocale: Locale;
   children: React.Component;
 }
 
@@ -20,4 +24,6 @@ const LocalizationProvider = (props: LocalizationProviderProps): React.ReactNode
   );
 };
 
-export { LocalizationContext, LocalizationProvider };
+const useLocalization = () => React.useContext(LocalizationContext);
+
+export { LocalizationContext, LocalizationProvider, useLocalization };

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -25,6 +25,7 @@ import getStringSet from '../ui/Label/stringSet';
 export default function Sendbird(props) {
   const {
     userId,
+    dateLocale,
     appId,
     accessToken,
     children,
@@ -169,7 +170,7 @@ export default function Sendbird(props) {
         },
       }}
     >
-      <LocalizationProvider stringSet={localeStringSet}>
+      <LocalizationProvider stringSet={localeStringSet} dateLocale={dateLocale}>
         {children}
       </LocalizationProvider>
     </SendbirdSdkContext.Provider>
@@ -187,6 +188,7 @@ Sendbird.propTypes = {
   ]).isRequired,
   theme: PropTypes.string,
   nickname: PropTypes.string,
+  dateLocale: PropTypes.shape({}),
   profileUrl: PropTypes.string,
   disableUserProfile: PropTypes.bool,
   renderUserProfile: PropTypes.func,
@@ -223,6 +225,7 @@ Sendbird.defaultProps = {
   accessToken: '',
   theme: 'light',
   nickname: '',
+  dateLocale: null,
   profileUrl: '',
   disableUserProfile: false,
   renderUserProfile: null,

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -24,6 +24,7 @@ export default function App(props) {
     userListQuery,
     nickname,
     profileUrl,
+    dateLocale,
     config = {},
     useReaction,
     replyType,
@@ -53,6 +54,7 @@ export default function App(props) {
       theme={theme}
       nickname={nickname}
       profileUrl={profileUrl}
+      dateLocale={dateLocale}
       userListQuery={userListQuery}
       config={config}
       colorSet={colorSet}
@@ -152,6 +154,7 @@ App.propTypes = {
   disableUserProfile: PropTypes.bool,
   renderUserProfile: PropTypes.func,
   onProfileEditSuccess: PropTypes.func,
+  dateLocale: PropTypes.shape({}),
   config: PropTypes.shape({
     // None Error Warning Info 'All/Debug'
     logLevel: PropTypes.oneOfType([
@@ -185,6 +188,7 @@ App.defaultProps = {
   nickname: '',
   profileUrl: '',
   userListQuery: null,
+  dateLocale: null,
   allowProfileEdit: false,
   onProfileEditSuccess: null,
   disableUserProfile: false,

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import kr from 'date-fns/locale/ko';
 
 import pkg from '../../../../package-lock.json'
 
@@ -190,6 +191,7 @@ export const Korean = () => fitPageSize(
     userId={array[0]}
     nickname={array[0]}
     showSearchIcon
+    dateLocale={kr}
     stringSet={{
       CHANNEL_LIST__TITLE: '채널 목록',
       CHANNEL__MESSAGE_INPUT__PLACE_HOLDER: '메시지 보내기',

--- a/src/smart-components/App/types.tsx
+++ b/src/smart-components/App/types.tsx
@@ -1,4 +1,6 @@
 import SendBird from "sendbird";
+import type { Locale } from "date-fns";
+
 import {
   ReplyType,
   UserListQuery,
@@ -14,6 +16,7 @@ export default interface AppProps {
   userListQuery?(): UserListQuery;
   nickname?: string;
   profileUrl?: string;
+  dateLocale?: Locale;
   allowProfileEdit?: boolean;
   disableUserProfile?: boolean;
   showSearchIcon?: boolean;

--- a/src/smart-components/Channel/components/ChannelHeader/utils.ts
+++ b/src/smart-components/Channel/components/ChannelHeader/utils.ts
@@ -1,8 +1,5 @@
-import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
 import SendBird from 'sendbird';
 import { LabelStringSet } from '../../../../ui/Label';
-
-export const prettyDate = (date: Date): string => formatDistanceToNowStrict(date, { addSuffix: true });
 
 export const getChannelTitle = (
   channel: SendBird.GroupChannel,

--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -18,6 +18,7 @@ import MessageContent from '../../../../ui/MessageContent';
 import FileViewer from '../FileViewer';
 import RemoveMessageModal from '../RemoveMessageModal';
 import { EveryMessage, RenderMessageProps } from '../../../../types';
+import { useLocalization } from '../../../../lib/LocalizationContext';
 
 type MessageUIProps = {
   message: EveryMessage;
@@ -45,6 +46,7 @@ const Message: React.FC<MessageUIProps> = (props: MessageUIProps) => {
     renderMessageContent,
   } = props;
 
+  const { dateLocale } = useLocalization();
   const globalStore = useSendbirdStateContext();
   const userId = globalStore?.config?.userId;
   const isOnline = globalStore?.config?.isOnline;
@@ -133,7 +135,9 @@ const Message: React.FC<MessageUIProps> = (props: MessageUIProps) => {
           hasSeparator && renderCustomSeperator?.() || (
             <DateSeparator>
               <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-                {format(message.createdAt, 'MMMM dd, yyyy')}
+                {format(message.createdAt, 'MMMM dd, yyyy', {
+                  locale: dateLocale,
+                })}
               </Label>
             </DateSeparator>
           )
@@ -172,7 +176,9 @@ const Message: React.FC<MessageUIProps> = (props: MessageUIProps) => {
         hasSeparator && (renderCustomSeperator?.() || (
           <DateSeparator>
             <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-              {format(message.createdAt, 'MMMM dd, yyyy')}
+              {format(message.createdAt, 'MMMM dd, yyyy', {
+                locale: dateLocale,
+              })}
             </Label>
           </DateSeparator>
         ))

--- a/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import SendBird from 'sendbird';
 
 import './channel-preview.scss';

--- a/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
@@ -11,7 +11,7 @@ import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import * as utils from './utils';
 
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-import { LocalizationContext } from '../../../../lib/LocalizationContext';
+import { useLocalization } from '../../../../lib/LocalizationContext';
 
 interface ChannelPreviewInterface {
   channel: SendBird.GroupChannel;
@@ -29,10 +29,10 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
   tabIndex,
 }: ChannelPreviewInterface) => {
   const sbState = useSendbirdStateContext();
+  const { dateLocale, stringSet } = useLocalization();
   const userId = sbState?.stores?.userStore?.user?.userId;
   const theme = sbState?.config?.theme;
   const { isBroadcast, isFrozen } = channel;
-  const { stringSet } = useContext(LocalizationContext);
   return (
     <div
       className={[
@@ -102,7 +102,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
             type={LabelTypography.CAPTION_3}
             color={LabelColors.ONBACKGROUND_2}
           >
-            {utils.getLastMessageCreatedAt(channel)}
+            {utils.getLastMessageCreatedAt(channel, dateLocale)}
           </Label>
         </div>
         <div className="sendbird-channel-preview__content__lower">

--- a/src/smart-components/ChannelList/components/ChannelPreview/utils.js
+++ b/src/smart-components/ChannelList/components/ChannelPreview/utils.js
@@ -1,5 +1,6 @@
 import isToday from 'date-fns/isToday';
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isYesterday from 'date-fns/isYesterday';
 
 import { truncateString } from '../../../../utils';
@@ -22,20 +23,18 @@ export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelSt
     .join(', ');
 };
 
-export const getLastMessageCreatedAt = (channel) => {
-  if (!channel || !channel.lastMessage) {
+export const getLastMessageCreatedAt = (channel, locale) => {
+  const createdAt = channel?.lastMessage?.createdAt;
+  if (!createdAt) {
     return '';
   }
-  const date = channel.lastMessage.createdAt;
-  if (isToday(date)) {
-    return format(date, 'p');
+  if (isToday(createdAt)) {
+    return format(createdAt, 'p', { locale });
   }
-
-  if (isYesterday(date)) {
-    return 'Yesterday';
+  if (isYesterday(createdAt)) {
+    return formatRelative(createdAt, new Date(), { locale });
   }
-
-  return format(date, 'MMM dd');
+  return format(createdAt, 'MMM dd', { locale });
 };
 
 export const getTotalMembers = (channel) => (

--- a/src/smart-components/OpenChannel/components/OpenChannelMessage/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelMessage/index.tsx
@@ -28,6 +28,7 @@ import {
 import { useOpenChannel } from '../../context/OpenChannelProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import type { EveryMessage, RenderMessageProps } from '../../../../types';
+import { useLocalization } from '../../../../lib/LocalizationContext';
 
 export type OpenChannelMessageProps = {
   renderMessage?: (props: RenderMessageProps) => React.ReactNode;
@@ -53,6 +54,7 @@ export default function MessagOpenChannelMessageeHoc(props: OpenChannelMessagePr
     updateMessage,
     resendMessage,
   } = useOpenChannel();
+  const { dateLocale } = useLocalization();
   const editDisabled = currentOpenChannel?.isFrozen;
 
   const globalState = useSendbirdStateContext();
@@ -117,7 +119,9 @@ export default function MessagOpenChannelMessageeHoc(props: OpenChannelMessagePr
         hasSeparator && (
           <DateSeparator>
             <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-              {format(message?.createdAt, 'MMMM dd, yyyy')}
+              {format(message?.createdAt, 'MMMM dd, yyyy', {
+                locale: dateLocale,
+              })}
             </Label>
           </DateSeparator>
         )

--- a/src/ui/ChannelPreview/index.jsx
+++ b/src/ui/ChannelPreview/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import './index.scss';
@@ -7,7 +7,7 @@ import ChannelAvatar from '../ChannelAvatar/index';
 import Badge from '../Badge';
 import Icon, { IconColors, IconTypes } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../Label';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 
 import * as utils from './utils';
 
@@ -25,7 +25,7 @@ export default function ChannelPreview({
     userId,
   } = currentUser;
   const { isBroadcast, isFrozen } = channel;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, locale } = useLocalization();
   return (
     <div
       className={[
@@ -95,7 +95,7 @@ export default function ChannelPreview({
             type={LabelTypography.CAPTION_3}
             color={LabelColors.ONBACKGROUND_2}
           >
-            {utils.getLastMessageCreatedAt(channel)}
+            {utils.getLastMessageCreatedAt(channel, locale)}
           </Label>
         </div>
         <div className="sendbird-channel-preview__content__lower">

--- a/src/ui/ChannelPreview/utils.js
+++ b/src/ui/ChannelPreview/utils.js
@@ -1,5 +1,6 @@
 import isToday from 'date-fns/isToday';
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isYesterday from 'date-fns/isYesterday';
 
 import { truncateString } from '../../utils';
@@ -22,20 +23,18 @@ export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelSt
     .join(', ');
 };
 
-export const getLastMessageCreatedAt = (channel) => {
-  if (!channel || !channel.lastMessage) {
+export const getLastMessageCreatedAt = (channel, locale) => {
+  const createdAt = channel?.lastMessage?.createdAt;
+  if (!createdAt) {
     return '';
   }
-  const date = channel.lastMessage.createdAt;
-  if (isToday(date)) {
-    return format(date, 'p');
+  if (isToday(createdAt)) {
+    return format(createdAt, 'p', { locale });
   }
-
-  if (isYesterday(date)) {
-    return 'Yesterday';
+  if (isYesterday(createdAt)) {
+    return formatRelative(createdAt, new Date(), { locale });
   }
-
-  return format(date, 'MMM dd');
+  return format(createdAt, 'MMM dd', { locale });
 };
 
 export const getTotalMembers = (channel) => (

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useContext, useRef, useState } from 'react';
 import { GroupChannel, UserMessage, FileMessage, EmojiContainer } from 'sendbird';
+import format from 'date-fns/format';
 import './index.scss';
 
 import Avatar from '../Avatar';
@@ -27,11 +28,11 @@ import {
   isOGMessage,
   isThumbnailMessage,
   getSenderName,
-  getMessageCreatedAt,
   CoreMessageType,
 } from '../../utils';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 import { ReplyType } from '../../index.js';
+import { useLocalization } from '../../lib/LocalizationContext';
 
 interface Props {
   className?: string | Array<string>;
@@ -74,6 +75,7 @@ export default function MessageContent({
   setQuoteMessage,
 }: Props): ReactElement {
   const messageTypes = getUIKitMessageTypes();
+  const { dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const avatarRef = useRef(null);
   const [mouseHover, setMouseHover] = useState(false);
@@ -271,7 +273,9 @@ export default function MessageContent({
               type={LabelTypography.CAPTION_3}
               color={LabelColors.ONBACKGROUND_2}
             >
-              {getMessageCreatedAt(message)}
+              {format(message?.createdAt || 0, 'p', {
+                locale: dateLocale,
+              })}
             </Label>
           )}
         </div>

--- a/src/ui/MessageSearchFileItem/index.tsx
+++ b/src/ui/MessageSearchFileItem/index.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import './index.scss';
 
 import Avatar from '../Avatar';
 import Icon, { IconColors } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../Label';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 import { getCreatedAt, getIconOfFileType, truncate } from './utils';
 
 interface Props {
@@ -25,7 +25,7 @@ export default function MessageSearchFileItem(props: Props): ReactElement {
   const fileMessageUrl = url;
   const sender = message.sender || message._sender;
   const { profileUrl, nickname } = sender;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useLocalization();
 
   return (
     <div
@@ -79,7 +79,7 @@ export default function MessageSearchFileItem(props: Props): ReactElement {
         type={LabelTypography.CAPTION_3}
         color={LabelColors.ONBACKGROUND_2}
       >
-        {getCreatedAt(createdAt)}
+        {getCreatedAt(createdAt, dateLocale)}
       </Label>
       <div className="sendbird-message-search-file-item__right-footer" />
     </div>

--- a/src/ui/MessageSearchFileItem/utils.ts
+++ b/src/ui/MessageSearchFileItem/utils.ts
@@ -1,19 +1,21 @@
+import type { Locale } from 'date-fns';
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isToday from 'date-fns/isToday';
 import isYesterday from 'date-fns/isYesterday';
 import { IconTypes } from '../Icon';
 
-export function getCreatedAt(createdAt: number): string {
+export function getCreatedAt(createdAt: number, locale: Locale): string {
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p');
+    return format(createdAt, 'p', { locale });
   }
   if (isYesterday(createdAt)) {
-    return 'Yesterday';
+    return formatRelative(createdAt, new Date(), { locale });
   }
-  return format(createdAt, 'MMM dd');
+  return format(createdAt, 'MMM dd', { locale });
 }
 
 export function getIconOfFileType(message: SendbirdUIKit.ClientFileMessage): string {

--- a/src/ui/MessageSearchItem/getCreatedAt.ts
+++ b/src/ui/MessageSearchItem/getCreatedAt.ts
@@ -1,17 +1,19 @@
+import type { Locale } from 'date-fns';
 import format from 'date-fns/format';
+import formatRelative from 'date-fns/formatRelative';
 import isToday from 'date-fns/isToday';
 import isYesterday from 'date-fns/isYesterday';
 
 // getCreatedAt
-export default (createdAt: number): string => {
+export default function (createdAt: number, locale: Locale): string {
   if (!createdAt) {
     return '';
   }
   if (isToday(createdAt)) {
-    return format(createdAt, 'p');
+    return format(createdAt, 'p', { locale });
   }
   if (isYesterday(createdAt)) {
-    return 'Yesterday';
+    return formatRelative(createdAt, new Date(), { locale });
   }
-  return format(createdAt, 'MMM dd');
-};
+  return format(createdAt, 'MMM dd', { locale });
+}

--- a/src/ui/MessageSearchItem/index.tsx
+++ b/src/ui/MessageSearchItem/index.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import './index.scss';
 import getCreatedAt from './getCreatedAt';
 
 import Avatar from '../Avatar';
 import Label, { LabelTypography, LabelColors } from '../Label';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 
 interface Props {
   className?: string | Array<string>;
@@ -23,7 +23,7 @@ export default function MessageSearchItem({
   const messageText = message.message;
   const sender = message.sender || message._sender;
   const { profileUrl, nickname } = sender;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useLocalization();
 
   return (
     <div
@@ -66,7 +66,7 @@ export default function MessageSearchItem({
           type={LabelTypography.CAPTION_3}
           color={LabelColors.ONBACKGROUND_2}
         >
-          {getCreatedAt(createdAt)}
+          {getCreatedAt(createdAt, dateLocale)}
         </Label>
       </div>
       <div className="sendbird-message-search-item__right-footer" />

--- a/src/ui/MessageStatus/index.tsx
+++ b/src/ui/MessageStatus/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import format from 'date-fns/format';
 import './index.scss';
 
 import Icon, { IconTypes, IconColors } from '../Icon';
@@ -6,12 +7,12 @@ import Label, { LabelColors, LabelTypography } from '../Label';
 import Loader from '../Loader';
 
 import {
-  getMessageCreatedAt,
   getOutgoingMessageState,
   getOutgoingMessageStates,
   isSentStatus,
 } from '../../utils';
 import { FileMessage, GroupChannel, UserMessage } from 'sendbird';
+import { useLocalization } from '../../lib/LocalizationContext';
 
 export const MessageStatusTypes = getOutgoingMessageStates();
 
@@ -26,6 +27,7 @@ export default function MessageStatus({
   message,
   channel,
 }: MessageStatusProps): React.ReactElement {
+  const { dateLocale } = useLocalization();
   const status = useMemo(() => (
     getOutgoingMessageState(channel, message)
   ), [channel?.getUnreadMemberCount?.(message), channel?.getUndeliveredMemberCount?.(message)]);
@@ -81,7 +83,9 @@ export default function MessageStatus({
           type={LabelTypography.CAPTION_3}
           color={LabelColors.ONBACKGROUND_2}
         >
-          {getMessageCreatedAt(message)}
+          {format(message?.createdAt || 0, 'p', {
+            locale: dateLocale,
+          })}
         </Label>
       )}
     </div>

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -12,7 +12,7 @@ import TextButton from '../TextButton';
 import UserProfile from '../UserProfile';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { LocalizationContext, useLocalization } from '../../lib/LocalizationContext';
 import { checkFileType, truncate } from './utils';
 import { ClientFileMessage } from '../../index';
 import {
@@ -46,9 +46,9 @@ export default function OpenchannelFileMessage({
   resendMessage,
 }: Props): JSX.Element {
   const status = message?.sendingStatus;
+  const { dateLocale, stringSet } = useLocalization();
   const contextMenuRef = useRef(null);
   const avatarRef = useRef(null);
-  const { stringSet } = useContext(LocalizationContext);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
 
   const openFileUrl = () => { window.open(message.url); };
@@ -135,8 +135,10 @@ export default function OpenchannelFileMessage({
                 color={LabelColors.ONBACKGROUND_3}
               >
                 {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
+                  message?.createdAt && (
+                    format(message.createdAt, 'p', {
+                      locale: dateLocale,
+                    })
                   )
                 }
               </Label>

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -12,7 +12,7 @@ import TextButton from '../TextButton';
 import UserProfile from '../UserProfile';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 
-import { LocalizationContext, useLocalization } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 import { checkFileType, truncate } from './utils';
 import { ClientFileMessage } from '../../index';
 import {

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -15,7 +15,7 @@ import { UserProfileContext } from '../../lib/UserProfileContext';
 
 import uuidv4 from '../../utils/uuid';
 import { copyToClipboard } from '../OpenchannelUserMessage/utils';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 import { checkOGIsEnalbed, createUrlTester, URL_REG } from './utils';
 import { ClientUserMessage } from '../../index';
 import {
@@ -60,7 +60,7 @@ export default function OpenchannelOGMessage({
   const { ogMetaData } = message;
   const { defaultImage } = ogMetaData;
 
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const [contextStyle, setContextStyle] = useState({});
   const messageComponentRef = useRef(null);
@@ -218,8 +218,10 @@ export default function OpenchannelOGMessage({
                   color={LabelColors.ONBACKGROUND_3}
                 >
                   {
-                    message.createdAt && (
-                      format(message.createdAt, 'p')
+                    message?.createdAt && (
+                      format(message?.createdAt, 'p', {
+                        locale: dateLocale,
+                      })
                     )
                   }
                 </Label>

--- a/src/ui/OpenchannelThumbnailMessage/index.tsx
+++ b/src/ui/OpenchannelThumbnailMessage/index.tsx
@@ -9,7 +9,7 @@ import format from 'date-fns/format';
 import './index.scss';
 import { SUPPORTING_TYPES, getSupportingFileType } from './utils';
 import { ClientFileMessage } from '../../index';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 
 import Avatar from '../Avatar';
 import ContextMenu, { MenuItems, MenuItem } from '../ContextMenu';
@@ -61,7 +61,7 @@ export default function OpenchannelThumbnailMessage({
   } = message;
   const status = message?.sendingStatus;
   const thumbnailUrl = (thumbnails && thumbnails.length > 0 && thumbnails[0].url) || null;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const [messageWidth, setMessageWidth] = useState(360);
   const messageRef = useRef(null);
@@ -168,8 +168,10 @@ export default function OpenchannelThumbnailMessage({
                 color={LabelColors.ONBACKGROUND_3}
               >
                 {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
+                  message?.createdAt && (
+                    format(message.createdAt, 'p', {
+                      locale: dateLocale,
+                    })
                   )
                 }
               </Label>

--- a/src/ui/OpenchannelUserMessage/index.tsx
+++ b/src/ui/OpenchannelUserMessage/index.tsx
@@ -18,7 +18,7 @@ import Loader from '../Loader';
 import UserProfile from '../UserProfile';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 import { copyToClipboard } from './utils';
 import uuidv4 from '../../utils/uuid';
 import { ClientUserMessage } from '../../index';
@@ -61,7 +61,7 @@ export default function OpenchannelUserMessage({
   }
 
   // hooks
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
   const messageRef = useRef(null);
   const avatarRef = useRef(null);
@@ -180,8 +180,10 @@ export default function OpenchannelUserMessage({
                 color={LabelColors.ONBACKGROUND_3}
               >
                 {
-                  message.createdAt && (
-                    format(message.createdAt, 'p')
+                  message?.createdAt && (
+                    format(message?.createdAt, 'p', {
+                      locale: dateLocale,
+                    })
                   )
                 }
               </Label>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import format from 'date-fns/format';
 import SendBird, { AdminMessage, Emoji, EmojiCategory, EmojiContainer, FileMessage, GroupChannel, GroupChannelListQuery, Member, MessageListParams, OpenChannel, Reaction, SendBirdInstance, User, UserMessage } from "sendbird";
 import { EveryMessage } from '../types';
 
@@ -306,7 +305,6 @@ export const getEmojiMapAll = (emojiContainer: EmojiContainer): Map<string, Emoj
 
 export const getUserName = (user: User): string => (user?.friendName || user?.nickname || user?.userId);
 export const getSenderName = (message: UserMessage | FileMessage): string => (message.sender && getUserName(message.sender));
-export const getMessageCreatedAt = (message: UserMessage | FileMessage): string => format(message.createdAt || 0, 'p');
 
 export const hasSameMembers = <T>(a: T[], b: T[]): boolean => {
   if (a === b) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,8 +1,4 @@
-import format from 'date-fns/format';
-
 export const noop = () => {};
-
-export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
 
 export const getSenderName = (message) => (
   message.sender && (
@@ -15,7 +11,6 @@ export const getSenderName = (message) => (
 export const getSenderProfileUrl = (message) => message.sender && message.sender.profileUrl;
 
 export default {
-  getMessageCreatedAt,
   getSenderName,
   getSenderProfileUrl,
 };


### PR DESCRIPTION
Date can be localized using date-fns/locale
Example:

```
import kr from 'date-fns/locale/ko';
import {App} from 'sendbird-uikit';

<App appId="" userId="" dateLocale={kr}/>
```

[UIKIT-576](https://sendbird.atlassian.net/browse/UIKIT-576)