### PR TITLE
feat: implement hooks/useLongPress

### DIFF
--- a/src/hooks/useLongPress.tsx
+++ b/src/hooks/useLongPress.tsx
@@ -1,0 +1,94 @@
+// thanks to: https://stackoverflow.com/questions/48048957/react-long-press-event
+import {
+  useState,
+  useRef,
+  useCallback,
+} from 'react';
+import {
+  useMediaQueryContext,
+} from '../lib/MediaQueryContext';
+
+const DEFAULT_DURATION = 300;
+
+function preventDefault(e: Event) {
+  if (!isTouchEvent(e)) return;
+
+  if (e.touches.length < 2 && e.preventDefault) {
+    e.preventDefault();
+  }
+};
+
+export function isTouchEvent(e: Event): e is TouchEvent {
+  return e && "touches" in e;
+};
+
+interface PressHandlers<T> {
+  onLongPress: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
+  onClick?: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
+}
+
+interface Options {
+  delay?: number;
+  shouldPreventDefault?: boolean;
+}
+
+export default function useLongPress<T> ({
+  onLongPress,
+  onClick,
+}: PressHandlers<T>, {
+  delay = DEFAULT_DURATION,
+  shouldPreventDefault = true,
+}: Options = {}) {
+  const { isMobile } = useMediaQueryContext();
+  const [longPressTriggered, setLongPressTriggered] = useState(false);
+  // https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+  const target = useRef<EventTarget>();
+
+  const start = useCallback((e: React.MouseEvent<T> | React.TouchEvent<T>) => {
+    if (!isMobile) {
+      return;
+    }
+    e.persist();
+    const clonedEvent = {
+      ...e
+    };
+
+    if (shouldPreventDefault && e.target) {
+      e.target.addEventListener(
+        "touchend",
+        preventDefault, {
+          passive: false
+        }
+      );
+      target.current = e.target;
+    }
+
+    timeout.current = setTimeout(() => {
+      onLongPress(clonedEvent);
+      setLongPressTriggered(true);
+    }, delay);
+  }, [onLongPress, delay, shouldPreventDefault, isMobile]);
+
+  const clear = useCallback((
+    e: React.MouseEvent<T> | React.TouchEvent<T>,
+    shouldTriggerClick = true
+  ) => {
+    timeout.current && clearTimeout(timeout.current);
+    shouldTriggerClick && !longPressTriggered && onClick?.(e);
+
+    setLongPressTriggered(false);
+
+    if (shouldPreventDefault && target.current) {
+      target.current.removeEventListener("touchend", preventDefault);
+    }
+  },[shouldPreventDefault, onClick, longPressTriggered]);
+
+  return {
+    onMouseDown: (e: React.MouseEvent<T>) => start(e),
+    onTouchStart: (e: React.TouchEvent<T>) => start(e),
+    onMouseUp: (e: React.MouseEvent<T>) => clear(e),
+    onMouseLeave: (e: React.MouseEvent<T>) => clear(e, false),
+    onTouchEnd: (e: React.TouchEvent<T>) => clear(e)
+  };
+};

--- a/src/hooks/useLongPress.tsx
+++ b/src/hooks/useLongPress.tsx
@@ -1,4 +1,22 @@
 // thanks to: https://stackoverflow.com/questions/48048957/react-long-press-event
