### PR TITLE
fix: Apply the text overflow ellipsis to the words of emoji tooltip

### DIFF
--- a/src/ui/Tooltip/index.scss
+++ b/src/ui/Tooltip/index.scss
@@ -31,5 +31,9 @@
     font-style: normal;
     line-height: 1.33;
     letter-spacing: normal;
+    word-break: keep-all;
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
## For Internal Contributors

[QM-1845](https://sendbird.atlassian.net/browse/QM-1845)

## Description Of Changes

Apply the text-overflow ellipsis to the words of emoji tooltip

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
