### PR TITLE
feat: implement MediaQueryProvider

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -47,6 +47,7 @@ declare module "SendbirdUIKitGlobal" {
     accessToken?: string;
     customApiHost?: string,
     customWebSocketHost?: string,
+    mediaQueryBreakPoint?: string,
     theme?: 'light' | 'dark';
     userListQuery?(): UserListQuery;
     nickname?: string;
@@ -215,6 +216,7 @@ declare module "SendbirdUIKitGlobal" {
     configureSession?: (sdk: SendbirdGroupChat | SendbirdOpenChat) => SessionHandler;
     customApiHost?: string,
     customWebSocketHost?: string,
+    mediaQueryBreakPoint?: string,
     children?: React.ReactNode | React.ReactElement;
     theme?: 'light' | 'dark';
     nickname?: string;

--- a/src/lib/MediaQueryContext.tsx
+++ b/src/lib/MediaQueryContext.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import type { Logger } from './SendbirdState';
+
+const DEFAULT_MOBILE = '768px';
+const MOBILE_CLASSNAME = 'sendbird--mobile-mode';
+
+const MediaQueryContext = React.createContext({
+  mediaQueryBreakPoint: DEFAULT_MOBILE,
+  isMobile: false,
+});
+
+export interface MediaQueryProviderProps {
+  children: React.ReactElement;
+  mediaQueryBreakPoint?: string;
+  logger?: Logger;
+}
+
+const addClassNameToBody = () => {
+  try {
+    const body = document.querySelector('body');
+    body.classList.add(MOBILE_CLASSNAME);
+  } catch {
+    // noop
+  }
+};
+
+const removeClassNameFromBody = () => {
+  try {
+    const body = document.querySelector('body');
+    body.classList.remove(MOBILE_CLASSNAME);
+  } catch {
+    // noop
+  }
+};
+
+const MediaQueryProvider = (props: MediaQueryProviderProps): React.ReactElement => {
+  const {
+    children,
+    logger,
+  } = props;
+  const mediaQueryBreakPoint = props?.mediaQueryBreakPoint || DEFAULT_MOBILE;
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const updateSize = () => {
+      const mq = window.matchMedia(`(max-width: ${mediaQueryBreakPoint})`);
+      logger?.info?.(`MediaQueryProvider: Screensize updated to ${mediaQueryBreakPoint}`);
+      if (mq.matches) {
+        setIsMobile(true);
+        addClassNameToBody();
+        logger?.info?.(`MediaQueryProvider: isMobile: true`);
+      } else {
+        setIsMobile(false);
+        removeClassNameFromBody();
+        logger?.info?.(`MediaQueryProvider: isMobile: false`);
+      }
+    }
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    logger?.info?.(`MediaQueryProvider: addEventListener`, updateSize);
+    return () => {
+      window.removeEventListener('resize', updateSize);
+      logger?.info?.(`MediaQueryProvider: removeEventListener`, updateSize);
+    }
+  }, [mediaQueryBreakPoint]);
+  return (
+    <MediaQueryContext.Provider value={{ mediaQueryBreakPoint, isMobile }}>
+      {children}
+    </MediaQueryContext.Provider>
+  );
+};
+
+export type useMediaQueryContextType = () => {
+  mediaQueryBreakPoint: string,
+};
+
+const useMediaQueryContext: useMediaQueryContextType = () => React.useContext(MediaQueryContext);
+
+export { MediaQueryProvider, useMediaQueryContext };

--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -21,6 +21,7 @@ import pubSubFactory from './pubSub/index';
 import useAppendDomNode from '../hooks/useAppendDomNode';
 
 import { LocalizationProvider } from './LocalizationContext';
+import { MediaQueryProvider } from './MediaQueryContext';
 import getStringSet from '../ui/Label/stringSet';
 
 export default function Sendbird(props) {
@@ -30,6 +31,7 @@ export default function Sendbird(props) {
     appId,
     accessToken,
     configureSession,
+    mediaQueryBreakPoint,
     customApiHost,
     customWebSocketHost,
     children,
@@ -199,9 +201,11 @@ export default function Sendbird(props) {
         },
       }}
     >
-      <LocalizationProvider stringSet={localeStringSet} dateLocale={dateLocale}>
-        {children}
-      </LocalizationProvider>
+      <MediaQueryProvider logger={logger} mediaQueryBreakPoint={mediaQueryBreakPoint}>
+        <LocalizationProvider stringSet={localeStringSet} dateLocale={dateLocale}>
+          {children}
+        </LocalizationProvider>
+      </MediaQueryProvider>
     </SendbirdSdkContext.Provider>
   );
 }
@@ -212,6 +216,7 @@ Sendbird.propTypes = {
   accessToken: PropTypes.string,
   customApiHost: PropTypes.string,
   customWebSocketHost: PropTypes.string,
+  mediaQueryBreakPoint: PropTypes.string,
   configureSession: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.element,
@@ -268,6 +273,7 @@ Sendbird.defaultProps = {
   customWebSocketHost: null,
   configureSession: null,
   theme: 'light',
+  mediaQueryBreakPoint: null,
   nickname: '',
   dateLocale: null,
   profileUrl: '',

--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -22,6 +22,7 @@ export default function App(props) {
     accessToken,
     customApiHost,
     customWebSocketHost,
+    mediaQueryBreakPoint,
     theme,
     userListQuery,
     nickname,
@@ -59,6 +60,7 @@ export default function App(props) {
       accessToken={accessToken}
       customApiHost={customApiHost}
       customWebSocketHost={customWebSocketHost}
+      mediaQueryBreakPoint={mediaQueryBreakPoint}
       theme={theme}
       nickname={nickname}
       profileUrl={profileUrl}
@@ -164,6 +166,7 @@ App.propTypes = {
   userListQuery: PropTypes.func,
   nickname: PropTypes.string,
   profileUrl: PropTypes.string,
+  mediaQueryBreakPoint: PropTypes.string,
   allowProfileEdit: PropTypes.bool,
   disableUserProfile: PropTypes.bool,
   disableMarkAsDelivered: PropTypes.bool,
@@ -209,6 +212,7 @@ App.defaultProps = {
   nickname: '',
   profileUrl: '',
   userListQuery: null,
+  mediaQueryBreakPoint: null,
   dateLocale: null,
   allowProfileEdit: false,
   onProfileEditSuccess: null,


### PR DESCRIPTION
* Add props App?.mediaQueryBreakPoint, SendbirdProvider?.mediaQueryBreakPoint
* mediaQueryBreakPoint accepts a valid screensize in pixels, under which UIKit will work in mobile-mode
* Default is 768px
* Example: <App mediaQueryBreakPoint="568px" />

Internal:
* Implement MediaQueryProvider to manage mobile-mode
* Implement hook: const { mediaQueryBreakPoint, isMobile } = useMediaQueryContext();
* Add MOBILE_CLASSNAME = 'sendbird--mobile-mode'; to <body /> to identify mode

fixes: https://sendbird.atlassian.net/browse/UIKIT-2390
