### PR TITLE
fix: Declare MessageSearchOrder in MessageSearch

### DIFF
--- a/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
+++ b/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import type { GroupChannel, SendbirdGroupChat } from '@sendbird/chat/groupChannel';
-import { MessageSearchOrder, MessageSearchQueryParams } from '@sendbird/chat/lib/__definition';
+import type { MessageSearchQueryParams } from '@sendbird/chat/lib/__definition';
 import type {
   AdminMessage,
   BaseMessage,
@@ -12,6 +12,11 @@ import type { SendbirdError } from '@sendbird/chat';
 
 import type { Logger } from '../../../../lib/SendbirdState';
 import * as messageActionTypes from '../dux/actionTypes';
+
+enum MessageSearchOrder {
+  SCORE = 'score',
+  TIMESTAMP = 'ts',
+}
 
 interface MainProps {
   currentChannel: GroupChannel;


### PR DESCRIPTION
MessageSearchOrder is an enum, which cannot be imported from
`@sendbird/chat/lib/__definition`
Todo: tell chat team to export it through @sendbird/chat
