### PR TITLE
feat: allow customers to use rem units for typography

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -77,7 +77,7 @@ declare module "SendbirdUIKitGlobal" {
       maxMentionCount?: number,
       maxSuggestionCount?: number,
     };
-    useRemFontUnit?: boolean;
+    isREMUnitEnabled?: boolean;
   }
 
   export interface ClientMessage {

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -77,6 +77,7 @@ declare module "SendbirdUIKitGlobal" {
       maxMentionCount?: number,
       maxSuggestionCount?: number,
     };
+    useRemFontUnit?: boolean;
   }
 
   export interface ClientMessage {

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -55,7 +55,6 @@ export default function Sendbird(props) {
     userMention = {},
     isREMUnitEnabled = false,
   } = config;
-  console.warn({ config, isREMUnitEnabled });
   const [logger, setLogger] = useState(LoggerFactory(logLevel));
   const [pubSub, setPubSub] = useState();
   const [sdkStore, sdkDispatcher] = useReducer(sdkReducers, sdkInitialState);

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -1,4 +1,5 @@
 import './index.scss';
+import './__experimental__typography.scss';
 
 import React, { useEffect, useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
@@ -52,6 +53,7 @@ export default function Sendbird(props) {
   const {
     logLevel = '',
     userMention = {},
+    useRemFontUnit = false,
   } = config;
   const [logger, setLogger] = useState(LoggerFactory(logLevel));
   const [pubSub, setPubSub] = useState();
@@ -94,6 +96,7 @@ export default function Sendbird(props) {
     'sendbird-modal-root',
     'sendbird-dropdown-portal',
     'sendbird-emoji-list-portal',
+    useRemFontUnit ? 'sendbird-experimental__rem__units' : '',
   ], 'body');
 
   // should move to reducer
@@ -228,6 +231,7 @@ Sendbird.propTypes = {
       maxMentionCount: PropTypes.number,
       maxSuggestionCount: PropTypes.number,
     }),
+    useRemFontUnit: PropTypes.bool,
   }),
   stringSet: PropTypes.objectOf(PropTypes.string),
   colorSet: PropTypes.objectOf(PropTypes.string),

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -53,8 +53,9 @@ export default function Sendbird(props) {
   const {
     logLevel = '',
     userMention = {},
-    useRemFontUnit = false,
+    isREMUnitEnabled = false,
   } = config;
+  console.warn({ config, isREMUnitEnabled });
   const [logger, setLogger] = useState(LoggerFactory(logLevel));
   const [pubSub, setPubSub] = useState();
   const [sdkStore, sdkDispatcher] = useReducer(sdkReducers, sdkInitialState);
@@ -96,7 +97,6 @@ export default function Sendbird(props) {
     'sendbird-modal-root',
     'sendbird-dropdown-portal',
     'sendbird-emoji-list-portal',
-    useRemFontUnit ? 'sendbird-experimental__rem__units' : '',
   ], 'body');
 
   // should move to reducer
@@ -104,6 +104,14 @@ export default function Sendbird(props) {
   useEffect(() => {
     setCurrenttheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    const body = document.querySelector('body');
+    body.classList.remove('sendbird-experimental__rem__units');
+    if (isREMUnitEnabled) {
+      body.classList.add('sendbird-experimental__rem__units');
+    }
+  }, [isREMUnitEnabled]);
   // add-remove theme from body
   useEffect(() => {
     logger.info('Setup theme', `Theme: ${currenttheme}`);
@@ -231,7 +239,7 @@ Sendbird.propTypes = {
       maxMentionCount: PropTypes.number,
       maxSuggestionCount: PropTypes.number,
     }),
-    useRemFontUnit: PropTypes.bool,
+    isREMUnitEnabled: PropTypes.bool,
   }),
   stringSet: PropTypes.objectOf(PropTypes.string),
   colorSet: PropTypes.objectOf(PropTypes.string),

--- a/src/lib/__experimental__typography.scss
+++ b/src/lib/__experimental__typography.scss
@@ -1,0 +1,110 @@
+// We are tyring to move font size into "rem" units for accesibility
+// todo: make this default in @sendbird/uikit@v4
+
+// assuming <html>@fontsize = 16px
+//  about rem https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/#rems
+.sendbird-experimental__rem__units {
+  // typography
+  .sendbird-label--h-1 {
+    font-size: 1.25rem;
+  }
+
+  .sendbird-label--h-2 {
+    font-size: 1.125rem;
+  }
+
+  .sendbird-label--subtitle-1 {
+    font-size: 1rem;
+  }
+
+  .sendbird-label--subtitle-2 {
+    font-size: .875rem;
+  }
+
+  .sendbird-label--body-1 {
+   font-size: .875rem;
+  }
+
+  .sendbird-label--body-2 {
+    font-size: .75rem;
+  }
+
+  .sendbird-label--button-1 {
+    font-size: .875rem;
+  }
+
+  .sendbird-label--button-2 {
+    font-size: .875rem;
+  }
+
+  .sendbird-label--caption-1 {
+   font-size: .875rem;
+  }
+
+  .sendbird-label--caption-2 {
+   font-size: .75rem;
+  }
+
+  .sendbird-label--caption-3 {
+    font-size: .75rem;
+  }
+
+  // message search
+  .sendbird-message-search-pannel {
+    .sendbird-message-search-pannel__input__container__input-area {
+      font-size: .875rem;
+    }
+  }
+
+  // checkbox
+  .sendbird-checkbox {
+    font-size: 1.375rem;
+  }
+
+  .sendbird-mention-user-label {
+    font-size: .875rem;
+    &.purple {
+      font-size: 1.125rem;
+    }
+  }
+
+  // message input
+  .sendbird-message-input {
+    .sendbird-message-input--textarea,
+    .sendbird-message-input--placeholder {
+      font-size: .875rem;
+    }
+  }
+
+  // input
+  .sendbird-input {
+    .sendbird-input__input,
+    .sendbird-input__placeholder {
+      font-size: .875rem;
+    }
+  }
+
+  // tooltip
+  .sendbird-tooltip {
+    &__text {
+      font-size: .75rem;
+    }
+  }
+
+  // quote-message
+  .sendbird-quote-message {
+    .sendbird-quote-message__replied-to {
+      .sendbird-quote-message__replied-to__text {
+        font-size: .75rem;
+      }
+    }
+    .sendbird-quote-message__replied-message {
+      .sendbird-quote-message__replied-message__text-message {
+        font-size: .75rem;
+      }
+    }
+    .sendbird-quote-message__replied-message__file-message {
+      font-size: .75rem;
+    }
+  }
+}

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -173,7 +173,7 @@ App.propTypes = {
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
     ]),
