### PR TITLE
feat: add prop?.value to MessageWrappers

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -535,6 +535,7 @@ declare module "SendbirdUIKitGlobal" {
   };
 
   export type MessageInputProps = {
+    // value is removed when channelURL changes
     value?: string;
     ref?: React.MutableRefObject<any>;
   };
@@ -664,6 +665,7 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   export type OpenChannelMessageInputWrapperProps = {
+    // value is removed when channelURL changes
     value?: string;
     ref?: React.MutableRefObject<any>;
   }
@@ -1725,6 +1727,7 @@ declare module '@sendbird/uikit-react/ui/MessageInput' {
     isEdit?: boolean,
     isMentionEnabled?: boolean;
     disabled?: boolean,
+    // value is removed when channelURL changes
     value?: string,
     name: string,
     placeholder?: string,

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -534,6 +534,11 @@ declare module "SendbirdUIKitGlobal" {
     renderMessageContent?: () => React.ReactNode | React.ReactElement;
   };
 
+  export type MessageInputProps = {
+    value?: string;
+    ref?: React.MutableRefObject<any>;
+  };
+
   export type MessageListProps = {
     renderMessage?: (props: RenderMessageProps) => React.ReactNode | React.ReactElement;
     renderPlaceholderEmpty?: () => React.ReactNode | React.ReactElement;
@@ -656,6 +661,11 @@ declare module "SendbirdUIKitGlobal" {
   export type OpenchannelMessageListProps = {
     renderMessage?: (props: RenderMessageProps) => React.ReactNode | React.ReactElement;
     renderPlaceHolderEmptyList?: () => React.ReactNode | React.ReactElement;
+  }
+
+  export type OpenChannelMessageInputWrapperProps = {
+    value?: string;
+    ref?: React.MutableRefObject<any>;
   }
 
   export type OpenChannelMessageProps = {
@@ -1116,7 +1126,8 @@ declare module '@sendbird/uikit-react/Channel/components/Message' {
 }
 
 declare module '@sendbird/uikit-react/Channel/components/MessageInput' {
-  const MessageInput: React.FunctionComponent;
+  import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
+  const MessageInput: React.FunctionComponent<SendbirdUIKitGlobal.MessageInputProps>;
   export default MessageInput;
 }
 
@@ -1175,9 +1186,9 @@ declare module '@sendbird/uikit-react/OpenChannel/components/OpenChannelHeader' 
 }
 
 declare module '@sendbird/uikit-react/OpenChannel/components/OpenChannelInput' {
-  const OpenChannelInput: React.FunctionComponent;
+  import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
+  const OpenChannelInput: React.FC<SendbirdUIKitGlobal.OpenChannelMessageInputWrapperProps>;
   export default OpenChannelInput;
-
 }
 
 declare module '@sendbird/uikit-react/OpenChannel/components/OpenChannelMessage' {

--- a/src/smart-components/Channel/components/MessageInput/index.tsx
+++ b/src/smart-components/Channel/components/MessageInput/index.tsx
@@ -11,7 +11,13 @@ import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import SuggestedMentionList from '../SuggestedMentionList';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 
-const MessageInputWrapper = (): JSX.Element => {
+export type MessageInputWrapperProps = {
+  value?: string;
+};
+
+
+const MessageInputWrapper = (props: MessageInputWrapperProps): JSX.Element => {
+  const { value } = props;
   const {
     currentGroupChannel,
     initialized,
@@ -124,6 +130,7 @@ const MessageInputWrapper = (): JSX.Element => {
       )}
       <MessageInput
         className="sendbird-message-input-wrapper__message-input"
+        value={value}
         channelUrl={channel?.url}
         mentionSelectedUser={selectedUser}
         isMentionEnabled={isMentionEnabled}

--- a/src/smart-components/OpenChannel/components/OpenChannelInput/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelInput/index.tsx
@@ -7,7 +7,7 @@ export type MessageInputWrapperProps = {
   value?: string;
 };
 
-const MessageInputWrapper = (props, ref: React.RefObject<HTMLInputElement>): JSX.Element => {
+const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObject<HTMLInputElement>): JSX.Element => {
   const {
     currentOpenChannel,
     disabled,
@@ -21,7 +21,7 @@ const MessageInputWrapper = (props, ref: React.RefObject<HTMLInputElement>): JSX
   }
 
   const { stringSet } = useContext(LocalizationContext);
-  const { value } = props?.value;
+  const { value } = props;
 
   return (
     <div className="sendbird-openchannel-footer">

--- a/src/smart-components/OpenChannel/components/OpenChannelInput/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelInput/index.tsx
@@ -3,6 +3,10 @@ import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import MessageInput from '../../../../ui/MessageInput';
 import { useOpenChannelContext } from '../../context/OpenChannelProvider';
 
+export type MessageInputWrapperProps = {
+  value?: string;
+};
+
 const MessageInputWrapper = (props, ref: React.RefObject<HTMLInputElement>): JSX.Element => {
   const {
     currentOpenChannel,
@@ -17,11 +21,13 @@ const MessageInputWrapper = (props, ref: React.RefObject<HTMLInputElement>): JSX
   }
 
   const { stringSet } = useContext(LocalizationContext);
+  const { value } = props?.value;
 
   return (
     <div className="sendbird-openchannel-footer">
       <MessageInput
         ref={ref}
+        value={value}
         disabled={disabled}
         onSendMessage={handleSendMessage}
         onFileUpload={handleFileUpload}

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -36,6 +36,17 @@ const handleUploadFile = (callback) => (event) => {
   // eslint-disable-next-line no-param-reassign
   event.target.value = '';
 };
+
+const displayCaret = (element, position) => {
+  const range = document.createRange();
+  const sel = window.getSelection();
+  range.setStart(element.childNodes[0], position);
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  element.focus();
+}
+
 const initialTargetStringInfo = {
   targetString: '',
   startNodeIndex: null,
@@ -92,6 +103,20 @@ const MessageInput = React.forwardRef((props, ref) => {
       }
     }
   ), []);
+
+  // for easilly initialize input value from outside, but
+  // useEffect(_, [channelUrl]) erase it
+  const initialValue = props?.value;
+  useEffect(() => {
+    const textField = ref?.current;
+    try {
+      textField.innerHTML = initialValue;
+      displayCaret(textField, initialValue?.length);
+    } catch { }
+    setMentionedUserIds([]);
+    setIsInput(textField?.innerText?.length > 0);
+    setHeight();
+  }, [initialValue]);
 
   // #Mention | Clear input value when channel changes
   useEffect(() => {
@@ -483,6 +508,7 @@ MessageInput.propTypes = {
     PropTypes.string,
     PropTypes.bool,
   ]),
+  value: PropTypes.string,
   isEdit: PropTypes.bool,
   isMentionEnabled: PropTypes.bool,
   message: PropTypes.shape({
@@ -515,6 +541,7 @@ MessageInput.defaultProps = {
   channelUrl: '',
   onSendMessage: noop,
   onUpdateMessage: noop,
+  value: null,
   message: null,
   isEdit: false,
   isMentionEnabled: false,


### PR DESCRIPTION
Message wrappers get new prop `value`
through which we can set value from outside ~

value is reset when channelURL changes