+/* example:
+  const Component = ({ onClick }) => {
+    const onLongPress = useLongPress({
+      onClick: onClick,
+      onLongPress: () => {
+        alert('longpress');
+      }
+    }, {
+      delay: 500,
+      shouldPreventDefault: true,
+    });
+    return (
+      <button {...onLongPress}>
+        hello
+      </button>
+    )
+  }
+*/
 import {
   useState,
   useRef,
@@ -11,7 +29,9 @@ import {
 const DEFAULT_DURATION = 300;
 
 function preventDefault(e: Event) {
-  if (!isTouchEvent(e)) return;
+  if (!isTouchEvent(e)) {
+    return
+  };
 
   if (e.touches.length < 2 && e.preventDefault) {
     e.preventDefault();

--- a/src/hooks/useLongPress.tsx
+++ b/src/hooks/useLongPress.tsx
@@ -42,6 +42,14 @@ export function isTouchEvent(e: Event): e is TouchEvent {
   return e && "touches" in e;
 };
 
+export function vibrate() {
+  try {
+    navigator.vibrate(100);
+  } catch {
+    //
+  }
+}
+
 interface PressHandlers<T> {
   onLongPress: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
   onClick?: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
@@ -87,6 +95,7 @@ export default function useLongPress<T> ({
     timeout.current = setTimeout(() => {
       onLongPress(clonedEvent);
       setLongPressTriggered(true);
+      vibrate();
     }, delay);
   }, [onLongPress, delay, shouldPreventDefault, isMobile]);
 

--- a/src/hooks/useLongPress.tsx
+++ b/src/hooks/useLongPress.tsx
@@ -17,7 +17,7 @@
     )
   }
 */
-import {
+import React, {
   useState,
   useRef,
   useCallback,
@@ -31,18 +31,18 @@ const DEFAULT_DURATION = 300;
 function preventDefault(e: Event) {
   if (!isTouchEvent(e)) {
     return
-  };
+  }
 
   if (e.touches.length < 2 && e.preventDefault) {
     e.preventDefault();
   }
-};
+}
 
 export function isTouchEvent(e: Event): e is TouchEvent {
-  return e && "touches" in e;
-};
+  return e && 'touches' in e;
+}
 
-export function vibrate() {
+export function vibrate(): void {
   try {
     navigator.vibrate(100);
   } catch {
@@ -60,13 +60,21 @@ interface Options {
   shouldPreventDefault?: boolean;
 }
 
+interface UseLongPressType<T> {
+  onMouseDown: (e: React.MouseEvent<T>) => void;
+  onTouchStart: (e: React.TouchEvent<T>) => void;
+  onMouseUp: (e: React.MouseEvent<T>) => void;
+  onMouseLeave: (e: React.MouseEvent<T>) => void;
+  onTouchEnd: (e: React.TouchEvent<T>) => void;
+}
+
 export default function useLongPress<T> ({
   onLongPress,
   onClick,
 }: PressHandlers<T>, {
   delay = DEFAULT_DURATION,
   shouldPreventDefault = true,
-}: Options = {}) {
+}: Options = {}): UseLongPressType<T> {
   const { isMobile } = useMediaQueryContext();
   const [longPressTriggered, setLongPressTriggered] = useState(false);
   // https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype
@@ -84,7 +92,7 @@ export default function useLongPress<T> ({
 
     if (shouldPreventDefault && e.target) {
       e.target.addEventListener(
-        "touchend",
+        'touchend',
         preventDefault, {
           passive: false
         }
@@ -101,15 +109,18 @@ export default function useLongPress<T> ({
 
   const clear = useCallback((
     e: React.MouseEvent<T> | React.TouchEvent<T>,
-    shouldTriggerClick = true
+    shouldTriggerClick = true,
   ) => {
-    timeout.current && clearTimeout(timeout.current);
-    shouldTriggerClick && !longPressTriggered && onClick?.(e);
-
+    if (timeout?.current) {
+      clearTimeout(timeout.current);
+    }
+    if (shouldTriggerClick && !longPressTriggered) {
+      onClick?.(e);
+    }
     setLongPressTriggered(false);
 
     if (shouldPreventDefault && target.current) {
-      target.current.removeEventListener("touchend", preventDefault);
+      target.current.removeEventListener('touchend', preventDefault);
     }
   },[shouldPreventDefault, onClick, longPressTriggered]);
 
@@ -118,6 +129,6 @@ export default function useLongPress<T> ({
     onTouchStart: (e: React.TouchEvent<T>) => start(e),
     onMouseUp: (e: React.MouseEvent<T>) => clear(e),
     onMouseLeave: (e: React.MouseEvent<T>) => clear(e, false),
-    onTouchEnd: (e: React.TouchEvent<T>) => clear(e)
+    onTouchEnd: (e: React.TouchEvent<T>) => clear(e),
   };
-};
+}

--- a/src/lib/MediaQueryContext.tsx
+++ b/src/lib/MediaQueryContext.tsx
@@ -69,9 +69,10 @@ const MediaQueryProvider = (props: MediaQueryProviderProps): React.ReactElement 
   );
 };
 
-export type useMediaQueryContextType = () => {
-  mediaQueryBreakPoint: string,
-};
+export type useMediaQueryContextType = () => ({
+  mediaQueryBreakPoint: string;
+  isMobile: boolean;
+});
 
 const useMediaQueryContext: useMediaQueryContextType = () => React.useContext(MediaQueryContext);
 


### PR DESCRIPTION
Internal hook to handle longPresses
* Works only in mobile mode
* Can vibrate on longpress in few devices/browsers
https://caniuse.com/mdn-api_navigator_vibrate

Interface:
```
interface PressHandlers<T> {
  onLongPress: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
  onClick?: (e: React.MouseEvent<T> | React.TouchEvent<T>) => void;
}
interface Options {
  delay?: number; // threshold as described before
  shouldPreventDefault?: boolean;
}
---
interface UseLongPressType<T> {
  onMouseDown: (e: React.MouseEvent<T>) => void;
  onTouchStart: (e: React.TouchEvent<T>) => void;
  onMouseUp: (e: React.MouseEvent<T>) => void;
  onMouseLeave: (e: React.MouseEvent<T>) => void;
  onTouchEnd: (e: React.TouchEvent<T>) => void;
}
---
function useLongPress<T> (
  pressHandlers: PressHandlers<T>,
  Options: Options,
): UseLongPressType<T>
```

Example:
```
  const Component = ({ onClick }) => {
    const onLongPress = useLongPress({
      onClick: onClick,
      onLongPress: () => {
        alert('longpress');
      }
    }, {
      delay: 500,
      shouldPreventDefault: true,
    });
    return (
      <button {...onLongPress}>
        hello
      </button>
    )
  }
```