-    useRemFontUnit: PropTypes.bool,
+    isREMUnitEnabled: PropTypes.bool,
   }),
   isReactionEnabled: PropTypes.bool,
   replyType: PropTypes.oneOf(['NONE', 'QUOTE_REPLY', 'THREAD']),

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -173,6 +173,7 @@ App.propTypes = {
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
     ]),
+    useRemFontUnit: PropTypes.bool,
   }),
   isReactionEnabled: PropTypes.bool,
   replyType: PropTypes.oneOf(['NONE', 'QUOTE_REPLY', 'THREAD']),

--- a/src/smart-components/App/stories/index.stories.js
+++ b/src/smart-components/App/stories/index.stories.js
@@ -53,7 +53,7 @@ export const basicSDK = () => fitPageSize(
     isReactionEnabled
     isTypingIndicatorEnabledOnChannelList
     isMessageReceiptStatusEnabledOnChannelList
-    /*config={{ logLevel: 'all' }}*/
+    config={{ logLevel: 'all', isREMUnitEnabled: true }}
   />
 );
 
@@ -65,7 +65,7 @@ export const darkTheme = () => fitPageSize(
     theme="dark"
     showSearchIcon
     replyType="QUOTE_REPLY"
-    config={{ logLevel: 'all' }}
+    config={{ logLevel: 'all', isREMUnitEnabled: true }}
     isMentionEnabled
     isTypingIndicatorEnabledOnChannelList
     isMessageReceiptStatusEnabledOnChannelList

--- a/src/smart-components/MessageSearch/index.scss
+++ b/src/smart-components/MessageSearch/index.scss
@@ -11,6 +11,22 @@
     background-color: t(bg-0);
   }
 
+  .sendbird-message-search-pannel__input__container__input-area {
+    position: absolute;
+    top: 14px;
+    left: 48px;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
+    outline: none;
+    font-size: 14px;
+    width: calc(100% - 90px);
+    @include themed() {
+      color: t(on-bg-1);
+      background-color: t(bg-0);
+    }
+  }
+
   .sendbird-message-search-pannel__header {
     position: relative;
     display: flex;
@@ -58,21 +74,6 @@
         position: absolute;
         top: 10px;
         left: 16px;
-      }
-      .sendbird-message-search-pannel__input__container__input-area {
-        position: absolute;
-        top: 14px;
-        left: 48px;
-        margin: 0px;
-        padding: 0px;
-        border: 0px;
-        outline: none;
-        font-size: 14px;
-        width: calc(100% - 90px);
-        @include themed() {
-          color: t(on-bg-1);
-          background-color: t(bg-0);
-        }
       }
       .sendbird-message-search-pannel__input__container__spinner {
         position: absolute;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,6 +25,7 @@ export interface SendBirdProviderConfig {
     maxMentionCount?: number,
     maxSuggestionCount?: number,
   };
+  useRemFontUnit?: boolean;
 }
 
 export interface ClientMessage {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,7 +25,7 @@ export interface SendBirdProviderConfig {
     maxMentionCount?: number,
     maxSuggestionCount?: number,
   };
-  useRemFontUnit?: boolean;
+  isREMUnitEnabled?: boolean;
 }
 
 export interface ClientMessage {

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -71,7 +71,6 @@ const MessageInput = React.forwardRef((props, ref) => {
   const [isInput, setIsInput] = useState(false);
   const [mentionedUserIds, setMentionedUserIds] = useState([]);
   const [targetStringInfo, setTargetStringInfo] = useState({ ...initialTargetStringInfo });
-
   const setHeight = useMemo(() => (
     () => {
       try {


### PR DESCRIPTION
Rem is better unit for accessibility support/mobile
So, we are adding rem as unit for typography/font size
We expect font-size 16px as base font-size, but to avoid breaking change,
customers should pass `config.isREMUnitEnabled` prop to `SendbirdProvider` to use "rem" units

ticket: https://sendbird.atlassian.net/browse/UIKIT-2176