### PR TITLE
[v3.2.1] (Oct 04 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog - v3
 
+## [v3.2.1] (Oct 02 2022)
+
+Fixes:
+
+* Do not bundle chat SDK with uikit compiled code
+
+Compiled UIKit code that is distributed through npm shouldn't
+have Chat SDK minified code included in it
+Chat SDK should be a dependency of UIKit
+Advantages:
+  * Chat SDK bug fixes will be added for free
+  * Eliminate the need for handlers
+What caused the issue:
+If you are using rollup for bundling
+in config.external you have to be specific
+ie>
+This works:
+```
+external: [
+  '@sendbird/chat',
+  '@sendbird/chat/groupChannel',
+  '@sendbird/chat/openChannel',
+  '@sendbird/chat/message',
+]
+```
+This doesn't:
+```
+external: [ '@sendbird/chat', ]
+```
+
+* Only react and react-dom should be peerDependencies
+
+For npm >= v7, npm autoinstall peerDependency packages
+According to `https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies`
+You want to express the compatibility of your package with a host tool
+or library while not necessarily doing a require of this host Even though react is required,
+its better to show that react is the host tool
+
 ## [v3.2.0] (Sep 27 2022)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Fixes:

* Donot bundle chat sdk with uikit compiled code

Compiled UIKit code that is distributed through npm shouldnt have Chat SDK minified code included in it Chat SDK should be a dependency of UIKit
Advantages:
  * Chat SDK bug fixes will be added for free
  * Eliminate the need for handlers What caused the issue:
If you are usig rollup for bundling
in config.external you have to be specific
ie>
This works:
```
external: [
  '@sendbird/chat',
  '@sendbird/chat/groupChannel',
  '@sendbird/chat/openChannel',
  '@sendbird/chat/message',
]
```
This doesnt:
```
external: [ '@sendbird/chat', ]
```

* Only react and react-dom should be peerDependencies

For npm >= v7, npm autoinstall peerDependency packages According to https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies You want to express the compatibility of your package with a host tool or library while not necessarily doing a require of this host Even though react is required, its better to show that react is the host tool

