### PR TITLE
fix: Change type of react elements

### DIFF
--- a/CHANGELOG_v2.md
+++ b/CHANGELOG_v2.md
@@ -294,7 +294,7 @@ channel OpenChannelSettings
 - Features/Bugs:
   * ChannelList
     * disableUserProfile: boolean
-    * renderUserProfile: React.Component
+    * renderUserProfile: React.ReactElement
 
 ## 1.2.4(Sept 17, 2020) Deprecated
 
@@ -304,16 +304,16 @@ channel OpenChannelSettings
 
   * SendBirdProvider
     * disableUserProfile: boolean
-    * renderUserProfile: React.Component
+    * renderUserProfile: React.ReactElement
     * allowProfileEdit: boolean
   * Channel
     * disableUserProfile: boolean
-    * renderUserProfile: React.Component
+    * renderUserProfile: React.ReactElement
   * ChannelSettings
     * disableUserProfile: boolean
-    * renderUserProfile: React.Component
+    * renderUserProfile: React.ReactElement
   * ChannelList
-    * renderHeader(): React.Component
+    * renderHeader(): React.ReactElement
     * allowProfileEdit: boolean
     * onThemeChange(theme: string): void
     * onProfileEditSuccess(user: User): void

--- a/MIGRATION_v2-to-v3.md
+++ b/MIGRATION_v2-to-v3.md
@@ -481,9 +481,9 @@ The following table lists properties that were added to the `ChannelList` module
 
 |Property name|Type|Description|
 |---|---|---|
-|renderPlaceHolderError|ReactElement|Renders a customized placeholder for error messages in the channel list. (Default: `null`)|
-|renderPlaceHolderLoading|ReactElement|Renders a customized placeholder for loading messages in the channel list. (Default: `null`)|
-|renderPlaceHolderEmptyList|ReactElement|Renders a customized placeholder message for when the channel list is empty. (Default: `null`)|
+|renderPlaceHolderError|React.ReactElement|Renders a customized placeholder for error messages in the channel list. (Default: `null`)|
+|renderPlaceHolderLoading|React.ReactElement|Renders a customized placeholder for loading messages in the channel list. (Default: `null`)|
+|renderPlaceHolderEmptyList|React.ReactElement|Renders a customized placeholder message for when the channel list is empty. (Default: `null`)|
 
 </div>
 
