### PR TITLE
Fix [v3] Fix the name text on FileMessage of OpenChannel

### DIFF
--- a/src/ui/OpenchannelFileMessage/index.scss
+++ b/src/ui/OpenchannelFileMessage/index.scss
@@ -33,6 +33,7 @@
     flex-direction: column;
     margin-left: 12px;
     margin-bottom: 4px;
+    width: calc(100% - 64px);
 
     .sendbird-openchannel-file-message__right__title {
       position: relative;
@@ -79,6 +80,7 @@
         height: 20px;
         max-height: 20px;
         text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
   }


### PR DESCRIPTION
[QM-1575](https://sendbird.atlassian.net/browse/QM-1575)

## Description Of Changes

* Apply `white-space: nowrap` to the name text on fileMessage in OpenChannel

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
