### PR TITLE
Fix Channel list fetch more issue

### DIFF
--- a/src/smart-components/Channel/components/MessageList/index.tsx
+++ b/src/smart-components/Channel/components/MessageList/index.tsx
@@ -9,7 +9,7 @@ import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
 import { compareMessagesForGrouping } from '../../context/utils';
 import Message from '../Message';
 import { RenderCustomSeparatorProps, RenderMessageProps } from '../../../../types';
-import { isAboutSame } from '../../context/utils';
+import { isAboutSame } from '../../../../utils'
 import uuidv4 from '../../../../utils/uuid';
 
 export type MessageListProps = {

--- a/src/smart-components/Channel/context/utils.js
+++ b/src/smart-components/Channel/context/utils.js
@@ -267,6 +267,4 @@ export const pxToNumber = (px) => {
   return null;
 };
 
-export const isAboutSame = (a, b, px) => (Math.abs(a - b) <= px);
-
 export default getParsedStatus;

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -14,6 +14,7 @@ import * as channelListActions from '../../dux/actionTypes';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import EditUserProfile from '../../../EditUserProfile';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
+import { isAboutSame } from '../../../../utils'
 
 const DELIVERY_RECIPT = 'delivery_receipt';
 
@@ -124,7 +125,7 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) 
         className="sendbird-channel-list__body"
         onScroll={(e) => {
           const target = e?.target as HTMLDivElement;
-          const fetchMore = target.clientHeight + target.scrollTop === target.scrollHeight;
+          const fetchMore = isAboutSame(target.clientHeight + target.scrollTop, target.scrollHeight, 10);
           if (fetchMore && channelSource?.hasNext) {
             logger.info('ChannelList: Fetching more channels');
             channelListDispatcher({

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -645,3 +645,5 @@ export const arrayEqual = (array1: Array<unknown>, array2: Array<unknown>): bool
   }
   return false;
 };
+
+export const isAboutSame = (a: number, b: number, px: number) => (Math.abs(a - b) <= px);


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.


## Description Of Changes

Hello ! We are developing products using sendbird-uikit. 
I opened this PR because there was a problem with the ChannelList component while using uikit.
ChannelList was not fetching more at some resolutions.
If the sum of clientHeight and scrollTop is exactly the same as scrollHeight, fetching more channels code will be excuted.

```typescript
const fetchMore = target.clientHeight + target.scrollTop === target.scrollHeight;
```

But, At some resolutions, it operates as follows.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/38802280/192704020-f439ffe2-c359-4b0b-9298-9ced13d28c0e.png">

The channel is not fetching more because it is not exactly same. 
So, I think it would be good to change the logic of fetching more by referring to the code of the MessageList component as follows.

https://github.com/sendbird/sendbird-uikit-react/blob/1bcbef99109f47bf0649f123cb818275b500816b/src/smart-components/Channel/components/MessageList/index.tsx#L72-L82

The `isAboutSame` function is a channel dependent util, so I move it to public util folder.  (This change is okay not to be reflected.)

I would really appreciate it if you could review this PR. 

Thanks :)


## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [x] Improvement (refactor code)
