### PR TITLE
fix: Return null when Word comp received empty string

### DIFF
--- a/src/ui/Word/index.tsx
+++ b/src/ui/Word/index.tsx
@@ -25,6 +25,9 @@ export default function Word(props: WordProps): JSX.Element {
     mentionTemplate = '@',
     renderString = null,
   } = props;
+  if (word === '') {
+    return null;
+  }
   return (
     <span className="sendbird-word">
       {


### PR DESCRIPTION
## For Internal Contributors

[QM-1844](https://sendbird.atlassian.net/browse/QM-1844)

## Description Of Changes

* Word should return null when the received string is empty

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
