### PR TITLE
release [v3.1.3] (Sep 16 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,15 @@ Features:
 
 Fixes:
 * Fix the position of ContextMenu
-* Set message context's border roundly by the state using the reaction feature
 * Do not exit the current open channel when the channel state is changed
+* Display menu only for operators on the member list
+* Hide muted icon when pop-up component is appeared
+* Set message context's border roundly by the state using the reaction feature
+  * Add props `isReactionEnabled` to the <TextMessageItemBody />
+  * Add props `isReactionEnabled` to the <OGMessageItemBody />
+  * Add props `isReactionEnabled` to the <FileMessageItemBody />
+  * Add props `isReactionEnabled` to the <ThumbnailMessageItemBody />
+  * Add props `isReactionEnabled` to the <UnknownMessageItemBody />
 * Add the message as a parameter of renderCustomSeparator
   * before: renderCustomSeparator={() => ReactElement}
   * after: renderCustomSeparator={(props: { message }) => ReactElement}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog - v3
 
+## [v3.1.3] (Sep 18 2022)
+
+Features:
+* Export SessionHandler through `@sendbird/uikit-react/handlers/SessionHandler`
+  * This is a workaround to fix an issue where inhertiance chains break custom handler implementation
+  * `import SessionHandler from '@sendbird/uikit-react/handlers/SessionHandler'`
+* Rem units can be used for typography
+  * Pass prop `config.isREMUnitEnabled` -> true on SendbirdProvider
+    to use "rem" units
+  * We are adding rem as unit for typography/font size
+
+Fixes:
+* Fix the position of ContextMenu
+* Do not exit the current open channel when the channel state is changed
+* Add the message as a parameter of renderCustomSeparator
+  * before: renderCustomSeparator={() => ReactElement}
+  * after: renderCustomSeparator={(props: { message }) => ReactElement}
+* Fix typo on the type
+  * renderCustomSep'e'rator to renderCustomSep'a'rator
+
 ## [v3.1.2] (Aug 31 2022)
 
 * Migrate UI components into TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
 
 Fixes:
 * Fix the position of ContextMenu
+* Set message context's border roundly by the state using the reaction feature
 * Do not exit the current open channel when the channel state is changed
 * Add the message as a parameter of renderCustomSeparator
   * before: renderCustomSeparator={() => ReactElement}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
[v3.1.3] (Sep 18 2022)

Features:
* Export SessionHandler through `@sendbird/uikit-react/handlers/SessionHandler`
  * This is a workaround to fix an issue where inhertiance chains break custom handler implementation
  * `import SessionHandler from '@sendbird/uikit-react/handlers/SessionHandler'`
* Rem units can be used for typography
  * Pass prop `config.isREMUnitEnabled` -> true on SendbirdProvider
    to use "rem" units
  * We are adding rem as unit for typography/font size

Fixes:
* Fix the position of ContextMenu
* Do not exit the current open channel when the channel state is changed
* Display menu only for operators on the member list
* Hide muted icon when pop-up component is appeared
* Set message context's border roundly by the state using the reaction feature
  * Add props `isReactionEnabled` to the <TextMessageItemBody />
  * Add props `isReactionEnabled` to the <OGMessageItemBody />
  * Add props `isReactionEnabled` to the <FileMessageItemBody />
  * Add props `isReactionEnabled` to the <ThumbnailMessageItemBody />
  * Add props `isReactionEnabled` to the <UnknownMessageItemBody />
* Add the message as a parameter of renderCustomSeparator
  * before: renderCustomSeparator={() => ReactElement}
  * after: renderCustomSeparator={(props: { message }) => ReactElement}
* Fix typo on the type
  * renderCustomSep'e'rator to renderCustomSep'a'rator