@@ -605,8 +605,8 @@ const MyFileMessageComponent = ({ message, chainTop, chainBottom }) => {
 
 |Render prop|From v2|To v3|
 |---|---|---|
-|renderMessageInput|({ channel, user, disabled, quoteMessage }) => React.ReactNode|() => React.ReactNode|
-|renderChannelHeader|renderChatHeader?: ({ channel, user }) => React.ReactNode|renderChannelHeader?: () => React.ReactNode|
+|renderMessageInput|({ channel, user, disabled, quoteMessage }) => React.ReactElement|() => React.ReactElement|
+|renderChannelHeader|renderChatHeader?: ({ channel, user }) => React.ReactElement|renderChannelHeader?: () => React.ReactElement|
 
 </div>
 
@@ -659,14 +659,14 @@ The following table lists properties that were added to the `Channel` module.
 
 |Property name|Type|Description|
 |---|---|---|
-|renderPlaceholderLoader|ReactElement|Renders a customized placeholder for loading messages in the channel. (Default: `null`)|
-|renderPlaceholderInvalid|ReactElement|Renders a customized placeholder for invalid channel state. (Default: `null`)|
-|renderPlaceholderEmpty|ReactElement|Renders a customized placeholder for an empty channel. (Default: `null`)|
-|renderChannelHeader|ReactElement|Renders a customized channel header component. (Default: `null`)|
-|renderMessage|ReactElement|Renders a customized message view in the channel. (Default: `null`)|
-|renderMessageInput|ReactElement|Renders a customized message input component. (Default: `null`)|
-|renderTypingIndicator|ReactElement|Renders a customized typing indicator component. (Default: `null`)|
-|renderCustomSeperator|ReactElement|Renders a customized date separator view in the message list component. (Default: `null`)|
+|renderPlaceholderLoader|React.ReactElement|Renders a customized placeholder for loading messages in the channel. (Default: `null`)|
+|renderPlaceholderInvalid|React.ReactElement|Renders a customized placeholder for invalid channel state. (Default: `null`)|
+|renderPlaceholderEmpty|React.ReactElement|Renders a customized placeholder for an empty channel. (Default: `null`)|
+|renderChannelHeader|React.ReactElement|Renders a customized channel header component. (Default: `null`)|
+|renderMessage|React.ReactElement|Renders a customized message view in the channel. (Default: `null`)|
+|renderMessageInput|React.ReactElement|Renders a customized message input component. (Default: `null`)|
+|renderTypingIndicator|React.ReactElement|Renders a customized typing indicator component. (Default: `null`)|
+|renderCustomSeperator|React.ReactElement|Renders a customized date separator view in the message list component. (Default: `null`)|
 
 </div>
 
@@ -698,7 +698,7 @@ import { ChannelSettings } from "@sendbird/uikit-react"
 
 |Render prop|From v2|To v3|
 |---|---|---|
-|renderChannelProfile|({ channel }) => React.ReactNode|() => React.ReactNode|
+|renderChannelProfile|({ channel }) => React.ReactElement|() => React.ReactElement|
 
 </div>
 
@@ -724,9 +724,9 @@ The following table lists properties that were added to the `ChannelSettings` mo
 
 |Property name|Type|Description|
 |---|---|---|
-|renderPlaceHolderError|ReactElement|Renders a customized placeholder for error messages that occur in the channel settings menu. (Default: `null`)|
-|renderModerationPanel|ReactElement|Renders a customized view of the moderation panel that displays the moderation tools for channel operators. (Default: `null`)|
-|renderexitChannel|ReactElement|Renders a customized leave channel button in the settings module. (Default: `null`)|
+|renderPlaceHolderError|React.ReactElement|Renders a customized placeholder for error messages that occur in the channel settings menu. (Default: `null`)|
+|renderModerationPanel|React.ReactElement|Renders a customized view of the moderation panel that displays the moderation tools for channel operators. (Default: `null`)|
+|renderexitChannel|React.ReactElement|Renders a customized leave channel button in the settings module. (Default: `null`)|
 
 </div>
 
@@ -758,8 +758,8 @@ import { OpenChannel } from "@sendbird/uikit-react"
 
 |Render prop|From v2|To v3|
 |---|---|---|
-|renderChannelTitle|({channel, user}) => React.ReactNode|() => React.ReactNode|
-|renderMessageInput|({channel, user, disabled}) => React.ReactNode|() => React.ReactNode|
+|renderChannelTitle|({channel, user}) => React.ReactElement|() => React.ReactElement|
+|renderMessageInput|({channel, user, disabled}) => React.ReactElement|() => React.ReactElement|
 
 </div>
 
@@ -806,12 +806,12 @@ The following table lists properties that were added to the `OpenChannel` module
 
 |Property name|Type|Description|
 |---|---|---|
-|renderMessage|ReactElement|Renders a customized message view in the channel. (Default: `null`)|
-|renderHeader|ReactElement|Renders a customized channel header component. (Default: `null`)|
-|renderInput|ReactElement|Renders a customized message input component. (Default: `null`)|
-|renderPlaceholderEmptyList|ReactElement|Renders a customized placeholder for an empty channel. (Default: `null`)|
-|renderPlaceHolderError|ReactElement|Renders a customized placeholder for error messages that occur in the channel. (Default: `null`)|
-|renderPlaceholderLoading|ReactElement|Renders a customized placeholder for loading messages in the channel. (Default: `null`)|
+|renderMessage|React.ReactElement|Renders a customized message view in the channel. (Default: `null`)|
+|renderHeader|React.ReactElement|Renders a customized channel header component. (Default: `null`)|
+|renderInput|React.ReactElement|Renders a customized message input component. (Default: `null`)|
+|renderPlaceholderEmptyList|React.ReactElement|Renders a customized placeholder for an empty channel. (Default: `null`)|
+|renderPlaceHolderError|React.ReactElement|Renders a customized placeholder for error messages that occur in the channel. (Default: `null`)|
+|renderPlaceholderLoading|React.ReactElement|Renders a customized placeholder for loading messages in the channel. (Default: `null`)|
 
 </div>
 
@@ -855,8 +855,8 @@ The following table lists properties that were added to the `OpenChannelSettings
 
 |Property name|Type|Description|
 |---|---|---|
-|renderOperatorUI|ReactElement|Renders a customized view of the channel settings for operators. (Default: `null`)|
-|renderParticipantList|ReactElement|Renders a customized view of the channel settings for non-operator members. (Default: `null`)|
+|renderOperatorUI|React.ReactElement|Renders a customized view of the channel settings for operators. (Default: `null`)|
+|renderParticipantList|React.ReactElement|Renders a customized view of the channel settings for non-operator members. (Default: `null`)|
 
 </div>
 
@@ -890,10 +890,10 @@ The following table lists properties that were added to the `MessageSearch` modu
 
 |Property name|Type|Description|
 |---|---|---|
-|renderPlaceHolderError|ReactElement|Renders a customized placeholder for error messages that occur in the search result. (Default: `null`)|
-|renderPlaceholderLoading|ReactElement|Renders a customized placeholder for loading messages in the search result. (Default: `null`)|
-|renderPlaceHolderNoString|ReactElement|Renders a customized placeholder for when there are no messages that match the search query.|
-|renderPlaceholderEmptyList|ReactElement|Renders a customized placeholder for an empty list of search results. (Default: `null`)|
+|renderPlaceHolderError|React.ReactElement|Renders a customized placeholder for error messages that occur in the search result. (Default: `null`)|
+|renderPlaceholderLoading|React.ReactElement|Renders a customized placeholder for loading messages in the search result. (Default: `null`)|
+|renderPlaceHolderNoString|React.ReactElement|Renders a customized placeholder for when there are no messages that match the search query.|
+|renderPlaceholderEmptyList|React.ReactElement|Renders a customized placeholder for an empty list of search results. (Default: `null`)|
 
 </div>
 

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -27,7 +27,7 @@ declare module "SendbirdUIKitGlobal" {
     allowProfileEdit?: boolean;
     disableUserProfile?: boolean;
     showSearchIcon?: boolean;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     onProfileEditSuccess?(user: User): void;
     config?: SendbirdProviderConfig;
     useReaction?: boolean;
@@ -182,13 +182,13 @@ declare module "SendbirdUIKitGlobal" {
     configureSession?: (sdk: SendbirdGroupChat | SendbirdOpenChat) => SessionHandler;
     customApiHost?: string,
     customWebSocketHost?: string,
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     theme?: 'light' | 'dark';
     nickname?: string;
     profileUrl?: string;
     dateLocale?: Locale;
     disableUserProfile?: boolean;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     allowProfileEdit?: boolean;
     userListQuery?(): UserListQuery;
     config?: SendbirdProviderConfig;
@@ -207,7 +207,7 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface SendBirdStateConfig {
     disableUserProfile: boolean;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     allowProfileEdit: boolean;
     isOnline: boolean;
     isMentionEnabled: boolean;
@@ -301,9 +301,9 @@ declare module "SendbirdUIKitGlobal" {
     onChannelSelect?(channel: GroupChannel): void;
     sortChannelList?: (channels: GroupChannel[]) => GroupChannel[];
     queries?: ChannelListQueries;
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     className?: string | Array<string>;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     disableUserProfile?: boolean;
     disableAutoSelect?: boolean;
     isTypingIndicatorEnabled?: boolean;
@@ -333,19 +333,19 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export interface ChannelListUIProps {
-    renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactNode;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
-    renderHeader?: (props: void) => React.ReactNode;
-    renderPlaceHolderError?: (props: void) => React.ReactNode;
-    renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-    renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+    renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactElement;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+    renderHeader?: (props: void) => React.ReactElement;
+    renderPlaceHolderError?: (props: void) => React.ReactElement;
+    renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+    renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
   }
 
   export interface ChannelListProps extends ChannelListProviderProps, ChannelListUIProps { }
 
   export interface ChannelListHeaderInterface {
-    renderHeader?: (props: void) => React.ReactNode;
-    renderIconButton?: (props: void) => React.ReactNode;
+    renderHeader?: (props: void) => React.ReactElement;
+    renderIconButton?: (props: void) => React.ReactElement;
     onEdit?: (props: void) => void;
     allowProfileEdit?: boolean;
   }
@@ -354,7 +354,7 @@ declare module "SendbirdUIKitGlobal" {
     channel: GroupChannel;
     isActive?: boolean;
     onClick: () => void;
-    renderChannelAction: (props: { channel: GroupChannel }) => React.ReactNode;
+    renderChannelAction: (props: { channel: GroupChannel }) => React.ReactElement;
     tabIndex: number;
   }
 
@@ -375,10 +375,10 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export interface ChannelSettingsUIProps {
-    renderPlaceholderError?: () => React.ReactNode;
-    renderChannelProfile?: () => React.ReactNode;
-    renderModerationPanel?: () => React.ReactNode;
-    renderLeaveChannel?: () => React.ReactNode;
+    renderPlaceholderError?: () => React.ReactElement;
+    renderChannelProfile?: () => React.ReactElement;
+    renderModerationPanel?: () => React.ReactElement;
+    renderLeaveChannel?: () => React.ReactElement;
   }
 
   export interface ApplicationUserListQuery {
@@ -393,14 +393,14 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export type ChannelSettingsContextProps = {
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     channelUrl: string;
     className?: string;
     onCloseClick?(): void;
     onChannelModified?(channel: GroupChannel): void;
     onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): GroupChannelUpdateParams;
     queries?: ChannelSettingsQueries;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     disableUserProfile?: boolean;
   }
 
@@ -449,7 +449,7 @@ declare module "SendbirdUIKitGlobal" {
 
   export type ChannelContextProps = {
     channelUrl: string;
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     useMessageGrouping?: boolean;
     useReaction?: boolean;
     showSearchIcon?: boolean;
@@ -462,20 +462,20 @@ declare module "SendbirdUIKitGlobal" {
     onSearchClick?(): void;
     replyType?: ReplyType;
     queries?: ChannelQueries;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     disableUserProfile?: boolean;
     renderUserMentionItem?: (props: { user: User }) => JSX.Element;
   };
 
   export interface ChannelUIProps {
-    renderPlaceholderLoader?: () => React.ReactNode;
-    renderPlaceholderInvalid?: () => React.ReactNode;
-    renderPlaceholderEmpty?: () => React.ReactNode;
-    renderChannelHeader?: () => React.ReactNode;
+    renderPlaceholderLoader?: () => React.ReactElement;
+    renderPlaceholderInvalid?: () => React.ReactElement;
+    renderPlaceholderEmpty?: () => React.ReactElement;
+    renderChannelHeader?: () => React.ReactElement;
     renderMessage?: (props: RenderMessageProps) => React.ComponentType;
-    renderMessageInput?: () => React.ReactNode;
-    renderTypingIndicator?: () => React.ReactNode;
-    renderCustomSeperator?: () => React.ReactNode;
+    renderMessageInput?: () => React.ReactElement;
+    renderTypingIndicator?: () => React.ReactElement;
+    renderCustomSeperator?: () => React.ReactElement;
   }
 
   export type CoreMessageType = AdminMessage | UserMessage | FileMessage;
@@ -524,16 +524,16 @@ declare module "SendbirdUIKitGlobal" {
     chainBottom?: boolean;
     handleScroll: () => void;
     // for extending
-    renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-    renderCustomSeperator?: () => React.ReactNode;
-    renderEditInput?: () => React.ReactNode;
-    renderMessageContent?: () => React.ReactNode;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+    renderCustomSeperator?: () => React.ReactElement;
+    renderEditInput?: () => React.ReactElement;
+    renderMessageContent?: () => React.ReactElement;
   };
 
   export type MessageListProps = {
-    renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-    renderPlaceholderEmpty?: () => React.ReactNode;
-    renderCustomSeperator?: () => React.ReactNode;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+    renderPlaceholderEmpty?: () => React.ReactElement;
+    renderCustomSeperator?: () => React.ReactElement;
   };
 
   export type SuggestedMentionListProps = {
@@ -598,7 +598,7 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface OpenChannelProviderProps {
     channelUrl: string;
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     useMessageGrouping?: boolean;
     queries?: OpenChannelQueries;
     messageLimit?: number;
@@ -606,7 +606,7 @@ declare module "SendbirdUIKitGlobal" {
     onBeforeSendFileMessage?(file_: File): FileMessageCreateParams;
     onChatHeaderActionClick?(): void;
     disableUserProfile?: boolean;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   }
 
   export interface OpenChannelMessagesState {
@@ -638,24 +638,24 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export interface OpenChannelUIProps {
-    renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-    renderHeader?: () => React.ReactNode;
-    renderInput?: () => React.ReactNode;
-    renderPlaceHolderEmptyList?: () => React.ReactNode;
-    renderPlaceHolderError?: () => React.ReactNode;
-    renderPlaceHolderLoading?: () => React.ReactNode;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+    renderHeader?: () => React.ReactElement;
+    renderInput?: () => React.ReactElement;
+    renderPlaceHolderEmptyList?: () => React.ReactElement;
+    renderPlaceHolderError?: () => React.ReactElement;
+    renderPlaceHolderLoading?: () => React.ReactElement;
   }
 
   export interface OpenChannelProps extends OpenChannelProviderProps, OpenChannelUIProps {
   }
 
   export type OpenchannelMessageListProps = {
-    renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-    renderPlaceHolderEmptyList?: () => React.ReactNode;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+    renderPlaceHolderEmptyList?: () => React.ReactElement;
   }
 
   export type OpenChannelMessageProps = {
-    renderMessage?: (props: RenderMessageProps) => React.ReactNode;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
     message: EveryMessage;
     chainTop?: boolean;
     chainBottom?: boolean;
@@ -668,18 +668,18 @@ declare module "SendbirdUIKitGlobal" {
    */
   export interface OpenChannelSettingsContextProps {
     channelUrl: string;
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     onCloseClick?(): void;
     onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): OpenChannelUpdateParams;
     onChannelModified?(channel: OpenChannel): void;
     onDeleteChannel?(channel: OpenChannel): void;
     disableUserProfile?: boolean;
-    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+    renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   }
 
   export interface OpenChannelSettingsUIProps {
-    renderOperatorUI?: () => React.ReactNode;
-    renderParticipantList?: () => React.ReactNode;
+    renderOperatorUI?: () => React.ReactElement;
+    renderParticipantList?: () => React.ReactElement;
   }
 
   export interface OpenChannelSettingsProps extends OpenChannelSettingsContextProps, OpenChannelSettingsUIProps {
@@ -692,7 +692,7 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export interface OperatorUIProps {
-    renderChannelProfile?: () => React.ReactNode;
+    renderChannelProfile?: () => React.ReactElement;
   }
 
   export interface OpenChannelEditDetailsProps {
@@ -704,7 +704,7 @@ declare module "SendbirdUIKitGlobal" {
    */
   export interface MessageSearchProviderProps {
     channelUrl: string;
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     searchString?: string;
     requestString?: string;
     messageSearchQuery?: MessageSearchQuery;
@@ -740,10 +740,10 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export interface MessageSearchUIProps {
-    renderPlaceHolderError?: (props: void) => React.ReactNode;
-    renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-    renderPlaceHolderNoString?: (props: void) => React.ReactNode;
-    renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+    renderPlaceHolderError?: (props: void) => React.ReactElement;
+    renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+    renderPlaceHolderNoString?: (props: void) => React.ReactElement;
+    renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
     renderSearchItem?(
       {
         message,
@@ -763,7 +763,7 @@ declare module "SendbirdUIKitGlobal" {
    * CreateChannel
    */
   export interface CreateChannelProviderProps {
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     onCreateChannel(channel: GroupChannel): void;
     onBeforeCreateChannel?(users: Array<string>): GroupChannelCreateParams;
     userListQuery?(): UserListQuery;
@@ -783,7 +783,7 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface CreateChannelUIProps {
     onCancel?(): void;
-    renderStepOne?: (props: void) => React.ReactNode;
+    renderStepOne?: (props: void) => React.ReactElement;
   }
 
   export interface CreateChannelProps extends CreateChannelProviderProps, CreateChannelUIProps { }
@@ -800,7 +800,7 @@ declare module "SendbirdUIKitGlobal" {
    * EditUserProfile
    */
   export interface EditUserProfileProps {
-    children?: React.ReactNode;
+    children?: React.ReactElement;
     onCancel?(): void;
     onThemeChange?(theme: string): void;
     onEditProfile?(updatedUser: User): void;
@@ -826,9 +826,9 @@ declare module '@sendbird/uikit-react' {
   export const OpenChannelSettings: React.FunctionComponent<SendbirdUIKitGlobal.OpenChannelSettingsProps>
   export const MessageSearch: React.FunctionComponent<SendbirdUIKitGlobal.MessageSearchProps>
   export function withSendBird(
-    ChildComp: React.Component | React.ElementType,
+    ChildComp: React.Component | React.ElementType | React.ReactElement,
     mapStoreToProps?: (store: SendbirdUIKitGlobal.SendBirdState) => unknown
-  ): (props: unknown) => React.ReactNode;
+  ): (props: unknown) => React.ReactElement;
   export function useSendbirdStateContext(): SendbirdUIKitGlobal.SendBirdState;
 }
 
@@ -859,9 +859,9 @@ declare module '@sendbird/uikit-react/useSendbirdStateContext' {
 declare module '@sendbird/uikit-react/withSendbird' {
   import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
   function withSendbird(
-    ChildComp: React.Component | React.ElementType,
+    ChildComp: React.Component | React.ElementType | React.ReactElement,
     mapStoreToProps?: (store: SendbirdUIKitGlobal.SendBirdState) => unknown
-  ): (props: unknown) => React.ReactNode;
+  ): (props: unknown) => React.ReactElement;
   export default withSendbird;
 }
 

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -472,7 +472,7 @@ declare module "SendbirdUIKitGlobal" {
     renderPlaceholderInvalid?: () => React.ReactElement;
     renderPlaceholderEmpty?: () => React.ReactElement;
     renderChannelHeader?: () => React.ReactElement;
-    renderMessage?: (props: RenderMessageProps) => React.ComponentType;
+    renderMessage?: (props: RenderMessageProps) => React.ReactElement;
     renderMessageInput?: () => React.ReactElement;
     renderTypingIndicator?: () => React.ReactElement;
     renderCustomSeperator?: () => React.ReactElement;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -89,13 +89,13 @@ interface SendBirdProviderProps {
   configureSession?: (sdk: SendbirdChat) => SessionHandler;
   customApiHost?: string,
   customWebSocketHost?: string,
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   theme?: 'light' | 'dark';
   nickname?: string;
   profileUrl?: string;
   dateLocale?: Locale;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   allowProfileEdit?: boolean;
   userListQuery?(): UserListQuery;
   config?: SendBirdProviderConfig;
@@ -113,7 +113,7 @@ interface SendBirdProviderProps {
 
 interface SendBirdStateConfig {
   disableUserProfile: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   allowProfileEdit: boolean;
   isOnline: boolean;
   isMentionEnabled: boolean;
@@ -264,7 +264,7 @@ interface AppProps {
   allowProfileEdit?: boolean;
   disableUserProfile?: boolean;
   showSearchIcon?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onProfileEditSuccess?(user: User): void;
   config?: SendBirdProviderConfig;
   isReactionEnabled?: boolean;
@@ -323,9 +323,9 @@ export interface ChannelListProviderProps {
   onChannelSelect?(channel: GroupChannel): void;
   sortChannelList?: (channels: GroupChannel[]) => GroupChannel[];
   queries?: ChannelListQueries;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   className?: string | string[];
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
   disableAutoSelect?: boolean;
   typingChannels?: Array<GroupChannel>;
@@ -354,19 +354,19 @@ interface RenderChannelPreviewProps {
 }
 
 interface ChannelListUIProps {
-  renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactNode;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
-  renderHeader?: (props: void) => React.ReactNode;
-  renderPlaceHolderError?: (props: void) => React.ReactNode;
-  renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-  renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+  renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactElement;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  renderHeader?: (props: void) => React.ReactElement;
+  renderPlaceHolderError?: (props: void) => React.ReactElement;
+  renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+  renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
 }
 
 interface ChannelListProps extends ChannelListProviderInterface, ChannelListUIProps {}
 
 interface ChannelListHeaderInterface {
-  renderHeader?: (props: void) => React.ReactNode;
-  renderIconButton?: (props: void) => React.ReactNode;
+  renderHeader?: (props: void) => React.ReactElement;
+  renderIconButton?: (props: void) => React.ReactElement;
   onEdit?: (props: void) => void;
   allowProfileEdit?: boolean;
 }
@@ -376,7 +376,7 @@ interface ChannelPreviewInterface {
   isActive?: boolean;
   isTyping?: boolean;
   onClick: () => void;
-  renderChannelAction: (props: { channel: GroupChannel }) => React.ReactNode;
+  renderChannelAction: (props: { channel: GroupChannel }) => React.ReactElement;
   tabIndex: number;
 }
 
@@ -397,10 +397,10 @@ interface ChannelSettingsProviderInterface {
 }
 
 interface ChannelSettingsUIProps {
-  renderPlaceholderError?: () => React.ReactNode;
-  renderChannelProfile?: () => React.ReactNode;
-  renderModerationPanel?: () => React.ReactNode;
-  renderLeaveChannel?: () => React.ReactNode;
+  renderPlaceholderError?: () => React.ReactElement;
+  renderChannelProfile?: () => React.ReactElement;
+  renderModerationPanel?: () => React.ReactElement;
+  renderLeaveChannel?: () => React.ReactElement;
 }
 
 interface ApplicationUserListQuery {
@@ -415,14 +415,14 @@ interface ChannelSettingsQueries {
 }
 
 type ChannelSettingsContextProps = {
-  children: React.ReactNode;
+  children: React.ReactElement;
   channelUrl: string;
   className?: string;
   onCloseClick?(): void;
   onChannelModified?(channel: GroupChannel): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): GroupChannelUpdateParams;
   queries?: ChannelSettingsQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
 }
 
@@ -467,9 +467,9 @@ declare module '@sendbird/uikit-react'  {
   export type OpenChannelSettings = React.FunctionComponent<OpenChannelSettingsProps>
   export type MessageSearch = React.FunctionComponent<MessageSearchProps>
   export function withSendBird(
-    ChildComp: React.Component | React.ElementType,
+    ChildComp: React.Component | React.ElementType | React.ReactElement,
     mapStoreToProps?: (store: SendBirdState) => unknown
-  ): (props: unknown) => React.ReactNode;
+  ): (props: unknown) => React.ReactElement;
   export function useSendbirdStateContext(): SendBirdState;
 }
 
@@ -495,9 +495,9 @@ declare module '@sendbird/uikit-react/useSendbirdStateContext' {
 
 declare module '@sendbird/uikit-react/withSendBird' {
   function withSendBird(
-    ChildComp: React.Component | React.ElementType,
+    ChildComp: React.Component | React.ElementType | React.ReactElement,
     mapStoreToProps?: (store: SendBirdState) => unknown
-  ): (props: unknown) => React.ReactNode;
+  ): (props: unknown) => React.ReactElement;
   export default withSendBird;
 }
 
@@ -596,7 +596,7 @@ type ChannelQueries = {
 
 type ChannelContextProps = {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   isReactionEnabled?: boolean;
   isMessageGroupingEnabled?: boolean;
   showSearchIcon?: boolean;
@@ -609,19 +609,19 @@ type ChannelContextProps = {
   onSearchClick?(): void;
   replyType?: ReplyType;
   queries?: ChannelQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
 };
 
 interface ChannelUIProps {
-  renderPlaceholderLoader?: () => React.ReactNode;
-  renderPlaceholderInvalid?: () => React.ReactNode;
-  renderPlaceholderEmpty?: () => React.ReactNode;
-  renderChannelHeader?: () => React.ReactNode;
+  renderPlaceholderLoader?: () => React.ReactElement;
+  renderPlaceholderInvalid?: () => React.ReactElement;
+  renderPlaceholderEmpty?: () => React.ReactElement;
+  renderChannelHeader?: () => React.ReactElement;
   renderMessage?: (props: RenderMessageProps) => React.ComponentType;
-  renderMessageInput?: () => React.ReactNode;
-  renderTypingIndicator?: () => React.ReactNode;
-  renderCustomSeparator?: () => React.ReactNode;
+  renderMessageInput?: () => React.ReactElement;
+  renderTypingIndicator?: () => React.ReactElement;
+  renderCustomSeparator?: () => React.ReactElement;
 }
 
 type CoreMessageType = AdminMessage | UserMessage | FileMessage;
@@ -670,16 +670,16 @@ type MessageUIProps = {
   chainBottom?: boolean;
   handleScroll: () => void;
   // for extending
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-  renderCustomSeparator?: () => React.ReactNode;
-  renderEditInput?: () => React.ReactNode;
-  renderMessageContent?: () => React.ReactNode;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderCustomSeparator?: () => React.ReactElement;
+  renderEditInput?: () => React.ReactElement;
+  renderMessageContent?: () => React.ReactElement;
 };
 
 type MessageListProps = {
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-  renderPlaceholderEmpty?: () => React.ReactNode;
-  renderCustomSeparator?: () => React.ReactNode;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderPlaceholderEmpty?: () => React.ReactElement;
+  renderCustomSeparator?: () => React.ReactElement;
 };
 
 type SuggestedMentionListProps = {
@@ -814,7 +814,7 @@ type OpenChannelQueries = {
 
 interface OpenChannelProviderProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   isMessageGroupingEnabled?: boolean;
   queries?: OpenChannelQueries;
   messageLimit?: number;
@@ -822,7 +822,7 @@ interface OpenChannelProviderProps {
   onBeforeSendFileMessage?(file_: File): FileMessageCreateParams;
   onChatHeaderActionClick?(): void;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
 }
 
 interface OpenChannelMessagesState {
@@ -854,24 +854,24 @@ interface OpenChannelInterface extends OpenChannelProviderProps, OpenChannelMess
 }
 
 interface OpenChannelUIProps {
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-  renderHeader?: () => React.ReactNode;
-  renderInput?: () => React.ReactNode;
-  renderPlaceHolderEmptyList?: () => React.ReactNode;
-  renderPlaceHolderError?: () => React.ReactNode;
-  renderPlaceHolderLoading?: () => React.ReactNode;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderHeader?: () => React.ReactElement;
+  renderInput?: () => React.ReactElement;
+  renderPlaceHolderEmptyList?: () => React.ReactElement;
+  renderPlaceHolderError?: () => React.ReactElement;
+  renderPlaceHolderLoading?: () => React.ReactElement;
 }
 
 interface OpenChannelProps extends OpenChannelProviderProps, OpenChannelUIProps {
 }
 
 type OpenchannelMessageListProps = {
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-  renderPlaceHolderEmptyList?: () => React.ReactNode;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderPlaceHolderEmptyList?: () => React.ReactElement;
 }
 
 type OpenChannelMessageProps = {
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   message: EveryMessage;
   chainTop?: boolean;
   chainBottom?: boolean;
@@ -923,18 +923,18 @@ declare module '@sendbird/uikit-react/OpenChannel/components/OpenChannelUI' {
 
 interface OpenChannelSettingsContextProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCloseClick?(): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): OpenChannelUpdateParams;
   onChannelModified?(channel: OpenChannel): void;
   onDeleteChannel?(channel: OpenChannel): void;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
 }
 
 interface OpenChannelSettingsUIProps {
-  renderOperatorUI?: () => React.ReactNode;
-  renderParticipantList?: () => React.ReactNode;
+  renderOperatorUI?: () => React.ReactElement;
+  renderParticipantList?: () => React.ReactElement;
 }
 
 interface OpenChannelSettingsProps extends OpenChannelSettingsContextProps, OpenChannelSettingsUIProps {
@@ -947,7 +947,7 @@ interface OpenChannelSettingsContextType extends OpenChannelSettingsContextProps
 }
 
 interface OperatorUIProps {
-  renderChannelProfile?: () => React.ReactNode;
+  renderChannelProfile?: () => React.ReactElement;
 }
 
 interface OpenChannelEditDetailsProps {
@@ -986,7 +986,7 @@ declare module '@sendbird/uikit-react/OpenChannelSettings/components/Participant
 
 export interface MessageSearchProviderProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   searchString?: string;
   requestString?: string;
   messageSearchQuery?: MessageSearchQuery;
@@ -1021,10 +1021,10 @@ interface MessageSearchProviderInterface extends MessageSearchProviderProps {
 }
 
 interface MessageSearchUIProps {
-  renderPlaceHolderError?: (props: void) => React.ReactNode;
-  renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-  renderPlaceHolderNoString?: (props: void) => React.ReactNode;
-  renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+  renderPlaceHolderError?: (props: void) => React.ReactElement;
+  renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+  renderPlaceHolderNoString?: (props: void) => React.ReactElement;
+  renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
   renderSearchItem?(
     {
       message,
@@ -1056,7 +1056,7 @@ declare module '@sendbird/uikit-react/MessageSearch/components/MessageSearchUI' 
 }
 
 interface CreateChannelProviderProps {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCreateChannel(channel: GroupChannel): void;
   onBeforeCreateChannel?(users: Array<string>): GroupChannelCreateParams;
   userListQuery?(): UserListQuery;
@@ -1077,7 +1077,7 @@ interface CreateChannelContextInterface {
 
 interface CreateChannelUIProps {
   onCancel?(): void;
-  renderStepOne?:(props: void) => React.ReactNode;
+  renderStepOne?:(props: void) => React.ReactElement;
 }
 
 interface CreateChannelProps extends CreateChannelProviderProps, CreateChannelUIProps {}
@@ -1116,7 +1116,7 @@ declare module '@sendbird/uikit-react/CreateChannel/components/SelectChannelType
 }
 
 interface EditUserProfileProps {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCancel?(): void;
   onThemeChange?(theme: string): void;
   onEditProfile?(updatedUser: User): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -618,7 +618,7 @@ interface ChannelUIProps {
   renderPlaceholderInvalid?: () => React.ReactElement;
   renderPlaceholderEmpty?: () => React.ReactElement;
   renderChannelHeader?: () => React.ReactElement;
-  renderMessage?: (props: RenderMessageProps) => React.ComponentType;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderTypingIndicator?: () => React.ReactElement;
   renderCustomSeparator?: () => React.ReactElement;

--- a/src/lib/LocalizationContext.tsx
+++ b/src/lib/LocalizationContext.tsx
@@ -12,10 +12,10 @@ const LocalizationContext = React.createContext({
 interface LocalizationProviderProps {
   stringSet: Record<string, string>;
   dateLocale: Locale;
-  children: React.Component;
+  children: React.ReactElement;
 }
 
-const LocalizationProvider = (props: LocalizationProviderProps): React.ReactNode => {
+const LocalizationProvider = (props: LocalizationProviderProps): React.ReactElement => {
   const { children } = props;
   return (
     <LocalizationContext.Provider value={props}>

--- a/src/lib/SendbirdState.tsx
+++ b/src/lib/SendbirdState.tsx
@@ -32,7 +32,7 @@ export enum SendbirdUIKitThemes {
 
 interface SendBirdStateConfig {
   disableUserProfile: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   allowProfileEdit: boolean;
   isOnline: boolean;
   userId: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,13 +27,13 @@ export interface SendBirdProviderProps {
   userId: string;
   appId: string;
   accessToken?: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   theme?: 'light' | 'dark';
   nickname?: string;
   profileUrl?: string;
   dateLocale?: Locale;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: SendBirdTypes.RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: SendBirdTypes.RenderUserProfileProps) => React.ReactElement;
   allowProfileEdit?: boolean;
   userListQuery?(): SendBirdTypes.UserListQuery;
   config?: SendBirdTypes.SendBirdProviderConfig;
@@ -51,7 +51,7 @@ export interface SendBirdProviderProps {
 
 export interface SendBirdStateConfig {
   disableUserProfile: boolean;
-  renderUserProfile?: (props: SendBirdTypes.RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: SendBirdTypes.RenderUserProfileProps) => React.ReactElement;
   allowProfileEdit: boolean;
   isOnline: boolean;
   userId: string;

--- a/src/smart-components/App/types.ts
+++ b/src/smart-components/App/types.ts
@@ -22,7 +22,7 @@ export default interface AppProps {
   allowProfileEdit?: boolean;
   disableUserProfile?: boolean;
   showSearchIcon?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onProfileEditSuccess?(user: User): void;
   config?: SendBirdProviderConfig;
   isReactionEnabled?: boolean;

--- a/src/smart-components/Channel/components/ChannelUI/index.tsx
+++ b/src/smart-components/Channel/components/ChannelUI/index.tsx
@@ -16,14 +16,14 @@ import { RenderMessageProps } from '../../../../types';
 import * as messageActionTypes from '../../context/dux/actionTypes';
 
 export interface ChannelUIProps {
-  renderPlaceholderLoader?: () => React.ReactNode;
-  renderPlaceholderInvalid?: () => React.ReactNode;
-  renderPlaceholderEmpty?: () => React.ReactNode;
-  renderChannelHeader?: () => React.ReactNode;
-  renderMessage?: (props: RenderMessageProps) => React.ReactNode;
-  renderMessageInput?: () => React.ReactNode;
-  renderTypingIndicator?: () => React.ReactNode;
-  renderCustomSeparator?: () => React.ReactNode;
+  renderPlaceholderLoader?: () => React.ReactElement;
+  renderPlaceholderInvalid?: () => React.ReactElement;
+  renderPlaceholderEmpty?: () => React.ReactElement;
+  renderChannelHeader?: () => React.ReactElement;
+  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessageInput?: () => React.ReactElement;
+  renderTypingIndicator?: () => React.ReactElement;
+  renderCustomSeparator?: () => React.ReactElement;
 }
 
 const ChannelUI: React.FC<ChannelUIProps> = ({

--- a/src/smart-components/Channel/context/ChannelProvider.tsx
+++ b/src/smart-components/Channel/context/ChannelProvider.tsx
@@ -67,7 +67,7 @@ export type ChannelQueries = {
 };
 
 export type ChannelContextProps = {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   channelUrl: string;
   isReactionEnabled?: boolean;
   isMessageGroupingEnabled?: boolean;
@@ -81,7 +81,7 @@ export type ChannelContextProps = {
   onSearchClick?(): void;
   replyType?: ReplyType;
   queries?: ChannelQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
 };
 

--- a/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
@@ -9,8 +9,8 @@ import './index.scss';
 import Avatar from '../../../../ui/Avatar';
 
 interface ChannelListHeaderInterface {
-  renderHeader?: (props: void) => React.ReactNode;
-  renderIconButton?: (props: void) => React.ReactNode;
+  renderHeader?: (props: void) => React.ReactElement;
+  renderIconButton?: (props: void) => React.ReactElement;
   onEdit?: (props: void) => void;
   allowProfileEdit?: boolean;
 }

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -32,12 +32,12 @@ interface RenderUserProfileProps {
 }
 
 export interface ChannelListUIProps {
-  renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactNode;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
-  renderHeader?: (props: void) => React.ReactNode;
-  renderPlaceHolderError?: (props: void) => React.ReactNode;
-  renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-  renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+  renderChannelPreview?: (props: RenderChannelPreviewProps) => React.ReactElement;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  renderHeader?: (props: void) => React.ReactElement;
+  renderPlaceHolderError?: (props: void) => React.ReactElement;
+  renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+  renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
 }
 
 const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) => {

--- a/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelPreview/index.tsx
@@ -24,7 +24,7 @@ interface ChannelPreviewInterface {
   isActive?: boolean;
   isTyping?: boolean;
   onClick: () => void;
-  renderChannelAction: (props: { channel: GroupChannel }) => React.ReactNode;
+  renderChannelAction: (props: { channel: GroupChannel }) => React.ReactElement;
   tabIndex: number;
 }
 

--- a/src/smart-components/ChannelList/context/ChannelListProvider.tsx
+++ b/src/smart-components/ChannelList/context/ChannelListProvider.tsx
@@ -73,9 +73,9 @@ export interface ChannelListProviderProps {
   onChannelSelect?(channel: GroupChannel): void;
   sortChannelList?: (channels: GroupChannel[]) => GroupChannel[];
   queries?: ChannelListQueries;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   className?: string | string[];
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
   disableAutoSelect?: boolean;
   typingChannels?: Array<GroupChannel>;

--- a/src/smart-components/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/smart-components/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -16,10 +16,10 @@ import LeaveChannelModal from '../LeaveChannel';
 import UserPanel from '../UserPanel';
 
 export interface ChannelSettingsUIProps {
-  renderPlaceholderError?: () => React.ReactNode;
-  renderChannelProfile?: () => React.ReactNode;
-  renderModerationPanel?: () => React.ReactNode;
-  renderLeaveChannel?: () => React.ReactNode;
+  renderPlaceholderError?: () => React.ReactElement;
+  renderChannelProfile?: () => React.ReactElement;
+  renderModerationPanel?: () => React.ReactElement;
+  renderLeaveChannel?: () => React.ReactElement;
 }
 
 const ChannelSettingsUI: React.FC<ChannelSettingsUIProps> = (props: ChannelSettingsUIProps) => {

--- a/src/smart-components/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/smart-components/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -26,14 +26,14 @@ interface ChannelSettingsQueries {
 }
 
 export type ChannelSettingsContextProps = {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   channelUrl: string;
   className?: string;
   onCloseClick?(): void;
   onChannelModified?(channel: GroupChannel): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): GroupChannelUpdateParams;
   queries?: ChannelSettingsQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   disableUserProfile?: boolean;
 }
 

--- a/src/smart-components/CreateChannel/components/CreateChannelUI/index.tsx
+++ b/src/smart-components/CreateChannel/components/CreateChannelUI/index.tsx
@@ -7,7 +7,7 @@ import SelectChannelType from '../SelectChannelType';
 
 export interface CreateChannelUIProps {
   onCancel?(): void;
-  renderStepOne?:(props: void) => React.ReactNode;
+  renderStepOne?:(props: void) => React.ReactElement;
 }
 
 const CreateChannel: React.FC<CreateChannelUIProps> = (props: CreateChannelUIProps) => {

--- a/src/smart-components/CreateChannel/context/CreateChannelProvider.tsx
+++ b/src/smart-components/CreateChannel/context/CreateChannelProvider.tsx
@@ -18,7 +18,7 @@ export interface UserListQuery {
 }
 
 export interface CreateChannelProviderProps {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCreateChannel(channel: GroupChannel): void;
   onBeforeCreateChannel?(users: Array<string>): GroupChannelCreateParams;
   userListQuery?(): UserListQuery;

--- a/src/smart-components/EditUserProfile/context/EditUserProfIleProvider.tsx
+++ b/src/smart-components/EditUserProfile/context/EditUserProfIleProvider.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react';
 const EditUserProfileProviderContext = React.createContext(undefined);
 
 export interface EditUserProfileProps {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCancel?(): void;
   onThemeChange?(theme: string): void;
   onEditProfile?(updatedUser: User): void;

--- a/src/smart-components/MessageSearch/components/MessageSearchUI/index.tsx
+++ b/src/smart-components/MessageSearch/components/MessageSearchUI/index.tsx
@@ -14,10 +14,10 @@ import { ClientSentMessages } from '../../../../types';
 const COMPONENT_CLASS_NAME = 'sendbird-message-search';
 
 export interface MessageSearchUIProps {
-  renderPlaceHolderError?: (props: void) => React.ReactNode;
-  renderPlaceHolderLoading?: (props: void) => React.ReactNode;
-  renderPlaceHolderNoString?: (props: void) => React.ReactNode;
-  renderPlaceHolderEmptyList?: (props: void) => React.ReactNode;
+  renderPlaceHolderError?: (props: void) => React.ReactElement;
+  renderPlaceHolderLoading?: (props: void) => React.ReactElement;
+  renderPlaceHolderNoString?: (props: void) => React.ReactElement;
+  renderPlaceHolderEmptyList?: (props: void) => React.ReactElement;
   renderSearchItem?(
     {
       message,

--- a/src/smart-components/MessageSearch/context/MessageSearchProvider.tsx
+++ b/src/smart-components/MessageSearch/context/MessageSearchProvider.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useReducer,
 } from 'react';
+import { SendbirdError } from '@sendbird/chat';
 import type { MessageSearchQuery } from '@sendbird/chat/message';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { MessageSearchQueryParams } from '@sendbird/chat/lib/__definition';
@@ -23,11 +24,11 @@ import useSearchStringEffect from './hooks/useSearchStringEffect';
 
 export interface MessageSearchProviderProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   searchString?: string;
   requestString?: string;
   messageSearchQuery?: MessageSearchQueryParams;
-  onResultLoaded?(messages?: Array<ClientSentMessages>, error?: SendBird.SendBirdError): void;
+  onResultLoaded?(messages?: Array<ClientSentMessages>, error?: SendbirdError): void;
   onResultClick?(message: ClientSentMessages): void;
 }
 

--- a/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
+++ b/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
@@ -1,12 +1,11 @@
 import { useEffect } from 'react';
 
 import type { GroupChannel, SendbirdGroupChat } from '@sendbird/chat/groupChannel';
-import type { MessageSearchQueryParams } from '@sendbird/chat/lib/__definition';
+import { MessageSearchOrder, MessageSearchQueryParams } from '@sendbird/chat/lib/__definition';
 import type {
   AdminMessage,
   BaseMessage,
   FileMessage,
-  MessageSearchQuery,
   UserMessage,
 } from '@sendbird/chat/message';
 import type { SendbirdError } from '@sendbird/chat';
@@ -18,7 +17,7 @@ interface MainProps {
   currentChannel: GroupChannel;
   channelUrl: string;
   requestString?: string;
-  messageSearchQuery?: MessageSearchQuery;
+  messageSearchQuery?: MessageSearchQueryParams;
   onResultLoaded?: (
     messages?: Array<BaseMessage | UserMessage | FileMessage | AdminMessage>,
     error?: SendbirdError,
@@ -44,7 +43,7 @@ function useGetSearchedMessages(
       if (requestString) {
         const inputSearchMessageQueryObject: MessageSearchQueryParams = {
           ...messageSearchQuery,
-          order: 'ts' as const,
+          order: MessageSearchOrder.TIMESTAMP,
           channelUrl,
           messageTimestampFrom: currentChannel.invitedAt,
           keyword: requestString,

--- a/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
+++ b/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
@@ -56,7 +56,7 @@ type OpenChannelQueries = {
 
 export interface OpenChannelProviderProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   isMessageGroupingEnabled?: boolean;
   queries?: OpenChannelQueries;
   messageLimit?: number;
@@ -64,7 +64,7 @@ export interface OpenChannelProviderProps {
   onBeforeSendFileMessage?(file_: File): FileMessageCreateParams;
   onChatHeaderActionClick?(): void;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
 }
 
 

--- a/src/smart-components/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
+++ b/src/smart-components/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
@@ -14,8 +14,8 @@ import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import Icon, { IconTypes } from '../../../../ui/Icon';
 
 export interface OpenChannelUIProps {
-  renderOperatorUI?: () => React.ReactNode;
-  renderParticipantList?: () => React.ReactNode;
+  renderOperatorUI?: () => React.ReactElement;
+  renderParticipantList?: () => React.ReactElement;
 }
 
 const OpenChannelUI: React.FC<OpenChannelUIProps> = ({

--- a/src/smart-components/OpenChannelSettings/components/OperatorUI/index.tsx
+++ b/src/smart-components/OpenChannelSettings/components/OperatorUI/index.tsx
@@ -43,7 +43,7 @@ export const copyToClipboard = (text: string): boolean => {
 };
 
 export interface OperatorUIProps {
-  renderChannelProfile?: () => React.ReactNode;
+  renderChannelProfile?: () => React.ReactElement;
 }
 
 export const OperatorUI: React.FC<OperatorUIProps> = ({

--- a/src/smart-components/OpenChannelSettings/context/OpenChannelSettingsProvider.tsx
+++ b/src/smart-components/OpenChannelSettings/context/OpenChannelSettingsProvider.tsx
@@ -11,13 +11,13 @@ import uuidv4 from '../../../utils/uuid';
 
 export interface OpenChannelSettingsContextProps {
   channelUrl: string;
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   onCloseClick?(): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): OpenChannelUpdateParams;
   onChannelModified?(channel: OpenChannel): void;
   onDeleteChannel?(channel: OpenChannel): void;
   disableUserProfile?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactNode;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
 }
 
 interface OpenChannelSettingsContextType {

--- a/src/ui/LegacyEditUserProfile/index.tsx
+++ b/src/ui/LegacyEditUserProfile/index.tsx
@@ -177,6 +177,6 @@ interface ConnectedEditUserProfileProps {
 
 const ConnectedEditUserProfile: (
   props: ConnectedEditUserProfileProps
-) => React.Component = withSendbirdContext(EditUserProfile, mapStoreToProps);
+) => React.ReactElement = withSendbirdContext(EditUserProfile, mapStoreToProps);
 
 export default ConnectedEditUserProfile;


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2053](https://sendbird.atlassian.net/browse/UIKIT-2053)

## Description Of Changes

* Change every `React.ReactNode` and `React.Component` to `React.ReactElement`
* Use the type of SendbirdError
* Use the type MessageSearchQueryParams
* Use enum MessageSearchOrder.TIMESTAMP in the message search query params instead of `'ts' as const`

**ReactNode** could be `string | number | null | undefined | ReactElement | portal` and this(expecting string or number) causes **warning** when we use it like `<CustomComp />`
```typescript
// in the component
{ renderMessage } = props
const CustomMessage = useMemo(() => {
  return renderMessage({ ... });
}, []);
return (
  <div>
    <CustomMessage />
  </div>
);
```
so expecting **ReactElement** is better for our case

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
