### PR TITLE
[v3.2.4] (Nov 1 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog - v3
 
+## [v3.2.4] (Nov 1 2022)
+Features:
+* For Channel component, added separate prop isLoading?.boolean
+  Usage: `<Channel channelUrl {currentChannelUrl} isLoading={!currentChannelUrl} />`
+* For flicker in ChannelList, no extra props
+
+Fixes:
+* React UIKit placeholder rendering issue
+* Fix scroll issue in ChannelList where user cannot load more channels
+* Modify TS interface getLeaveChannel to getLeaveGroupChannel in selectors
+
 ## [v3.2.3] (Oct 14 2022)
 Feature:
 * Add a prop `disableMarkAsRead` into the <Channel />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Features:
* For Channel component, added separate prop isLoading?.boolean Usage: ```<Channel channelUrl {currentChannelUrl} isLoading={!currentChannelUrl} />```
  * For flicker in ChannelList, without extra props

Fixes:
* React UIKit placeholder rendering issue
* Fix scroll issue in ChannelList where user cannot load more channels
* Modify TS interface getLeaveChannel to getLeaveGroupChannel in selectors