### PR TITLE
Release/v3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - v3
 
-## [v3.2.5] (Nov 4 2022)
+## [v3.2.5] (Nov 7 2022)
 Fix:
 * Modify the type of parameters in the sendbirdSelectors
   There has been unsyncronous between reality and types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - v3
 
+## [v3.2.5] (Nov 4 2022)
+Fix:
+* Modify the type of parameters in the sendbirdSelectors
+  There has been unsyncronous between reality and types
+  This fix only affects to TypeScript
+  * getLeaveGroupChannel: `channel` to `channelUrl`
+  * getEnterOpenChannel: `channel` to `channelUrl`
+  * getExitOpenChannel: `channel` to `channelUrl`
+
 ## [v3.2.4] (Nov 1 2022)
 Features:
 * For Channel component, added separate prop isLoading?.boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
## [v3.2.5] (Nov 4 2022)
Fix:
* Modify the type of parameters in the sendbirdSelectors
  There has been unsyncronous between reality and types
  This fix only affects to TypeScript
  * getLeaveGroupChannel: `channel` to `channelUrl`
  * getEnterOpenChannel: `channel` to `channelUrl`
  * getExitOpenChannel: `channel` to `channelUrl`