### PR TITLE
fix: Set package.json type as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sendbird/uikit-react",
   "version": "3.0.1",
+  "type": "module",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
   "version": "3.0.1",
-  "type": "module",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -111,6 +111,10 @@ module.exports = ({
           src: './src/index.d.ts',
           dest: 'dist',
         },
+        {
+          src: './package.lock.json',
+          dest: 'dist',
+        },
       ],
     }),
   ],

--- a/scripts/package.template.json
+++ b/scripts/package.template.json
@@ -2,6 +2,7 @@
   "name": "@sendbird/uikit-react",
   "version": "{{ version }}",
   "description": "React based UI kit for sendbird",
+  "type": "module",
   "main": "index.js",
   "style": "dist/index.css",
   "typings": "index.d.ts",

--- a/scripts/steps.md
+++ b/scripts/steps.md
@@ -1,6 +1,9 @@
 1. Run npm build
 2. Update and replace dist/index.d.ts with scripts/index_d_ts
 3. Update and replace dist/package.json with scripts/package.template.json
+   * "type": "module"(only in package.template.json) need migration work in package.json
+   * Updated import paths
+   * Remove unnecessary scripts(build etc etc)
 4. Update and replace dist/README.md with main README.md
 4. Update and replace dist/CHANGELOG.md with main CHANGELOG.md
 4. Update and replace dist/LICENSE with main LICENSE


### PR DESCRIPTION
ESM library should have "type": "module" (package.json file that is going to /dist)
This fixes Cannot use import outside module issue in next.js

fixes: https://sendbird.atlassian.net/browse/UIKIT-1980