### PR TITLE
fix: cannot connect sometimes when customApiHost is empty (#231)

### DIFF
--- a/src/lib/dux/sdk/thunks.js
+++ b/src/lib/dux/sdk/thunks.js
@@ -62,15 +62,20 @@ export const handleConnection = ({
       let sessionHandler = null;
       sdkDispatcher({ type: SET_SDK_LOADING, payload: true });
       if (userId && appId) {
-        const newSdk = SendbirdChat.init({
+        const params = {
           appId,
           modules: [
             new GroupChannelModule(),
             new OpenChannelModule(),
           ],
-          customApiHost,
-          customWebSocketHost,
-        });
+        };
+        if (customApiHost) {
+          params.customApiHost = customApiHost;
+        }
+        if (customWebSocketHost) {
+          params.customWebSocketHost = customWebSocketHost;
+        }
+        const newSdk = SendbirdChat.init(params);
         if (configureSession && typeof configureSession === 'function') {
           sessionHandler = configureSession(newSdk);
         }


### PR DESCRIPTION
Connection cannot be established with no error message when customApiHost and customWebSocketHost
were passed as empty string