### PR TITLE
fix: Use ref from MessageInputWrapper props if present

### DIFF
--- a/src/smart-components/Channel/components/MessageInput/index.tsx
+++ b/src/smart-components/Channel/components/MessageInput/index.tsx
@@ -16,7 +16,10 @@ export type MessageInputWrapperProps = {
 };
 
 
-const MessageInputWrapper = (props: MessageInputWrapperProps): JSX.Element => {
+const MessageInputWrapper = (
+  props: MessageInputWrapperProps,
+  ref: React.MutableRefObject<any>,
+): JSX.Element => {
   const { value } = props;
   const {
     currentGroupChannel,
@@ -139,7 +142,7 @@ const MessageInputWrapper = (props: MessageInputWrapperProps): JSX.Element => {
           || (utils.isDisabledBecauseFrozen(channel) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED)
           || (utils.isDisabledBecauseMuted(channel) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED)
         }
-        ref={messageInputRef}
+        ref={ref || messageInputRef}
         disabled={disabled}
         onStartTyping={() => {
           channel?.startTyping();


### PR DESCRIPTION
Fixes warning in which ref wasnt provided to forwardRef
if present, use the ref from component(MessageInputWrapper)
else use the one from context