### PR TITLE
fix: export SessionHandler through UIKit

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -16,6 +16,7 @@ export default {
   'handlers/GroupChannelHandler': 'src/lib/handlers/GroupChannelHandler.ts',
   'handlers/OpenChannelHandler': 'src/lib/handlers/OpenChannelHandler.ts',
   'handlers/UserEventHandler': 'src/lib/handlers/UserEventHandler.ts',
+  'handlers/SessionHandler': 'src/lib/handlers/SessionHandler.ts',
 
   // ChannelList
   ChannelList: 'src/smart-components/ChannelList/index.tsx',

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -870,6 +870,10 @@ declare module '@sendbird/uikit-react/handlers/ConnectionHandler' {
   import { ConnectionHandler } from '@sendbird/chat';
   export default ConnectionHandler;
 }
+declare module '@sendbird/uikit-react/handlers/SessionHandler' {
+  import { SessionHandler } from '@sendbird/chat';
+  export default SessionHandler;
+}
 declare module '@sendbird/uikit-react/handlers/GroupChannelHandler' {
   import { GroupChannelHandler } from '@sendbird/chat/groupChannel';
   export default GroupChannelHandler;

--- a/src/lib/handlers/SessionHandler.ts
+++ b/src/lib/handlers/SessionHandler.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns the instance of SessionHandler
+ */
+import { SessionHandler } from "@sendbird/chat";
+
+export default SessionHandler;


### PR DESCRIPTION
SessionHandler cannot be used by importing directly via `@sendbird/chat`