### PR TITLE
fix: use ref instead of querySelector for DOM manipulation

### DIFF
--- a/src/smart-components/Channel/context/ChannelProvider.tsx
+++ b/src/smart-components/Channel/context/ChannelProvider.tsx
@@ -321,12 +321,18 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     replyType,
   }, {
     logger,
+    scrollRef,
     messagesDispatcher,
   });
 
   // handles API calls from withSendbird
   useEffect(() => {
-    const subscriber = utils.pubSubHandler(channelUrl, pubSub, messagesDispatcher);
+    const subscriber = utils.pubSubHandler({
+      channelUrl,
+      pubSub,
+      messagesDispatcher,
+      scrollRef,
+    });
     return () => {
       utils.pubSubHandleRemover(subscriber);
     };
@@ -336,6 +342,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   useHandleReconnect({ isOnline, replyType, disableMarkAsRead }, {
     logger,
     sdk,
+    scrollRef,
     currentGroupChannel,
     messagesDispatcher,
     userFilledMessageListQuery,
@@ -357,6 +364,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     {
       logger,
       pubSub,
+      scrollRef,
       messagesDispatcher,
     },
   );
@@ -365,6 +373,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     {
       logger,
       pubSub,
+      scrollRef,
       messagesDispatcher,
     },
   );

--- a/src/smart-components/Channel/context/hooks/useHandleChannelEvents.ts
+++ b/src/smart-components/Channel/context/hooks/useHandleChannelEvents.ts
@@ -74,7 +74,7 @@ function useHandleChannelEvents(
                   if (!disableMarkAsRead) {
                     currentGroupChannel?.markAsRead?.();
                   }
-                  scrollIntoLast();
+                  scrollIntoLast(0, scrollRef);
                 });
               } catch (error) {
                 logger.warning('Channel | onMessageReceived | scroll to end failed');

--- a/src/smart-components/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/smart-components/Channel/context/hooks/useHandleReconnect.ts
@@ -20,6 +20,7 @@ interface StaticParams {
   logger: Logger;
   sdk: SendbirdGroupChat;
   currentGroupChannel: GroupChannel;
+  scrollRef: React.RefObject<HTMLDivElement>;
   messagesDispatcher: ({ type: string, payload: any }) => void;
   userFilledMessageListQuery?: Record<string, any>;
 }
@@ -29,6 +30,7 @@ function useHandleReconnect(
   {
     logger,
     sdk,
+    scrollRef,
     currentGroupChannel,
     messagesDispatcher,
     userFilledMessageListQuery,
@@ -80,7 +82,7 @@ function useHandleReconnect(
                     messages,
                   },
                 });
-                setTimeout(() => utils.scrollIntoLast());
+                setTimeout(() => utils.scrollIntoLast(0, scrollRef));
               })
               .catch((error) => {
                 logger.error('Channel: Fetching messages failed', error);

--- a/src/smart-components/Channel/context/hooks/useInitialMessagesFetch.js
+++ b/src/smart-components/Channel/context/hooks/useInitialMessagesFetch.js
@@ -12,6 +12,7 @@ function useInitialMessagesFetch({
   replyType,
 }, {
   logger,
+  scrollRef,
   messagesDispatcher,
 }) {
   const channelUrl = currentGroupChannel?.url;
@@ -76,7 +77,7 @@ function useInitialMessagesFetch({
         })
         .finally(() => {
           if (!initialTimeStamp) {
-            setTimeout(() => utils.scrollIntoLast());
+            setTimeout(() => utils.scrollIntoLast(0, scrollRef));
           }
         });
     }

--- a/src/smart-components/Channel/context/hooks/useSendFileMessageCallback.js
+++ b/src/smart-components/Channel/context/hooks/useSendFileMessageCallback.js
@@ -11,6 +11,7 @@ export default function useSendFileMessageCallback({
 }, {
   logger,
   pubSub,
+  scrollRef,
   messagesDispatcher,
 }) {
   const sendMessage = useCallback((file, quoteMessage = null) => {
@@ -87,7 +88,7 @@ export default function useSendFileMessageCallback({
                     },
                     channel: currentGroupChannel,
                   });
-                  setTimeout(() => utils.scrollIntoLast(), 1000);
+                  setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
                 })
                 .onFailed((err, failedMessage) => {
                   logger.error('Channel: Sending file message failed!', { failedMessage, err });
@@ -137,7 +138,7 @@ export default function useSendFileMessageCallback({
             },
             channel: currentGroupChannel,
           });
-          setTimeout(() => utils.scrollIntoLast(), 1000);
+          setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
         })
         .onFailed((error, message) => {
           logger.error('Channel: Sending file message failed!', { message, error });

--- a/src/smart-components/Channel/context/hooks/useSendMessageCallback.js
+++ b/src/smart-components/Channel/context/hooks/useSendMessageCallback.js
@@ -11,6 +11,7 @@ export default function useSendMessageCallback({
 }, {
   logger,
   pubSub,
+  scrollRef,
   messagesDispatcher,
 }) {
   const messageInputRef = useRef(null);
@@ -63,7 +64,7 @@ export default function useSendMessageCallback({
             message: pendingMsg,
             channel: currentGroupChannel,
           });
-          setTimeout(() => utils.scrollIntoLast());
+          setTimeout(() => utils.scrollIntoLast(0, scrollRef));
         })
         .onFailed((err, msg) => {
           logger.warning('Channel: Sending message failed!', { message: msg, error: err });

--- a/src/smart-components/Channel/context/utils.js
+++ b/src/smart-components/Channel/context/utils.js
@@ -8,19 +8,19 @@ import { OutgoingMessageStates } from '../../../utils/exports/getOutgoingMessage
 const UNDEFINED = 'undefined';
 const { SUCCEEDED, FAILED, PENDING } = getSendingMessageStatus();
 
-export const scrollIntoLast = (intialTry = 0) => {
+export const scrollIntoLast = (intialTry = 0, scrollRef) => {
   const MAX_TRIES = 10;
   const currentTry = intialTry;
   if (currentTry > MAX_TRIES) {
     return;
   }
   try {
-    const scrollDOM = document.querySelector('.sendbird-conversation__messages-padding');
+    const scrollDOM = scrollRef?.current || document.querySelector('.sendbird-conversation__messages-padding');
     // eslint-disable-next-line no-multi-assign
     scrollDOM.scrollTop = scrollDOM.scrollHeight;
   } catch (error) {
     setTimeout(() => {
-      scrollIntoLast(currentTry + 1);
+      scrollIntoLast(currentTry + 1, scrollRef);
     }, 500 * currentTry);
   }
 };
@@ -35,12 +35,17 @@ export const pubSubHandleRemover = (subscriber) => {
   });
 };
 
-export const pubSubHandler = (channelUrl, pubSub, dispatcher) => {
+export const pubSubHandler = ({
+  channelUrl,
+  pubSub,
+  dispatcher,
+  scrollRef,
+}) => {
   const subscriber = new Map();
   if (!pubSub || !pubSub.subscribe) return subscriber;
   subscriber.set(topics.SEND_USER_MESSAGE, pubSub.subscribe(topics.SEND_USER_MESSAGE, (msg) => {
     const { channel, message } = msg;
-    scrollIntoLast();
+    scrollIntoLast(0, scrollRef);
     if (channelUrl === channel?.url) {
       dispatcher({
         type: channelActions.SEND_MESSAGEGE_SUCESS,
@@ -59,7 +64,7 @@ export const pubSubHandler = (channelUrl, pubSub, dispatcher) => {
   }));
   subscriber.set(topics.SEND_FILE_MESSAGE, pubSub.subscribe(topics.SEND_FILE_MESSAGE, (msg) => {
     const { channel, message } = msg;
-    scrollIntoLast();
+    scrollIntoLast(0, scrollRef);
     if (channelUrl === channel?.url) {
       dispatcher({
         type: channelActions.SEND_MESSAGEGE_SUCESS,

--- a/src/smart-components/Channel/context/utils.js
+++ b/src/smart-components/Channel/context/utils.js
@@ -8,9 +8,9 @@ import { OutgoingMessageStates } from '../../../utils/exports/getOutgoingMessage
 const UNDEFINED = 'undefined';
 const { SUCCEEDED, FAILED, PENDING } = getSendingMessageStatus();
 
-export const scrollIntoLast = (intialTry = 0, scrollRef) => {
+export const scrollIntoLast = (initialTry = 0, scrollRef) => {
   const MAX_TRIES = 10;
-  const currentTry = intialTry;
+  const currentTry = initialTry;
   if (currentTry > MAX_TRIES) {
     return;
   }

--- a/src/smart-components/OpenChannel/components/OpenChannelUI/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelUI/index.tsx
@@ -36,6 +36,7 @@ const OpenChannelUI: React.FC<OpenChannelUIProps> = ({
     loading,
     isInvalid,
     messageInputRef,
+    conversationScrollRef,
   } = useOpenChannelContext();
   if (
     !currentOpenChannel
@@ -70,6 +71,7 @@ const OpenChannelUI: React.FC<OpenChannelUIProps> = ({
         )
       }
       <OpenChannelMessageList
+        ref={conversationScrollRef}
         renderMessage={renderMessage}
         renderPlaceHolderEmptyList={renderPlaceHolderEmptyList}
       />

--- a/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
+++ b/src/smart-components/OpenChannel/context/OpenChannelProvider.tsx
@@ -166,11 +166,11 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
   );
   useHandleChannelEvents(
     { currentOpenChannel, checkScrollBottom },
-    { sdk, logger, messagesDispatcher },
+    { sdk, logger, messagesDispatcher, scrollRef: conversationScrollRef },
   );
   useInitialMessagesFetch(
     { currentOpenChannel, userFilledMessageListParams },
-    { logger, messagesDispatcher },
+    { logger, messagesDispatcher, scrollRef: conversationScrollRef },
   );
 
   const fetchMore: boolean = utils.shouldFetchMore(allMessages?.length, messageLimit);
@@ -181,11 +181,11 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
   );
   const handleSendMessage = useSendMessageCallback(
     { currentOpenChannel, onBeforeSendUserMessage, checkScrollBottom, messageInputRef },
-    { sdk, logger, messagesDispatcher },
+    { sdk, logger, messagesDispatcher, scrollRef: conversationScrollRef },
   );
   const handleFileUpload = useFileUploadCallback(
     { currentOpenChannel, onBeforeSendFileMessage, checkScrollBottom, imageCompression },
-    { sdk, logger, messagesDispatcher },
+    { sdk, logger, messagesDispatcher, scrollRef: conversationScrollRef },
   );
   const updateMessage = useUpdateMessageCallback(
     { currentOpenChannel, onBeforeSendUserMessage },
@@ -213,7 +213,7 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
     }
     subscriber.set(topics.SEND_USER_MESSAGE, pubSub.subscribe(topics.SEND_USER_MESSAGE, (msg) => {
       const { channel, message } = msg;
-      scrollIntoLast();
+      scrollIntoLast(0, conversationScrollRef);
       if (channel && (channelUrl === channel?.url)) {
         messagesDispatcher({
           type: messageActionTypes.SENDING_MESSAGE_SUCCEEDED,
@@ -232,7 +232,7 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
     }));
     subscriber.set(topics.SEND_FILE_MESSAGE, pubSub.subscribe(topics.SEND_FILE_MESSAGE, (msg) => {
       const { channel, message } = msg;
-      scrollIntoLast();
+      scrollIntoLast(0, conversationScrollRef);
       if (channel && (channelUrl === channel?.url)) {
         messagesDispatcher({
           type: messageActionTypes.SENDING_MESSAGE_SUCCEEDED,

--- a/src/smart-components/OpenChannel/context/hooks/useFileUploadCallback.ts
+++ b/src/smart-components/OpenChannel/context/hooks/useFileUploadCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import type { OpenChannel, SendbirdOpenChat } from '@sendbird/chat/openChannel';
 import type { FileMessageCreateParams } from '@sendbird/chat/message';
 
@@ -19,19 +19,19 @@ interface DynamicParams {
 interface StaticParams {
   sdk: SendbirdOpenChat;
   logger: Logger;
+  scrollRef: React.RefObject<HTMLElement>;
   messagesDispatcher: ({ type: string, payload: any }) => void;
 }
 
 type CallbackReturn = (file: File) => void;
 
-function useFileUploadCallback(
-  {
-    currentOpenChannel,
-    checkScrollBottom,
-    imageCompression = {},
-    onBeforeSendFileMessage,
+function useFileUploadCallback({
+  currentOpenChannel,
+  checkScrollBottom,
+  imageCompression = {},
+  onBeforeSendFileMessage,
   }: DynamicParams,
-  { sdk, logger, messagesDispatcher }: StaticParams,
+  { sdk, logger, messagesDispatcher, scrollRef }: StaticParams,
 ): CallbackReturn {
   return useCallback((file) => {
     if (sdk) {
@@ -113,7 +113,7 @@ function useFileUploadCallback(
                     });
                     if (isBottom) {
                       setTimeout(() => {
-                        utils.scrollIntoLast();
+                        utils.scrollIntoLast(0, scrollRef);
                       });
                     }
                   })
@@ -167,7 +167,7 @@ function useFileUploadCallback(
             });
             if (isBottom) {
               setTimeout(() => {
-                utils.scrollIntoLast();
+                utils.scrollIntoLast(0, scrollRef);
               });
             }
           })

--- a/src/smart-components/OpenChannel/context/hooks/useHandleChannelEvents.ts
+++ b/src/smart-components/OpenChannel/context/hooks/useHandleChannelEvents.ts
@@ -16,12 +16,13 @@ interface DynamicParams {
 interface StaticParams {
   sdk: SendbirdOpenChat;
   logger: Logger;
+  scrollRef: React.RefObject<HTMLElement>;
   messagesDispatcher: (props: MessagesDispatcherType) => void;
 }
 
 function useHandleChannelEvents(
   { currentOpenChannel, checkScrollBottom }: DynamicParams,
-  { sdk, logger, messagesDispatcher }: StaticParams,
+  { sdk, logger, messagesDispatcher, scrollRef }: StaticParams,
 ): void {
   useEffect(() => {
     const messageReceiverId = uuidv4();
@@ -39,7 +40,7 @@ function useHandleChannelEvents(
           if (scrollToEnd) {
             try {
               setTimeout(() => {
-                scrollIntoLast();
+                scrollIntoLast(0, scrollRef);
               });
             } catch (error) {
               logger.warning('OpenChannel | onMessageReceived | scroll to end failed');

--- a/src/smart-components/OpenChannel/context/hooks/useInitialMessagesFetch.ts
+++ b/src/smart-components/OpenChannel/context/hooks/useInitialMessagesFetch.ts
@@ -1,6 +1,6 @@
 import { MessageListParams } from '@sendbird/chat/message';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import type { CustomUseReducerDispatcher, Logger } from '../../../../lib/SendbirdState';
 import * as messageActionTypes from '../dux/actionTypes';
@@ -14,11 +14,12 @@ interface DynamicParams {
 interface StaticParams {
   logger: Logger;
   messagesDispatcher: CustomUseReducerDispatcher;
+  scrollRef: React.RefObject<HTMLElement>;
 }
 
 function useInitialMessagesFetch(
   { currentOpenChannel, userFilledMessageListParams }: DynamicParams,
-  { logger, messagesDispatcher }: StaticParams,
+  { logger, messagesDispatcher, scrollRef }: StaticParams,
 ): void {
   useEffect(() => {
     logger.info('OpenChannel | useInitialMessagesFetch: Setup started', currentOpenChannel);
@@ -59,7 +60,7 @@ function useInitialMessagesFetch(
             lastMessageTimestamp,
           },
         });
-        setTimeout(() => { scrollIntoLast(); });
+        setTimeout(() => { scrollIntoLast(0, scrollRef); });
       }).catch((error) => {
         logger.error('OpenChannel | useInitialMessagesFetch: Fetching messages failed', error);
         messagesDispatcher({

--- a/src/smart-components/OpenChannel/context/hooks/useSendMessageCallback.ts
+++ b/src/smart-components/OpenChannel/context/hooks/useSendMessageCallback.ts
@@ -1,7 +1,7 @@
 import type { UserMessageCreateParams } from '@sendbird/chat/message';
 import type { OpenChannel, SendbirdOpenChat } from '@sendbird/chat/openChannel';
 
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import type { Logger } from '../../../../lib/SendbirdState';
 import * as messageActionTypes from '../dux/actionTypes';
 import * as utils from '../utils';
@@ -16,11 +16,12 @@ interface StaticParams {
   sdk: SendbirdOpenChat;
   logger: Logger;
   messagesDispatcher: (props: { type: string, payload: any }) => void;
+  scrollRef: React.RefObject<HTMLElement>;
 }
 
 function useSendMessageCallback(
   { currentOpenChannel, onBeforeSendUserMessage, checkScrollBottom, messageInputRef }: DynamicParams,
-  { sdk, logger, messagesDispatcher }: StaticParams,
+  { sdk, logger, messagesDispatcher, scrollRef }: StaticParams,
 ): () => void {
   return useCallback(() => {
     if (sdk) {
@@ -60,7 +61,7 @@ function useSendMessageCallback(
           });
           if (isBottom) {
             setTimeout(() => {
-              utils.scrollIntoLast();
+              utils.scrollIntoLast(0, scrollRef);
             });
           }
         })

--- a/src/smart-components/OpenChannel/context/utils.ts
+++ b/src/smart-components/OpenChannel/context/utils.ts
@@ -21,9 +21,9 @@ export const shouldFetchMore = (messageLength: number, maxMessages: number): boo
   return false;
 }
 
-export const scrollIntoLast = (intialTry = 0, scrollRef: React.RefObject<HTMLElement>): void => {
+export const scrollIntoLast = (initialTry = 0, scrollRef: React.RefObject<HTMLElement>): void => {
   const MAX_TRIES = 10;
-  const currentTry = intialTry;
+  const currentTry = initialTry;
   if (currentTry > MAX_TRIES) {
     return;
   }

--- a/src/smart-components/OpenChannel/context/utils.ts
+++ b/src/smart-components/OpenChannel/context/utils.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type { User } from '@sendbird/chat';
 import type { AdminMessage, FileMessage, UserMessage } from '@sendbird/chat/message';
 import type { OpenChannel, ParticipantListQuery } from '@sendbird/chat/openChannel';
@@ -20,19 +21,19 @@ export const shouldFetchMore = (messageLength: number, maxMessages: number): boo
   return false;
 }
 
-export const scrollIntoLast = (intialTry = 0): void => {
+export const scrollIntoLast = (intialTry = 0, scrollRef: React.RefObject<HTMLElement>): void => {
   const MAX_TRIES = 10;
   const currentTry = intialTry;
   if (currentTry > MAX_TRIES) {
     return;
   }
   try {
-    const scrollDOM = document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
+    const scrollDOM = scrollRef?.current || document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
     // eslint-disable-next-line no-multi-assign
     scrollDOM.scrollTop = scrollDOM.scrollHeight;
   } catch (error) {
     setTimeout(() => {
-      scrollIntoLast(currentTry + 1);
+      scrollIntoLast(currentTry + 1, scrollRef);
     }, 500 * currentTry);
   }
 };

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -47,6 +47,14 @@ const displayCaret = (element, position) => {
   element.focus();
 }
 
+const resetInput = (ref) => {
+  try {
+    ref.current.innerHTML = '';
+  } catch {
+    //
+  }
+}
+
 const initialTargetStringInfo = {
   targetString: '',
   startNodeIndex: null,
@@ -122,7 +130,7 @@ const MessageInput = React.forwardRef((props, ref) => {
   useEffect(() => {
     if (!isEdit) {
       setIsInput(false);
-      document.getElementById(TEXT_FIELD_ID).innerHTML = '';
+      resetInput(ref);
     }
   }, [channelUrl]);
 
@@ -326,7 +334,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       });
       const params = { message: messageText, mentionTemplate };
       onSendMessage(params);
-      document.getElementById(TEXT_FIELD_ID).innerHTML = '';
+      resetInput(ref);
       setIsInput(false);
       setHeight();
     }
@@ -354,7 +362,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       });
       const params = { messageId, message: messageText, mentionTemplate };
       onUpdateMessage(params);
-      document.getElementById(TEXT_FIELD_ID).innerHTML = '';
+      resetInput(ref);
     }
   };
 
@@ -413,7 +421,7 @@ const MessageInput = React.forwardRef((props, ref) => {
           onInput={() => {
             setHeight();
             onStartTyping();
-            setIsInput(document?.getElementById?.(TEXT_FIELD_ID)?.innerText?.length > 0);
+            setIsInput(ref?.current?.innerText?.length > 0);
             useMentionedLabelDetection();
           }}
           onPaste={(e) => {


### PR DESCRIPTION
QuerySelector is inaccurate when multiple channels are rendered parallel

This doesnt include root for dropdowns/fileviewer etc