### PR TITLE
fix: onlinestatus should work even configureSession is provided

### DIFF
--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -140,7 +140,7 @@ export default function Sendbird(props) {
     };
   }, [currenttheme]);
 
-  const isOnline = useOnlineStatus(sdkStore.sdk, logger, configureSession);
+  const isOnline = useOnlineStatus(sdkStore.sdk, logger);
 
   const localeStringSet = React.useMemo(() => {
     if (!stringSet) {

--- a/src/lib/hooks/useOnlineStatus.js
+++ b/src/lib/hooks/useOnlineStatus.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 
 import { uuidv4 } from '../../utils/uuid';
 
-function useConnectionStatus(sdk, logger, configureSession) {
+function useConnectionStatus(sdk, logger) {
   const [isOnline, setIsOnline] = useState(true);
 
   useEffect(() => {
@@ -29,7 +29,7 @@ function useConnectionStatus(sdk, logger, configureSession) {
       logger.info('Added ConnectionHandler', uniqueHandlerId);
       // workaround -> addConnectionHandler invalidates session handler
       // provided through configureSession
-      if (sdk?.addConnectionHandler && !configureSession) {
+      if (sdk?.addConnectionHandler) {
         sdk.addConnectionHandler(uniqueHandlerId, handler);
       }
     } catch {
@@ -43,7 +43,7 @@ function useConnectionStatus(sdk, logger, configureSession) {
         //
       }
     };
-  }, [sdk, configureSession]);
+  }, [sdk]);
 
   useEffect(() => {
     const tryReconnect = () => {


### PR DESCRIPTION
This feature was disabled because of a bug in sessionHandler in SDK now,
we can re-enable this
see: https://github.com/sendbird/sendbird-uikit-react/pull/307
fixes: https://sendbird.atlassian.net/browse/SBISSUE-10323