### PR TITLE
hotfix: remove type from handler type import

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -867,19 +867,19 @@ declare module '@sendbird/uikit-react/withSendbird' {
 
 // handlers
 declare module '@sendbird/uikit-react/handlers/ConnectionHandler' {
-  import type { ConnectionHandler } from '@sendbird/chat';
+  import { ConnectionHandler } from '@sendbird/chat';
   export default ConnectionHandler;
 }
 declare module '@sendbird/uikit-react/handlers/GroupChannelHandler' {
-  import type { GroupChannelHandler } from '@sendbird/chat/groupChannel';
+  import { GroupChannelHandler } from '@sendbird/chat/groupChannel';
   export default GroupChannelHandler;
 }
 declare module '@sendbird/uikit-react/handlers/OpenChannelHandler' {
-  import type { OpenChannelHandler } from '@sendbird/chat/openChannel';
+  import { OpenChannelHandler } from '@sendbird/chat/openChannel';
   export default OpenChannelHandler;
 }
 declare module '@sendbird/uikit-react/handlers/UserEventHandler' {
-  import type { UserEventHandler } from "@sendbird/chat";
+  import { UserEventHandler } from "@sendbird/chat";
   export default UserEventHandler;
 }
 


### PR DESCRIPTION
To solve - cannot be used as a value when imports using the `import type` declaration