### PR TITLE
feat: accept customApiHost & customWebSocketHost

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -17,6 +17,8 @@
     appId: string;
     userId: string;
     accessToken?: string;
+    customApiHost?: string,
+    customWebSocketHost?: string,
     theme?: 'light' | 'dark';
     userListQuery?(): UserListQuery;
     nickname?: string;
@@ -175,6 +177,8 @@
     appId: string;
     accessToken?: string;
     configureSession?: (sdk: SendbirdGroupChat | SendbirdOpenChat) => SessionHandler;
+    customApiHost?: string,
+    customWebSocketHost?: string,
     children?: React.ReactNode;
     theme?: 'light' | 'dark';
     nickname?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,6 +87,8 @@ interface SendBirdProviderProps {
   appId: string;
   accessToken?: string;
   configureSession?: (sdk: SendbirdChat) => SessionHandler;
+  customApiHost?: string,
+  customWebSocketHost?: string,
   children?: React.ReactNode;
   theme?: 'light' | 'dark';
   nickname?: string;
@@ -252,6 +254,8 @@ interface AppProps {
   appId: string;
   userId: string;
   accessToken?: string;
+  customApiHost?: string,
+  customWebSocketHost?: string,
   theme?: 'light' | 'dark';
   userListQuery?(): UserListQuery;
   nickname?: string;

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -29,6 +29,8 @@ export default function Sendbird(props) {
     appId,
     accessToken,
     configureSession,
+    customApiHost,
+    customWebSocketHost,
     children,
     disableUserProfile,
     renderUserProfile,
@@ -73,6 +75,8 @@ export default function Sendbird(props) {
       nickname,
       profileUrl,
       configureSession,
+      customApiHost,
+      customWebSocketHost,
       sdk: sdkStore.sdk,
       logger,
     }, {
@@ -194,6 +198,8 @@ Sendbird.propTypes = {
   userId: PropTypes.string.isRequired,
   appId: PropTypes.string.isRequired,
   accessToken: PropTypes.string,
+  customApiHost: PropTypes.string,
+  customWebSocketHost: PropTypes.string,
   configureSession: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.element,
@@ -244,6 +250,8 @@ Sendbird.propTypes = {
 
 Sendbird.defaultProps = {
   accessToken: '',
+  customApiHost: null,
+  customWebSocketHost: null,
   configureSession: null,
   theme: 'light',
   nickname: '',

--- a/src/lib/dux/sdk/thunks.js
+++ b/src/lib/dux/sdk/thunks.js
@@ -43,6 +43,8 @@ export const handleConnection = ({
   profileUrl,
   accessToken,
   configureSession,
+  customApiHost,
+  customWebSocketHost,
   sdk,
   logger,
 }, dispatchers) => {
@@ -66,6 +68,8 @@ export const handleConnection = ({
             new GroupChannelModule(),
             new OpenChannelModule(),
           ],
+          customApiHost,
+          customWebSocketHost,
         });
         if (configureSession && typeof configureSession === 'function') {
           sessionHandler = configureSession(newSdk);

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -20,6 +20,8 @@ export default function App(props) {
     appId,
     userId,
     accessToken,
+    customApiHost,
+    customWebSocketHost,
     theme,
     userListQuery,
     nickname,
@@ -54,6 +56,8 @@ export default function App(props) {
       appId={appId}
       userId={userId}
       accessToken={accessToken}
+      customApiHost={customApiHost}
+      customWebSocketHost={customWebSocketHost}
       theme={theme}
       nickname={nickname}
       profileUrl={profileUrl}
@@ -152,6 +156,8 @@ App.propTypes = {
   appId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
   accessToken: PropTypes.string,
+  customApiHost: PropTypes.string,
+  customWebSocketHost: PropTypes.string,
   theme: PropTypes.string,
   userListQuery: PropTypes.func,
   nickname: PropTypes.string,
@@ -193,6 +199,8 @@ App.propTypes = {
 
 App.defaultProps = {
   accessToken: '',
+  customApiHost: '',
+  customWebSocketHost: '',
   theme: 'light',
   nickname: '',
   profileUrl: '',

--- a/src/smart-components/App/types.ts
+++ b/src/smart-components/App/types.ts
@@ -12,6 +12,8 @@ export default interface AppProps {
   appId: string;
   userId: string;
   accessToken?: string;
+  customApiHost?: string,
+  customWebSocketHost?: string,
   theme?: 'light' | 'dark';
   userListQuery?(): UserListQuery;
   nickname?: string;


### PR DESCRIPTION
Accept customApiHost & customWebSocketHost on SendbirdProvider and App
These urls let the SDK to connect to custom domains

fixes: https://sendbird.atlassian.net/browse/UIKIT-1853