### PR TITLE
[v3.1.3] (Sep 16 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog - v3
 
+## [v3.1.3] (Sep 18 2022)
+
+Features:
+* Export SessionHandler through `@sendbird/uikit-react/handlers/SessionHandler`
+  * This is a workaround to fix an issue where inhertiance chains break custom handler implementation
+  * `import SessionHandler from '@sendbird/uikit-react/handlers/SessionHandler'`
+* Rem units can be used for typography
+  * Pass prop `config.isREMUnitEnabled` -> true on SendbirdProvider
+    to use "rem" units
+  * We are adding rem as unit for typography/font size
+
+Fixes:
+* Fix the position of ContextMenu
+* Do not exit the current open channel when the channel state is changed
+* Add the message as a parameter of renderCustomSeparator
+  * before: renderCustomSeparator={() => ReactElement}
+  * after: renderCustomSeparator={(props: { message }) => ReactElement}
+* Fix typo on the type
+  * renderCustomSep'e'rator to renderCustomSep'a'rator
+
 ## [v3.1.2] (Aug 31 2022)
 
 * Migrate UI components into TypeScript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -1443,6 +1443,7 @@ declare module '@sendbird/uikit-react/ui/FileMessageItemBody' {
     message: FileMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
   }
   const FileMessageItemBody: React.FC<FileMessageItemBodyProps>;
   export default FileMessageItemBody;
@@ -1736,6 +1737,8 @@ declare module '@sendbird/uikit-react/ui/OGMessageItemBody' {
     message: UserMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isMentionEnabled?: boolean;
+    isReactionEnabled?: boolean;
   }
   const OGMessageItemBody: React.FC<OGMessageItemBodyProps>;
   export default OGMessageItemBody;
@@ -1932,6 +1935,8 @@ declare module '@sendbird/uikit-react/ui/TextMessageItemBody' {
     message: UserMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isMentionEnabled?: boolean;
+    isReactionEnabled?: boolean;
   }
   const TextMessageItemBody: React.FC<TextMessageItemBodyProps>;
   export default TextMessageItemBody;
@@ -1944,6 +1949,7 @@ declare module '@sendbird/uikit-react/ui/ThumbnailMessageItemBody' {
     message: FileMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
     showFileViewer?: (bool: boolean) => void;
   }
   const ThumbnailMessageItemBody: React.FC<ThumbnailMessageItemBodyProps>;
@@ -1976,6 +1982,7 @@ declare module '@sendbird/uikit-react/ui/UnknownMessageItemBody' {
     isByMe?: boolean;
     message: SendbirdUIKitGlobal.CoreMessageType;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
   }
   const UnknownMessageItemBody: React.FC<UnknownMessageItemBodyProps>;
   export default UnknownMessageItemBody;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1353,6 +1353,7 @@ declare module '@sendbird/uikit-react/ui/FileMessageItemBody' {
     message: FileMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
   }
   type FileMessageItemBody = React.FC<FileMessageItemBodyProps>;
   export default FileMessageItemBody;
@@ -1614,6 +1615,8 @@ declare module '@sendbird/uikit-react/ui/OGMessageItemBody' {
     message: UserMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isMentionEnabled?: boolean;
+    isReactionEnabled?: boolean;
   }
   type OGMessageItemBody = React.FC<OGMessageItemBodyProps>;
   export default OGMessageItemBody;
@@ -1814,6 +1817,8 @@ declare module '@sendbird/uikit-react/ui/TextMessageItemBody' {
     message: UserMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isMentionEnabled?: boolean;
+    isReactionEnabled?: boolean;
   }
   type TextMessageItemBody = React.FC<TextMessageItemBodyProps>;
   export default TextMessageItemBody;
@@ -1826,6 +1831,7 @@ declare module '@sendbird/uikit-react/ui/ThumbnailMessageItemBody' {
     message: FileMessage;
     isByMe?: boolean;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
     showFileViewer?: (bool: boolean) => void;
   }
   type ThumbnailMessageItemBody = React.FC<ThumbnailMessageItemBodyProps>;
@@ -1860,6 +1866,7 @@ declare module '@sendbird/uikit-react/ui/UnknownMessageItemBody' {
     isByMe?: boolean;
     message: CoreMessageType;
     mouseHover?: boolean;
+    isReactionEnabled?: boolean;
   }
   type UnknownMessageItemBody = React.FC<UnknownMessageItemBodyProps>;
   export default UnknownMessageItemBody;

--- a/src/smart-components/Channel/context/ChannelProvider.tsx
+++ b/src/smart-components/Channel/context/ChannelProvider.tsx
@@ -208,10 +208,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   const isSuper = currentGroupChannel?.isSuper || false;
   const isBroadcast = currentGroupChannel?.isBroadcast || false;
   const { appInfo } = sdk;
-  const usingReaction = (
-    appInfo?.useReaction && !isBroadcast && !isSuper && (config?.isReactionEnabled || isReactionEnabled)
-    // TODO: Make isReactionEnabled independent from appInfo.useReaction
-  );
+  const usingReaction = appInfo?.useReaction && !isBroadcast && !isSuper && (config?.isReactionEnabled || isReactionEnabled);
 
   const emojiAllMap = useMemo(() => (
     usingReaction

--- a/src/ui/FileMessageItemBody/__tests__/FileMessageItemBody.spec.js
+++ b/src/ui/FileMessageItemBody/__tests__/FileMessageItemBody.spec.js
@@ -117,6 +117,7 @@ describe('FileMessageItemBody', () => {
   it('should have class name by reactions of message prop', () => {
     const component = mount(
       <FileMessageItemBody
+        isReactionEnabled
         message={createMockMessage((mock) => ({
           ...mock,
           reactions: [{}, {}],

--- a/src/ui/FileMessageItemBody/__tests__/__snapshots__/FileMessageItemBody.spec.js.snap
+++ b/src/ui/FileMessageItemBody/__tests__/__snapshots__/FileMessageItemBody.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FileMessageItemBody should do a snapshot test of the FileMessageItemBody DOM 1`] = `
 <div
-  className="classname-for-snapshot sendbird-file-message-item-body outgoing mouse-hover reactions"
+  className="classname-for-snapshot sendbird-file-message-item-body outgoing mouse-hover "
 >
   <div
     className="sendbird-file-message-item-body__file-icon"

--- a/src/ui/FileMessageItemBody/index.tsx
+++ b/src/ui/FileMessageItemBody/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   message: FileMessage;
   isByMe?: boolean;
   mouseHover?: boolean;
+  isReactionEnabled?: boolean;
 }
 
 export default function FileMessageItemBody({
@@ -20,6 +21,7 @@ export default function FileMessageItemBody({
   message,
   isByMe = false,
   mouseHover = false,
+  isReactionEnabled = false,
 }: Props): ReactElement {
 
   return (
@@ -28,7 +30,7 @@ export default function FileMessageItemBody({
       'sendbird-file-message-item-body',
       isByMe ? 'outgoing' : 'incoming',
       mouseHover ? 'mouse-hover' : '',
-      message?.reactions?.length > 0 ? 'reactions' : '',
+      (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
     ])}>
       <div className="sendbird-file-message-item-body__file-icon">
         <Icon

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -228,6 +228,7 @@ export default function MessageContent({
               isByMe={isByMe}
               mouseHover={mouseHover}
               isMentionEnabled={config?.isMentionEnabled || false}
+              isReactionEnabled={isReactionEnabled}
             />
           )}
           {(isOGMessage(message as UserMessage)) && (
@@ -237,6 +238,7 @@ export default function MessageContent({
               isByMe={isByMe}
               mouseHover={mouseHover}
               isMentionEnabled={config?.isMentionEnabled || false}
+              isReactionEnabled={isReactionEnabled}
             />
           )}
           {(getUIKitMessageType((message as FileMessage)) === messageTypes.FILE) && (
@@ -245,6 +247,7 @@ export default function MessageContent({
               message={message as FileMessage}
               isByMe={isByMe}
               mouseHover={mouseHover}
+              isReactionEnabled={isReactionEnabled}
             />
           )}
           {(isThumbnailMessage(message as FileMessage)) && (
@@ -253,6 +256,7 @@ export default function MessageContent({
               message={message as FileMessage}
               isByMe={isByMe}
               mouseHover={mouseHover}
+              isReactionEnabled={isReactionEnabled}
               showFileViewer={showFileViewer}
             />
           )}
@@ -262,6 +266,7 @@ export default function MessageContent({
               message={message}
               isByMe={isByMe}
               mouseHover={mouseHover}
+              isReactionEnabled={isReactionEnabled}
             />
           )}
           {/* reactions */}

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   isByMe?: boolean;
   mouseHover?: boolean;
   isMentionEnabled?: boolean;
+  isReactionEnabled?: boolean;
 }
 
 export default function OGMessageItemBody({
@@ -24,6 +25,7 @@ export default function OGMessageItemBody({
   isByMe = false,
   mouseHover = false,
   isMentionEnabled = false,
+  isReactionEnabled = false,
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const openOGUrl = (): void => {
@@ -36,7 +38,7 @@ export default function OGMessageItemBody({
       'sendbird-og-message-item-body',
       isByMe ? 'outgoing' : 'incoming',
       mouseHover ? 'mouse-hover' : '',
-      message?.reactions?.length > 0 ? 'reactions' : '',
+      (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
     ])}>
       <Label
         key={uuidv4()}

--- a/src/ui/TextMessageItemBody/__tests__/TextMessageItemBody.spec.js
+++ b/src/ui/TextMessageItemBody/__tests__/TextMessageItemBody.spec.js
@@ -95,6 +95,7 @@ describe('TextMessageItemBody', () => {
   it('should have class name by reactions of message prop', () => {
     const component = mount(
       <TextMessageItemBody
+        isReactionEnabled
         message={createMockMessage((mockMessage) => ({
           ...mockMessage,
           reactions: [{}, {}, {}],

--- a/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
+++ b/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
@@ -5,7 +5,7 @@ exports[`TextMessageItemBody should do a snapshot test of the TextMessageItemBod
   className="sendbird-label sendbird-label--body-1 sendbird-label--color-oncontent-1"
 >
   <div
-    className="class-name-for-snapshot sendbird-text-message-item-body outgoing mouse-hover reactions"
+    className="class-name-for-snapshot sendbird-text-message-item-body outgoing mouse-hover "
   >
     First second third fourth fifth
     <span

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -14,6 +14,7 @@ interface Props {
   isByMe?: boolean;
   mouseHover?: boolean;
   isMentionEnabled?: boolean;
+  isReactionEnabled?: boolean;
 }
 
 export default function TextMessageItemBody({
@@ -22,6 +23,7 @@ export default function TextMessageItemBody({
   isByMe = false,
   mouseHover = false,
   isMentionEnabled = false,
+  isReactionEnabled = false,
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
@@ -38,7 +40,7 @@ export default function TextMessageItemBody({
         'sendbird-text-message-item-body',
         isByMe ? 'outgoing' : 'incoming',
         mouseHover ? 'mouse-hover' : '',
-        message?.reactions?.length > 0 ? 'reactions' : '',
+        (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
       ])}>
         {
           isMessageMentioned

--- a/src/ui/ThumbnailMessageItemBody/__tests__/__snapshots__/ThumbnailMessageItemBody.spec.js.snap
+++ b/src/ui/ThumbnailMessageItemBody/__tests__/__snapshots__/ThumbnailMessageItemBody.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ThumbnailMessageItemBody should do a snapshot test of the ThumbnailMessageItemBody DOM 1`] = `
 <div
-  className="classname-for-snapshot sendbird-thumbnail-message-item-body outgoing mouse-hover reactions"
+  className="classname-for-snapshot sendbird-thumbnail-message-item-body outgoing mouse-hover "
   onClick={[Function]}
 >
   <div

--- a/src/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/ui/ThumbnailMessageItemBody/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   message: FileMessage;
   isByMe?: boolean;
   mouseHover?: boolean;
+  isReactionEnabled?: boolean;
   showFileViewer?: (bool: boolean) => void;
 }
 
@@ -19,6 +20,7 @@ export default function ThumbnailMessageItemBody({
   message,
   isByMe = false,
   mouseHover = false,
+  isReactionEnabled = false,
   showFileViewer,
 }: Props): ReactElement {
   const { thumbnails = [] } = message;
@@ -32,7 +34,7 @@ export default function ThumbnailMessageItemBody({
         'sendbird-thumbnail-message-item-body',
         isByMe ? 'outgoing' : 'incoming',
         mouseHover ? 'mouse-hover' : '',
-        message?.reactions?.length > 0 ? 'reactions' : '',
+        (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
       ])}
       onClick={() => {
         if (isSentMessage(message)) {

--- a/src/ui/UnknownMessageItemBody/__tests__/UnknownMessageItemBody.spec.js
+++ b/src/ui/UnknownMessageItemBody/__tests__/UnknownMessageItemBody.spec.js
@@ -92,6 +92,7 @@ describe('UnknownMessageItemBody', () => {
   it('should have class name by reactions of message', () => {
     const component = mount(
       <UnknownMessageItemBody
+        isReactionEnabled
         message={createMockMessage((mockMessage) => ({
           ...mockMessage,
           reactions: [{}, {}, {}],

--- a/src/ui/UnknownMessageItemBody/__tests__/__snapshots__/UnknownMessageItemBody.spec.js.snap
+++ b/src/ui/UnknownMessageItemBody/__tests__/__snapshots__/UnknownMessageItemBody.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`UnknownMessageItemBody should do a snapshot test of the UnknownMessageItemBody DOM 1`] = `
 <div
-  className="class-name-for-snapshot sendbird-unknown-message-item-body outgoing mouse-hover reactions"
+  className="class-name-for-snapshot sendbird-unknown-message-item-body outgoing mouse-hover "
 >
   <span
     className="sendbird-unknown-message-item-body__header sendbird-label sendbird-label--body-1 sendbird-label--color-oncontent-1"

--- a/src/ui/UnknownMessageItemBody/index.tsx
+++ b/src/ui/UnknownMessageItemBody/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   isByMe?: boolean;
   message: BaseMessage;
   mouseHover?: boolean;
+  isReactionEnabled?: boolean;
 }
 
 export default function UnknownMessageItemBody({
@@ -18,6 +19,7 @@ export default function UnknownMessageItemBody({
   message,
   isByMe = false,
   mouseHover = false,
+  isReactionEnabled = false,
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   return (
@@ -26,7 +28,7 @@ export default function UnknownMessageItemBody({
       'sendbird-unknown-message-item-body',
       isByMe ? 'outgoing' : 'incoming',
       mouseHover ? 'mouse-hover' : '',
-      message?.reactions?.length > 0 ? 'reactions' : '',
+      (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
     ])}>
       <Label
         className="sendbird-unknown-message-item-body__header"


### PR DESCRIPTION
Features:
* Export SessionHandler through `@sendbird/uikit-react/handlers/SessionHandler`
  * This is a workaround to fix an issue where inhertiance chains break custom handler implementation
  * `import SessionHandler from '@sendbird/uikit-react/handlers/SessionHandler'`
* Rem units can be used for typography
  * Pass prop `config.isREMUnitEnabled` -> true on SendbirdProvider to use "rem" units
  * We are adding rem as unit for typography/font size

Fixes:
* Fix the position of ContextMenu
* Do not exit the current open channel when the channel state is changed
* Add the message as a parameter of renderCustomSeparator
  * before: renderCustomSeparator={() => ReactElement}
  * after: renderCustomSeparator={(props: { message }) => ReactElement}
* Fix typo on the type
  * renderCustomSep'e'rator to renderCustomSep'a'rator
