### PR TITLE
fix: Donot bundle chat sdk with uikit compiled code

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,8 +38,10 @@ module.exports = ({
     },
   ],
   external: [
-    // unbundled version of @sendbird/chat fails in production
-    // '@sendbird/chat',
+    '@sendbird/chat',
+    '@sendbird/chat/groupChannel',
+    '@sendbird/chat/openChannel',
+    '@sendbird/chat/message',
     'react-dom/server',
     'prop-types',
     'react',


### PR DESCRIPTION
Compiled UIKit code that is distributed through npm shouldnt have Chat SDK minified code included in it

Chat SDK should be a dependency of UIKit
Advantages:
* Chat SDK bug fixes will be added for free
* Eliminate the need for handlers

---

So what was the issue:
If you are usig rollup for bundling
in config.external you have to be specific
ie>
This works:
```
external: [
  '@sendbird/chat',
  '@sendbird/chat/groupChannel', 
  '@sendbird/chat/openChannel', 
  '@sendbird/chat/message',
]
```
This doesnt:
```
external: [ '@sendbird/chat', ]
```

fixes: https://sendbird.atlassian.net/browse/UIKIT-2274