### PR TITLE
Bugfix [v3] QM-1547_Keep suggested mention max count

### DIFF
--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -1,9 +1,10 @@
 import React, {
+  useRef,
+  useMemo,
   useState,
   useEffect,
-  useRef,
   useLayoutEffect,
-  useMemo,
+  ReactElement,
 } from 'react';
 import format from 'date-fns/format';
 
@@ -37,7 +38,7 @@ type MessageUIProps = {
   renderMessageContent?: () => React.ReactNode;
 };
 
-const Message: React.FC<MessageUIProps> = (props: MessageUIProps) => {
+const Message = (props: MessageUIProps): ReactElement | React.ReactNode | React.ElementType<MessageUIProps> => {
   const {
     message,
     hasSeparator,

--- a/src/smart-components/Channel/components/MessageInput/index.tsx
+++ b/src/smart-components/Channel/components/MessageInput/index.tsx
@@ -42,7 +42,7 @@ const MessageInputWrapper = (): JSX.Element => {
     || utils.isDisabledBecauseMuted(channel)
     || !isOnline;
   const isOperator = utils.isOperator(channel);
-  const { isBroadcast } = channel;
+  const isBroadcast = channel?.isBroadcast;
 
   const displaySuggestedMentionList = isOnline
     && isMentionEnabled

--- a/src/smart-components/Channel/components/SuggestedMentionList/index.tsx
+++ b/src/smart-components/Channel/components/SuggestedMentionList/index.tsx
@@ -99,7 +99,7 @@ function SuggestedMentionList(props: SuggestedMentionListProps): JSX.Element {
     }
 
     const query = currentGroupChannel?.createMemberListQuery({
-      limit: maxSuggestionCount,
+      limit: maxSuggestionCount + 1,  // because current user could be included
       nicknameStartsWithFilter: searchString.slice(USER_MENTION_TEMP_CHAR.length),
     });
     // Add member list query for customization
@@ -112,8 +112,11 @@ function SuggestedMentionList(props: SuggestedMentionListProps): JSX.Element {
           setCurrentUser(memberList[0]);
         }
         setLastSearchString(searchString);
-        onFetchUsers(memberList);
-        setCurrentMemberList(memberList.filter((member) => currentUserId !== member?.userId));
+        const suggestingMembers = memberList
+          .filter((member) => currentUserId !== member?.userId)
+          .slice(0, maxSuggestionCount);
+        onFetchUsers(suggestingMembers);
+        setCurrentMemberList(suggestingMembers);
       })
       .catch((error) => {
         if (error) {

--- a/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
@@ -45,11 +45,12 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
   const userId = sbState?.stores?.userStore?.user?.userId;
   const theme = sbState?.config?.theme;
   const isMentionEnabled = sbState?.config?.isMentionEnabled;
-  const { isBroadcast, isFrozen } = channel;
+  const isFrozen = channel?.isFrozen || false;
+  const isBroadcast = channel?.isBroadcast || false;
   const isChannelTyping = isTypingIndicatorEnabled && isTyping;
   const isMessageStatusEnabled = isMessageReceiptStatusEnabled
     && (channel?.lastMessage?.messageType === 'user' || channel?.lastMessage?.messageType === 'file')
-    && channel?.lastMessage?.sender?.userId === userId;
+    && (channel?.lastMessage as UserMessage | FileMessage)?.sender?.userId === userId;
   return (
     <div
       className={[
@@ -147,7 +148,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
             }
             {
               !isChannelTyping && (
-                utils.getLastMessage(channel) + (isEditedMessage(channel?.lastMessage as SendBird.UserMessage) ? ` ${stringSet.MESSAGE_EDITED}` : '')
+                utils.getLastMessage(channel) + (isEditedMessage(channel?.lastMessage as UserMessage | FileMessage) ? ` ${stringSet.MESSAGE_EDITED}` : '')
               )
             }
           </Label>

--- a/src/ui/ChannelAvatar/utils.ts
+++ b/src/ui/ChannelAvatar/utils.ts
@@ -15,14 +15,10 @@ export const getChannelAvatarSource = (channel: GroupChannel, currentUserId: str
       return channel.coverUrl;
     }
   }
-
   return (channel?.members || [])
-    ? channel.members
-      .filter((member) => member.userId !== currentUserId)
-      .map(({ profileUrl }) => profileUrl)
-    : [];
+    .filter((member) => member.userId !== currentUserId)
+    .map(({ profileUrl }) => profileUrl);
 };
-
 
 export const generateDefaultAvatar = (channel: GroupChannel): boolean => {
   if (channel?.coverUrl) {

--- a/src/ui/ChannelPreview/index.jsx
+++ b/src/ui/ChannelPreview/index.jsx
@@ -24,7 +24,8 @@ export default function ChannelPreview({
   const {
     userId,
   } = currentUser;
-  const { isBroadcast, isFrozen } = channel;
+  const isFrozen = channel?.isFrozen;
+  const isBroadcast = channel?.isBroadcast;
   const { dateLocale, stringSet } = useLocalization();
   return (
     <div

--- a/src/ui/MentionLabel/index.tsx
+++ b/src/ui/MentionLabel/index.tsx
@@ -16,6 +16,7 @@ import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 interface MentionLabelProps {
   mentionTemplate: string;
   mentionedUserId: string;
+  mentionedUserNickname: string;
   isByMe: boolean;
 }
 
@@ -23,6 +24,7 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
   const {
     mentionTemplate,
     mentionedUserId,
+    mentionedUserNickname,
     isByMe,
   } = props;
 
@@ -65,7 +67,7 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
             type={LabelTypography.CAPTION_1}
             color={isByMe ? LabelColors.ONCONTENT_1 : LabelColors.ONBACKGROUND_1}
           >
-            {`${mentionTemplate}${mentionedUserId}`}
+            {`${mentionTemplate}${mentionedUserNickname}`}
           </Label>
         </a>
       )}

--- a/src/ui/MentionLabel/index.tsx
+++ b/src/ui/MentionLabel/index.tsx
@@ -82,7 +82,7 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
           closeDropdown={closeDropdown}
           style={{ paddingTop: 0, paddingBottom: 0 }}
         >
-          <UserProfile disableMessaging user={user} onSuccess={closeDropdown} />
+          <UserProfile user={user} onSuccess={closeDropdown} />
         </MenuItems>
       )}
     />

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -32,7 +32,6 @@ import {
   isOGMessage,
   isThumbnailMessage,
   getSenderName,
-  CoreMessageType,
 } from '../../utils';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 import { ReplyType } from '../../index.js';
@@ -46,7 +45,7 @@ interface Props {
   className?: string | Array<string>;
   userId: string;
   channel: GroupChannel;
-  message: CoreMessageType;
+  message: UserMessage | FileMessage;
   disabled?: boolean;
   chainTop?: boolean;
   chainBottom?: boolean;

--- a/src/ui/UnknownMessageItemBody/index.tsx
+++ b/src/ui/UnknownMessageItemBody/index.tsx
@@ -2,13 +2,14 @@ import React, { ReactElement, useContext } from 'react';
 import './index.scss';
 
 import Label, { LabelTypography, LabelColors } from '../Label';
-import { CoreMessageType, getClassName } from '../../utils';
+import { getClassName } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
+import { FileMessage, UserMessage } from '@sendbird/chat/message';
 
 interface Props {
   className?: string | Array<string>;
   isByMe?: boolean;
-  message: CoreMessageType;
+  message: UserMessage | FileMessage | any;
   mouseHover?: boolean;
 }
 

--- a/src/ui/Word/index.tsx
+++ b/src/ui/Word/index.tsx
@@ -29,7 +29,9 @@ export default function Word(props: WordProps): JSX.Element {
     <span className="sendbird-word">
       {
         convertWordToStringObj(word, message?.mentionedUsers).map((stringObj) => {
-          const { type, value } = stringObj;
+          const type = stringObj?.type || '';
+          const value = stringObj?.value || '';
+          const userId = stringObj?.userId || '';
           if (renderString && typeof renderString === 'function') {
             return renderString(stringObj);
           }
@@ -37,7 +39,8 @@ export default function Word(props: WordProps): JSX.Element {
             return (
               <MentionLabel
                 mentionTemplate={mentionTemplate}
-                mentionedUserId={value}
+                mentionedUserId={userId}
+                mentionedUserNickname={value}
                 key={uuidv4()}
                 isByMe={isByMe}
               />

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -152,13 +152,13 @@ export const isSentStatus = (state: string): boolean => (
   || state === OutgoingMessageStates.READ
 );
 
-export const isAdminMessage = (message: AdminMessage): boolean => (
+export const isAdminMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
   message && (message.isAdminMessage?.() || (message['messageType'] && message.messageType === 'admin'))
 );
-export const isUserMessage = (message: UserMessage): boolean => (
+export const isUserMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
   message && (message.isUserMessage?.() || (message['messageType'] && message.messageType === 'user'))
 );
-export const isFileMessage = (message: FileMessage): boolean => (
+export const isFileMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
   message && (message.isFileMessage?.() || (message['messageType'] && message.messageType === 'file'))
 );
 
@@ -172,7 +172,7 @@ export const isVideoMessage = (message: FileMessage): boolean => message && isTh
 export const isGifMessage = (message: FileMessage): boolean => message && isThumbnailMessage(message) && isGif(message.type);
 export const isAudioMessage = (message: FileMessage): boolean => message && isFileMessage(message) && isAudio(message.type);
 
-export const isEditedMessage = (message: UserMessage): boolean => isUserMessage(message) && (message?.updatedAt > 0);
+export const isEditedMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => isUserMessage(message) && (message?.updatedAt > 0);
 export const isEnabledOGMessage = (message: UserMessage): boolean => (
   (!message || !message.ogMetaData || !message.ogMetaData.url) ? false : true
 );


### PR DESCRIPTION
## For Internal Contributors

[QM-1547](https://sendbird.atlassian.net/browse/QM-1547)
[QM-1552](https://sendbird.atlassian.net/browse/QM-1552)
[QM-1553](https://sendbird.atlassian.net/browse/QM-1553)

## Description Of Changes

* QM-1547
  * Keep the maximum suggestion count even current user is included in the fetch
* QM-1552
  * Differentiate getting nickname and userId from stringObj
  * Fetch the `User` using userId instead of the nickname
  * Display mention text using the nickname
* QM-1553
  * Enable sending 1:1 message on the user profile of the user mentioned text

So the nickname could be changed, but userId is unchangeable

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
