### PR TITLE
[v3.1.2] (Aug 31 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog - v3
 
+## [v3.1.2] (Aug 31 2022)
+
+* Migrate UI components into TypeScript
+  This doesnt affect anyone, it a step in task to migrate the project source code into TS
+
+Fixes:
+* Type defn: Change type of react elements to `React.ReactElement`
+  * Change every `React.ReactNode` and `React.Component` to `React.ReactElement`
+  * Use the type of SendbirdError
+  * Use the type MessageSearchQueryParams
+  * Use enum MessageSearchOrder.TIMESTAMP in the message search query params instead of `'ts' as const`
+
+  **ReactNode** could be `string | number | null | undefined | ReactElement | portal` and this(expecting string or number) causes **warning** when we use it like `<CustomComp />`
+  ```typescript
+  // in the component
+  { renderMessage } = props
+  const CustomMessage = useMemo(() => {
+    return renderMessage({ ... });
+  }, []);
+  return (
+    <div>
+      <CustomMessage />
+    </div>
+  );
+  ```
+  so expecting **ReactElement** is better for our case
+* Fix message grouping:
+  Set isMessageGroupingEnabed to true(was set to false during v2 migration)
+
 ## [v3.1.1] (Aug 17 2022)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Migrate UI components into TypeScript
  This doesnt affect anyone, it a step in task to migrate the project source code into TS

Fixes:
* Type defn: Change type of react elements to `React.ReactElement`
  * Change every `React.ReactNode` and `React.Component` to `React.ReactElement`
  * Use the type of SendbirdError
  * Use the type MessageSearchQueryParams
  * Use enum MessageSearchOrder.TIMESTAMP in the message search query params instead of `'ts' as const`

  **ReactNode** could be `string | number | null | undefined | ReactElement | portal` and this(expecting string or number) causes **warning** when we use it like `<CustomComp />`
  ```typescript
  // in the component
  { renderMessage } = props
  const CustomMessage = useMemo(() => {
    return renderMessage({ ... });
  }, []);
  return (
    <div>
      <CustomMessage />
    </div>
  );
  ```
  so expecting **ReactElement** is better for our case
* Fix message grouping:
  Set isMessageGroupingEnabed to true(was set to false during v2 migration)

https://sendbird.atlassian.net/browse/SDKRLSD-466
