### PR TITLE
fix: Only react and react-dom should be peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@sendbird/chat": "^4.0.11",
+        "@sendbird/chat": "^4.0.13",
         "css-vars-ponyfill": "^2.3.2",
         "date-fns": "^2.16.1",
         "prop-types": "^15.7.2"
@@ -80,10 +80,6 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "@sendbird/chat": "^4.0.11",
-        "css-vars-ponyfill": "^2.3.2",
-        "date-fns": "^2.16.1",
-        "prop-types": "^15.7.2",
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
       }
@@ -4671,9 +4667,9 @@
       }
     },
     "node_modules/@sendbird/chat": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.0.11.tgz",
-      "integrity": "sha512-5ngAsts9llXUOZnQfWjpivCw5PAG0lzO6VJcp+aNJqenIje4DYlY8Gi5v4/xZFK+cWuDTYcZcUxilhCtknnXFg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.0.13.tgz",
+      "integrity": "sha512-vmIJldcVa8m5Wd9YBhbrfAX9w+N5iDAZnkeBnYQs5I4ov9txIs02+GqpobSWi77ywx/dgPVLm1+7nIkyuiCTLw==",
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.6"
       },
@@ -36758,9 +36754,9 @@
       }
     },
     "@sendbird/chat": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.0.11.tgz",
-      "integrity": "sha512-5ngAsts9llXUOZnQfWjpivCw5PAG0lzO6VJcp+aNJqenIje4DYlY8Gi5v4/xZFK+cWuDTYcZcUxilhCtknnXFg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.0.13.tgz",
+      "integrity": "sha512-vmIJldcVa8m5Wd9YBhbrfAX9w+N5iDAZnkeBnYQs5I4ov9txIs02+GqpobSWi77ywx/dgPVLm1+7nIkyuiCTLw==",
       "requires": {}
     },
     "@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -45,14 +45,11 @@
   "author": "SendBird <support@sendbird.com>",
   "license": "SEE LICENSE IN LICENSE.md",
   "peerDependencies": {
-    "css-vars-ponyfill": "^2.3.2",
-    "date-fns": "^2.16.1",
-    "prop-types": "^15.7.2",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.0.11",
+    "@sendbird/chat": "^4.0.13",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "prop-types": "^15.7.2"

--- a/scripts/package.template.json
+++ b/scripts/package.template.json
@@ -22,14 +22,11 @@
   "author": "SendBird <support@sendbird.com>",
   "license": "SEE LICENSE IN LICENSE.md",
   "peerDependencies": {
-    "css-vars-ponyfill": "^2.3.2",
-    "date-fns": "^2.16.1",
-    "prop-types": "^15.7.2",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.0.11",
+    "@sendbird/chat": "^4.0.13",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "prop-types": "^15.7.2"


### PR DESCRIPTION
For npm >= v7, npm autoinstall peerDependency packages

According to https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies You want to express the compatibility of your package with a host tiool or library while not necessarily doing a require of this host Even though react is required, its better to show that react is the host tool
