### PR TITLE
Release: [v3.0.0] (July 12 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog - v3
 
-## [v3.0.0-rc.0] (July 11 2022)
+## [v3.0.0] (July 12 2022)
 
 Features:
-* Use `@sendbird/chat@4`, see [MIGRATION_v2-to-v3.md](./MIGRATION_v2-to-v3.md) for details
+* Support `modules` and `components` in the UIKit
+* Upgraded to `@sendbird/chat@4`
 * Support react 18
+* See the Migration Guide for Converting V2 to V3. [[details](./MIGRATION_v2-to-v3.md)]
+* See more details and breaking changes. [[details](./CHANGELOG.md)]
 
 ## [3.0.0-beta.6] (June 03 2022)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/scripts/package.template.json
+++ b/scripts/package.template.json
@@ -28,7 +28,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.0.4",
+    "@sendbird/chat": "^4.0.6",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "prop-types": "^15.7.2"

--- a/scripts/steps.md
+++ b/scripts/steps.md
@@ -2,6 +2,8 @@
 2. Update and replace dist/index.d.ts with scripts/index_d_ts
 3. Update and replace dist/package.json with scripts/package.template.json
 4. Update and replace dist/README.md with main README.md
+4. Update and replace dist/CHANGELOG.md with main CHANGELOG.md
+4. Update and replace dist/LICENSE with main LICENSE
 5. npm publish inside dist
 
 We do step 2 because half project is in TS and other half in JS. Will update tooling soon to fix this issue


### PR DESCRIPTION
Features:
* Support `modules` and `components` in the UIKit
* Upgraded to `@sendbird/chat@4`
* Support react 18
* See the Migration Guide for Converting V2 to V3. [[details](./MIGRATION_v2-to-v3.md)]
* See more details and breaking changes. [[details](./CHANGELOG.md)]