### PR TITLE
fix: Do not show menu for non-admin user(ChannelSettings)

### DIFF
--- a/src/smart-components/ChannelSettings/components/ModerationPanel/MemberList.tsx
+++ b/src/smart-components/ChannelSettings/components/ModerationPanel/MemberList.tsx
@@ -70,7 +70,7 @@ export const MemberList = (): ReactElement => {
             user={member}
             currentUser={sdk.currentUser.userId}
             action={
-              (userId !== member.userId)
+              (channel?.myRole === 'operator' && userId !== member.userId)
                 ? ({ actionRef, parentRef }) => (
                   <ContextMenu
                     menuTrigger={(toggleDropdown) => (

--- a/src/smart-components/ChannelSettings/components/UserListItem/index.tsx
+++ b/src/smart-components/ChannelSettings/components/UserListItem/index.tsx
@@ -52,11 +52,6 @@ const UserListItem = ({
         COMPONENT_NAME, ...injectingClassNames,
       ].join(' ')}
     >
-      {
-        user.isMuted && (
-          <MutedAvatarOverlay />
-        )
-      }
       <ContextMenu
         menuTrigger={(toggleDropdown) => (
           <Avatar
@@ -100,6 +95,11 @@ const UserListItem = ({
           </MenuItems>
         )}
       />
+      {
+        user.isMuted && (
+          <MutedAvatarOverlay />
+        )
+      }
       <Label
         className={`${COMPONENT_NAME}__title`}
         type={LabelTypography.SUBTITLE_1}
@@ -137,7 +137,7 @@ const UserListItem = ({
       {
         action && (
           <div ref={actionRef} className={`${COMPONENT_NAME}__action`}>
-            { action({ actionRef, parentRef }) }
+            {action({ actionRef, parentRef })}
           </div>
         )
       }

--- a/src/ui/UserListItem/index.scss
+++ b/src/ui/UserListItem/index.scss
@@ -15,7 +15,6 @@
     position: absolute;
     top: 8px;
     left: 0px;
-    z-index: 1;
     cursor: pointer;
   }
 
@@ -23,7 +22,6 @@
     position: absolute;
     top: 8px;
     left: 0px;
-    z-index: 2;
     pointer-events: none;
   }
 


### PR DESCRIPTION
## Description Of Changes

* Display menu only for operators on the participant list
  * <img width="320" alt="image" src="https://user-images.githubusercontent.com/46333979/190959688-0e91976f-88e9-4f65-8594-624e2267ec9c.png">
* Hide muted icon when pop-up component is appeard
  * <img width="273" alt="image" src="https://user-images.githubusercontent.com/46333979/190959850-03d3e850-27a0-4c3c-8760-957fc66b7c06.png">


## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
