### PR TITLE
fix: Change the parameter types of sendbird selector functions

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -151,9 +151,9 @@ declare module "SendbirdUIKitGlobal" {
   export type GetGetOpenChannel = (
     channelUrl: string,
   ) => Promise<OpenChannel>;
-  export type GetLeaveGroupChannel = (channel: GroupChannel) => Promise<void>;
-  export type GetEnterOpenChannel = (channel: OpenChannel) => Promise<OpenChannel>;
-  export type GetExitOpenChannel = (channel: OpenChannel) => Promise<void>;
+  export type GetLeaveGroupChannel = (channelUrl: string) => Promise<void>;
+  export type GetEnterOpenChannel = (channelUrl: string) => Promise<OpenChannel>;
+  export type GetExitOpenChannel = (channelUrl: string) => Promise<void>;
   export type GetFreezeChannel = (channel: GroupChannel | OpenChannel) => Promise<void>;
   export type GetUnFreezeChannel = (channel: GroupChannel | OpenChannel) => Promise<void>;
   export type GetSendUserMessage = (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -200,9 +200,9 @@ type GetGetGroupChannel = (
 type GetGetOpenChannel = (
   channelUrl: string,
 ) => Promise<OpenChannel>;
-type GetLeaveGroupChannel = (channel: GroupChannel) => Promise<void>;
-type GetEnterOpenChannel = (channel: OpenChannel) => Promise<OpenChannel>;
-type GetExitOpenChannel = (channel: OpenChannel) => Promise<void>;
+type GetLeaveGroupChannel = (channelUrl: string) => Promise<void>;
+type GetEnterOpenChannel = (channelUrl: string) => Promise<OpenChannel>;
+type GetExitOpenChannel = (channelUrl: string) => Promise<void>;
 type GetFreezeChannel = (channel: GroupChannel | OpenChannel) => Promise<void>;
 type GetUnFreezeChannel = (channel: GroupChannel | OpenChannel) => Promise<void>;
 type GetSendUserMessage = (


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2445](https://sendbird.atlassian.net/browse/UIKIT-2445)

## Description Of Changes

(TS) Change the parameter types of sendbird selector functions from `channel` to `channelUrl`
* getLeaveGroupChannel
* getEnterOpenChannel
* getExitOpenChannel

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
