### PR TITLE
fix: Modify ts interface getLeaveChannel to getLeaveGroupChannel in selectors

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -194,7 +194,7 @@ You can make your own customized channel preview item component in this file. Yo
 ```javascript
 const CustomizedChannelPreviewItem = (props) => {
     const { channel } = props;
-    const onLeaveChannel = sendbirdSelectors.getLeaveChannel(store);
+    const onLeaveChannel = sendbirdSelectors.getLeaveGroupChannel(store);
     ...
     onLeaveChannel(channel);
 }

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -196,7 +196,7 @@ declare module "SendbirdUIKitGlobal" {
     getCreateOpenChannel: (store: SendBirdState) => GetCreateOpenChannel;
     getGetGroupChannel: (store: SendBirdState) => GetGetGroupChannel;
     getGetOpenChannel: (store: SendBirdState) => GetGetOpenChannel;
-    getLeaveChannel: (store: SendBirdState) => GetLeaveGroupChannel;
+    getLeaveGroupChannel: (store: SendBirdState) => GetLeaveGroupChannel;
     getEnterOpenChannel: (store: SendBirdState) => GetEnterOpenChannel;
     getExitOpenChannel: (store: SendBirdState) => GetExitOpenChannel;
     getFreezeChannel: (store: SendBirdState) => GetFreezeChannel;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -245,7 +245,7 @@ interface sendbirdSelectorsInterface {
   getCreateOpenChannel: (store: SendBirdState) => GetCreateOpenChannel;
   getGetGroupChannel: (store: SendBirdState) => GetGetGroupChannel;
   getGetOpenChannel: (store: SendBirdState) => GetGetOpenChannel;
-  getLeaveChannel: (store: SendBirdState) => GetLeaveGroupChannel;
+  getLeaveGroupChannel: (store: SendBirdState) => GetLeaveGroupChannel;
   getEnterOpenChannel: (store: SendBirdState) => GetEnterOpenChannel;
   getExitOpenChannel: (store: SendBirdState) => GetExitOpenChannel;
   getFreezeChannel: (store: SendBirdState) => GetFreezeChannel;

--- a/src/lib/stories/index.stories.js
+++ b/src/lib/stories/index.stories.js
@@ -60,8 +60,8 @@ const CustomComponent = ({ createChannel, sdk, leaveChannel }) => {
 };
 
 const CustomComponentWithSendBird = withSendBird(CustomComponent, (state) => {
-  const createChannel =  sendbirdSelectors.getCreateChannel(state);
-  const leaveChannel =  sendbirdSelectors.getLeaveChannel(state);
+  const createChannel =  sendbirdSelectors.getCreateGroupChannel(state);
+  const leaveChannel =  sendbirdSelectors.getLeaveGroupChannel(state);
   const sdk = sendbirdSelectors.getSdk(state);
   return ({ createChannel, sdk, leaveChannel });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -174,7 +174,7 @@ export interface sendbirdSelectorsInterface {
   getCreateOpenChannel: (store: SendBirdState) => GetCreateOpenChannel;
   getGetGroupChannel: (store: SendBirdState) => GetGetGroupChannel;
   getGetOpenChannel: (store: SendBirdState) => GetGetOpenChannel;
-  getLeaveChannel: (store: SendBirdState) => GetLeaveGroupChannel;
+  getLeaveGroupChannel: (store: SendBirdState) => GetLeaveGroupChannel;
   getEnterOpenChannel: (store: SendBirdState) => GetEnterOpenChannel;
   getExitOpenChannel: (store: SendBirdState) => GetExitOpenChannel;
   getFreezeChannel: (store: SendBirdState) => GetFreezeChannel;


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2445](https://sendbird.atlassian.net/browse/UIKIT-2445)

## Description Of Changes

* Modify ts interface in selectors
  * getLeaveChannel to getLeaveGroupChannel
  * https://sendbird.com/docs/uikit/v3/react/core-components/sendbirdselectors#1-sendbirdselectors

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
