### PR TITLE
Add typing indicator and message status into the channel preview

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -362,6 +362,7 @@ interface ChannelListHeaderInterface {
 interface ChannelPreviewInterface {
   channel: SendBird.GroupChannel;
   isActive?: boolean;
+  isTyping?: boolean;
   onClick: () => void;
   renderChannelAction: (props: { channel: SendBird.GroupChannel }) => React.ReactNode;
   tabIndex: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,6 +102,8 @@ interface SendBirdStateConfig {
     resizingWidth?: number | string,
     resizingHeight?: number | string,
   };
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 export interface SdkStore {
   error: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,12 +71,14 @@ interface SendBirdProviderProps {
   config?: SendBirdProviderConfig;
   stringSet?: Record<string, string>;
   colorSet?: Record<string, string>;
-  isMentionEnabled?: boolean;
   imageCompression?: {
     compressionRate?: number,
     resizingWidth?: number | string,
     resizingHeight?: number | string,
   };
+  isMentionEnabled?: boolean;
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 
 interface SendBirdStateConfig {
@@ -264,6 +266,9 @@ interface AppProps {
   };
   replyType?: ReplyType;
   disableAutoSelect?: boolean;
+  isMentionEnabled?: boolean;
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 
 interface ApplicationUserListQuery {
@@ -311,6 +316,9 @@ export interface ChannelListProviderProps {
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
   disableUserProfile?: boolean;
   disableAutoSelect?: boolean;
+  typingChannels?: Array<Sendbird.GroupChannel>;
+  isTypingIndicatorEnabled?: boolean;
+  isMessageReceiptStatusEnabled?: boolean;
 }
 
 export interface ChannelListProviderInterface extends ChannelListProviderProps {

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -42,6 +42,8 @@ export default function Sendbird(props) {
     imageCompression,
     useReaction,
     isMentionEnabled,
+    isTypingIndicatorEnabledOnChannelList,
+    isMessageReceiptStatusEnabledOnChannelList,
   } = props;
 
   const {
@@ -174,6 +176,8 @@ export default function Sendbird(props) {
             maxMentionCount: userMention?.maxMentionCount || 10,
             maxSuggestionCount: userMention?.maxSuggestionCount || 15,
           },
+          isTypingIndicatorEnabledOnChannelList,
+          isMessageReceiptStatusEnabledOnChannelList,
         },
       }}
     >
@@ -231,6 +235,8 @@ Sendbird.propTypes = {
       PropTypes.string,
     ]),
   }),
+  isTypingIndicatorEnabledOnChannelList: PropTypes.bool,
+  isMessageReceiptStatusEnabledOnChannelList: PropTypes.bool,
 };
 
 Sendbird.defaultProps = {
@@ -249,4 +255,6 @@ Sendbird.defaultProps = {
   imageCompression: {},
   useReaction: true,
   isMentionEnabled: false,
+  isTypingIndicatorEnabledOnChannelList: false,
+  isMessageReceiptStatusEnabledOnChannelList: false,
 };

--- a/src/lib/SendbirdState.tsx
+++ b/src/lib/SendbirdState.tsx
@@ -52,6 +52,8 @@ interface SendBirdStateConfig {
     resizingWidth?: number | string,
     resizingHeight?: number | string,
   };
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 
 export interface SdkStore {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,8 @@ export interface SendBirdProviderProps {
     resizingWidth?: number | string,
     resizingHeight?: number | string,
   };
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 
 interface SendBirdStateConfig {
@@ -49,6 +51,8 @@ interface SendBirdStateConfig {
     resizingWidth?: number | string,
     resizingHeight?: number | string,
   };
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }
 export interface SdkStore {
   error: boolean;

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -39,6 +39,8 @@ export default function App(props) {
     onProfileEditSuccess,
     imageCompression,
     disableAutoSelect,
+    isTypingIndicatorEnabledOnChannelList,
+    isMessageReceiptStatusEnabledOnChannelList,
   } = props;
   const [currentChannelUrl, setCurrentChannelUrl] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -64,6 +66,8 @@ export default function App(props) {
       imageCompression={imageCompression}
       useReaction={useReaction}
       isMentionEnabled={isMentionEnabled}
+      isTypingIndicatorEnabledOnChannelList={isTypingIndicatorEnabledOnChannelList}
+      isMessageReceiptStatusEnabledOnChannelList={isMessageReceiptStatusEnabledOnChannelList}
     >
       <div className="sendbird-app__wrap">
         <div className="sendbird-app__channellist-wrap">
@@ -183,6 +187,8 @@ App.propTypes = {
   }),
   disableAutoSelect: PropTypes.bool,
   isMentionEnabled: PropTypes.bool,
+  isTypingIndicatorEnabledOnChannelList: PropTypes.bool,
+  isMessageReceiptStatusEnabledOnChannelList: PropTypes.bool,
 };
 
 App.defaultProps = {
@@ -206,4 +212,6 @@ App.defaultProps = {
   colorSet: null,
   imageCompression: {},
   disableAutoSelect: false,
+  isTypingIndicatorEnabledOnChannelList: false,
+  isMessageReceiptStatusEnabledOnChannelList: false,
 };

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -225,6 +225,8 @@ export const user1 = () => fitPageSize(
     queries={{}}
     replyType="QUOTE_REPLY"
     isMentionEnabled
+    isTypingIndicatorEnabledOnChannelList
+    isMessageReceiptStatusEnabledOnChannelList
   />
 );
 export const user2 = () => fitPageSize(

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -210,6 +210,9 @@ export const Korean = () => fitPageSize(
       CHANNEL__MESSAGE_INPUT__PLACE_HOLDER__DISABLED: '입력이 불가능 합니다',
       CHANNEL__MESSAGE_INPUT__PLACE_HOLDER__MUTED: '음소거 되었습니다',
     }}
+    isMentionEnabled
+    isTypingIndicatorEnabledOnChannelList
+    isMessageReceiptStatusEnabledOnChannelList
   />
 );
 
@@ -246,6 +249,8 @@ export const user2 = () => fitPageSize(
       resizingHeight: '100px',
     }}
     isMentionEnabled
+    isTypingIndicatorEnabledOnChannelList
+    isMessageReceiptStatusEnabledOnChannelList
   />
 );
 export const user3 = () => fitPageSize(
@@ -259,6 +264,8 @@ export const user3 = () => fitPageSize(
     profileUrl={addProfile}
     config={{ logLevel: 'all' }}
     replyType="QUOTE_REPLY"
+    isTypingIndicatorEnabledOnChannelList
+    isMessageReceiptStatusEnabledOnChannelList
   />
 );
 export const user4 = () => fitPageSize(

--- a/src/smart-components/App/types.ts
+++ b/src/smart-components/App/types.ts
@@ -34,4 +34,6 @@ export default interface AppProps {
   };
   replyType?: ReplyType;
   disableAutoSelect?: boolean;
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
 }

--- a/src/smart-components/Channel/components/TypingIndicator.tsx
+++ b/src/smart-components/Channel/components/TypingIndicator.tsx
@@ -11,7 +11,7 @@ export interface TypingIndicatorTextProps {
   members: SendBird.Member[];
 }
 
-const TypingIndicatorText: React.FC<TypingIndicatorTextProps> = ({ members }: TypingIndicatorTextProps) => {
+export const TypingIndicatorText: React.FC<TypingIndicatorTextProps> = ({ members }: TypingIndicatorTextProps) => {
   const { stringSet } = useContext(LocalizationContext);
   if (!members || members.length === 0) {
     return '';

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -57,6 +57,7 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) 
     currentChannel,
     channelListDispatcher,
     channelSource,
+    typingChannels,
   } = useChannelListContext();
 
   const state = useSendbirdStateContext();
@@ -195,6 +196,7 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) 
                       onClick={onClick}
                       channel={channel}
                       isActive={channel.url === currentChannel?.url}
+                      isTyping={typingChannels.some(({ url }) => url === channel.url)}
                       renderChannelAction={(() => (
                         <ChannelPreviewAction
                           disabled={!isOnline}

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -196,7 +196,7 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) 
                       onClick={onClick}
                       channel={channel}
                       isActive={channel.url === currentChannel?.url}
-                      isTyping={typingChannels.some(({ url }) => url === channel.url)}
+                      isTyping={typingChannels?.some(({ url }) => url === channel.url)}
                       renderChannelAction={(() => (
                         <ChannelPreviewAction
                           disabled={!isOnline}

--- a/src/smart-components/ChannelList/components/ChannelPreview/channel-preview.scss
+++ b/src/smart-components/ChannelList/components/ChannelPreview/channel-preview.scss
@@ -67,6 +67,10 @@
         margin-left: 4px;
         margin-bottom: 4px;
         white-space: nowrap;
+        &.sendbird-message-status {
+          max-width: 74px;
+          justify-content: flex-end;
+        }
       }
     }
 

--- a/src/smart-components/ChannelList/context/ChannelListProvider.tsx
+++ b/src/smart-components/ChannelList/context/ChannelListProvider.tsx
@@ -221,7 +221,7 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
   }, [sdkIntialized, userFilledChannelListQuery, sortChannelList]);
 
   useEffect(() => {
-    if (sdk && sdk.ChannelHandler) {
+    if (sdk && sdk?.ChannelHandler) {
       const handlerId = uuidv4()
       const handler = new sdk.ChannelHandler()
       handler.onTypingStatusUpdated = (channel) => {

--- a/src/smart-components/ChannelList/index.tsx
+++ b/src/smart-components/ChannelList/index.tsx
@@ -21,6 +21,8 @@ const ChannelList: React.FC<ChannelListProps> = (props: ChannelListProps) => {
       sortChannelList={props?.sortChannelList}
       queries={props?.queries}
       disableAutoSelect={props?.disableAutoSelect}
+      isTypingIndicatorEnabled={props?.isTypingIndicatorEnabled}
+      isMessageReceiptStatusEnabled={props?.isMessageReceiptStatusEnabled}
     >
       <ChannelListUI
         renderChannelPreview={props?.renderChannelPreview}

--- a/src/ui/MessageStatus/index.scss
+++ b/src/ui/MessageStatus/index.scss
@@ -2,15 +2,15 @@
 
 .sendbird-message-status {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: flex-start;
   width: 100%;
   height: 100%;
 
   .sendbird-message-status__icon {
     position: relative;
     display: inline-block;
-    top: 4px;
-
+    top: -2px;
     &.hide-icon {
       display: none;
     }

--- a/src/ui/MessageStatus/stories/MessageStatus.stories.js
+++ b/src/ui/MessageStatus/stories/MessageStatus.stories.js
@@ -8,24 +8,44 @@ const pendingMessage = generateNormalMessage((message) => {
   message.sendingStatus = 'pending';
   return message;
 });
-
 const sentMessage = generateNormalMessage((message) => {
   message.sendingStatus = 'succeeded';
+  return message;
+});
+const readMessage = generateNormalMessage((message) => {
+  message.sendingStatus = 'succeeded';
+  message.getUnreadMemberCount = () => 0;
+  message.getUndeliveredMemberCount = () => 0;
+  return message;
+});
+const deliveredMessage = generateNormalMessage((message) => {
+  message.sendingStatus = 'succeeded';
+  message.getUnreadMemberCount = () => 0;
   return message;
 });
 const failedMessage = generateNormalMessage((message) => {
   message.sendingStatus = 'failed';
   return message;
 });
-
 export const messageStatus = () => [
-  <MessageStatus status={MessageStatusTypes.PENDING} message={pendingMessage} />,
-  <p />,
-  <MessageStatus status={MessageStatusTypes.SENT} message={sentMessage} />,
-  <p />,
-  <MessageStatus status={MessageStatusTypes.DELIVERED} message={sentMessage} />,
-  <p />,
-  <MessageStatus status={MessageStatusTypes.READ} message={sentMessage} />,
-  <p />,
-  <MessageStatus status={MessageStatusTypes.FAILED} message={failedMessage} />,
+  <p>
+    PENDING
+    <MessageStatus status={MessageStatusTypes.PENDING} message={pendingMessage} />
+  </p>,
+  <p>
+    SENT
+    <MessageStatus status={MessageStatusTypes.SENT} message={sentMessage} />
+  </p>,
+  <p>
+    DELIVERED
+    <MessageStatus status={MessageStatusTypes.DELIVERED} message={deliveredMessage} />
+  </p>,
+  <p>
+    READ
+    <MessageStatus status={MessageStatusTypes.READ} message={readMessage} />
+  </p>,
+  <p>
+    FAILED
+    <MessageStatus status={MessageStatusTypes.FAILED} message={failedMessage} />
+  </p>,
 ];


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-1645](https://sendbird.atlassian.net/browse/UIKIT-1645)

## Description Of Changes

[Development docs](https://sendbird.atlassian.net/wiki/spaces/UK/pages/1769603225/Typing+indicators+Delivery+Read+receipts+in+Channel+list)

App & SendbirdProvider
* Add props
  * isTypingIndicatorEnabledOnChannelList
  * isMessageReceiptStatusEnabledOnChannelList

Channel List
* Add props
  * isTypingIndicatorEnabled
  * isMessageReceiptStatusEnabled
* Add typing indicator into the Channel Preview component
* Add message status into the Channel Preview component

Add a brief description of the changes that you have involved in this PR

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
