### PR TITLE
fix: set default of isMessageGroupingEnabled to true

### DIFF
--- a/src/smart-components/Channel/context/ChannelProvider.tsx
+++ b/src/smart-components/Channel/context/ChannelProvider.tsx
@@ -153,7 +153,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     channelUrl,
     children,
     isReactionEnabled,
-    isMessageGroupingEnabled,
+    isMessageGroupingEnabled = true,
     showSearchIcon,
     highlightedMessage,
     startingPoint,

--- a/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
+++ b/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
@@ -92,7 +92,7 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
   const {
     channelUrl,
     children,
-    isMessageGroupingEnabled,
+    isMessageGroupingEnabled = true,
     queries,
     onBeforeSendUserMessage,
     messageLimit,


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2079](https://sendbird.atlassian.net/browse/UIKIT-2079)

## Description Of Changes

* Set the default value of isMessageGroupingEnabled props to true in the Channel and OpenChannel

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
