### PR TITLE
[v3.2.6] (Nov 14 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - v3
 
+## [v3.2.6] (Nov 14 2022)
+Fix:
+* Use ref instead of querySelector for DOM manipulation
+ Fixes the issue where input is not cleared when multiple channels are open at the same time
+* Apply pre-line into the OpenChannelUserMessage
+ Fixes the issue where OpenChannel UserMessage doesnt have new line
+
 ## [v3.2.5] (Nov 7 2022)
 Fix:
 * Modify the type of parameters in the sendbirdSelectors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Fix:
* Use ref instead of querySelector for DOM manipulation
  Fixes the issue where input is not cleared when multiple channels are open at the same time
* Apply pre-line into the OpenChannelUserMessage
 Fixes the issue where OpenChannel UserMessage doesnt have new line
