### PR TITLE
Fix: [v3] Display pending and failed status in the special group channels

### DIFF
--- a/src/ui/MessageStatus/__tests__/__snapshots__/MessageStatus.spec.js.snap
+++ b/src/ui/MessageStatus/__tests__/__snapshots__/MessageStatus.spec.js.snap
@@ -5,7 +5,7 @@ exports[`MessageStatus should do a snapshot test of the MessageStatus DOM 1`] = 
   className="example-text sendbird-message-status"
 >
   <div
-    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-done sendbird-icon-color--sent"
+    className="sendbird-message-status__icon  sendbird-icon sendbird-icon-done sendbird-icon-color--sent"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="button"
@@ -34,7 +34,7 @@ exports[`MessageStatus should do a snapshot test of the failed MessageStatus DOM
   className="example-text sendbird-message-status"
 >
   <div
-    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-error sendbird-icon-color--error"
+    className="sendbird-message-status__icon  sendbird-icon sendbird-icon-error sendbird-icon-color--error"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="button"
@@ -58,7 +58,7 @@ exports[`MessageStatus should do a snapshot test of the failed MessageStatus DOM
   className="example-text sendbird-message-status"
 >
   <div
-    className="sendbird-message-status__icon hide-icon sendbird-icon sendbird-icon-error sendbird-icon-color--error"
+    className="sendbird-message-status__icon  sendbird-icon sendbird-icon-error sendbird-icon-color--error"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="button"

--- a/src/ui/MessageStatus/index.tsx
+++ b/src/ui/MessageStatus/index.tsx
@@ -36,6 +36,10 @@ export default function MessageStatus({
     && !channel?.isSuper
     && !channel?.isPublic
     && !channel?.isBroadcast;
+  const hideMessageStatusIcon = channel?.isGroupChannel() && (
+    (channel.isSuper || channel.isPublic || channel.isBroadcast)
+    && !(status === MessageStatusTypes.PENDING || status === MessageStatusTypes.FAILED)
+  );
   const iconType = {
     [MessageStatusTypes.SENT]: IconTypes.DONE,
     [MessageStatusTypes.DELIVERED]: IconTypes.DONE_ALL,
@@ -58,7 +62,7 @@ export default function MessageStatus({
     >
       {(status === MessageStatusTypes.PENDING) ? (
         <Loader
-          className={`sendbird-message-status__icon ${showMessageStatusIcon ? '' : 'hide-icon'}`}
+          className="sendbird-message-status__icon"
           width="16px"
           height="16px"
         >
@@ -71,7 +75,7 @@ export default function MessageStatus({
         </Loader>
       ) : (
         <Icon
-          className={`sendbird-message-status__icon ${showMessageStatusIcon ? '' : 'hide-icon'}`}
+          className={`sendbird-message-status__icon ${hideMessageStatusIcon ? 'hide-icon' : ''}`}
           type={iconType[status] || IconTypes.ERROR}
           fillColor={iconColor[status]}
           width="16px"

--- a/src/ui/MessageStatus/index.tsx
+++ b/src/ui/MessageStatus/index.tsx
@@ -32,10 +32,6 @@ export default function MessageStatus({
   const status = useMemo(() => (
     getOutgoingMessageState(channel, message)
   ), [channel?.getUnreadMemberCount?.(message), channel?.getUndeliveredMemberCount?.(message)]);
-  const showMessageStatusIcon = channel?.isGroupChannel()
-    && !channel?.isSuper
-    && !channel?.isPublic
-    && !channel?.isBroadcast;
   const hideMessageStatusIcon = channel?.isGroupChannel() && (
     (channel.isSuper || channel.isPublic || channel.isBroadcast)
     && !(status === MessageStatusTypes.PENDING || status === MessageStatusTypes.FAILED)


### PR DESCRIPTION
## For Internal Contributors

[QM-1635](https://sendbird.atlassian.net/browse/QM-1635)

## Description Of Changes

* Change the message status appearing condition
  * to display it when (the sending status is 'pending' or 'failed' in the special group channels)
  * special group channels: super, broadcast, public

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
