### PR TITLE
fix: add channel (currentGroupChannel) to RenderMessageProps

### DIFF
--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -165,10 +165,11 @@ const Message = (props: MessageUIProps): React.FC<MessageUIProps> | React.ReactE
   const renderedMessage = useMemo(() => {
     return renderMessage?.({
       message,
+      channel: currentGroupChannel,
       chainTop,
       chainBottom,
     });
-  }, [message, renderMessage]);
+  }, [message, currentGroupChannel, renderMessage]);
   const renderedCustomSeparator = useMemo(() => {
     if (renderCustomSeparator) {
       return renderCustomSeparator?.({ message: message });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 import type { User } from "@sendbird/chat";
-import type { Member } from "@sendbird/chat/groupChannel";
+import type { GroupChannel, Member } from "@sendbird/chat/groupChannel";
 import type {
   AdminMessage,
   FileMessage,
@@ -37,6 +37,7 @@ export interface ClientMessage {
 
 export interface RenderMessageProps {
   message: UserMessage | FileMessage | AdminMessage;
+  channel: GroupChannel;
   chainTop: boolean;
   chainBottom: boolean;
 }


### PR DESCRIPTION
## Description Of Changes

* Added `channel: GroupChannel` to `RenderMessageProps` in order to able to render correct message status using newly exported utils function `getOutgoingMessageState(channel, message)`

## Reason

The built-in `<MessageContent />` component has access to the "channel" object (the current active group channel) and using this it can render correct message status right here. See code references:
1. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/smart-components/Channel/components/Message/index.tsx#L314 
2. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/ui/MessageContent/index.tsx#L218
3. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/ui/MessageStatus/index.tsx#L33

But if you are using the function `renderMessage?: (props: RenderMessageProps) => React.ReactElement` on the `<Channel />` component to override/extend the component behaviour, this function does **not** provide the `channel` object and therefore you are **not able to render the correct message status**. See code:
1. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/smart-components/Channel/index.tsx#L38
2. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/smart-components/Channel/components/Message/index.tsx#L35
3. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/smart-components/Channel/components/Message/index.tsx#L166)
4. https://github.com/sendbird/sendbird-uikit-react/blob/main/src/types.d.ts#L38

Let me know if you have any questions.

## Types Of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
