### PR TITLE
[v3.3.1] (Nov 23 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog - v3
 
+## [v3.3.1] (Nov 23 2022)
+Fixes:
+* Rename properties of `useThreadContext`
+  * `channelStatus` to `channelState`
+  * `parentMessageInfoStatus` to `parentMessageState`
+  * `threadListStatus` to `threadListState`
+* Change the state types to enum
+  ```typescript
+  enum ChannelStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
+  enum ParentMessageStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
+  enum ThreadListStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
+  ```
+
 ## [v3.3.0] (Nov 23 2022)
 Features:
 * Provide new module `Thread`. See the specific informations of this module on the [Docs page](https://sendbird.com/docs/uikit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -893,7 +893,7 @@ declare module "SendbirdUIKitGlobal" {
     INVALID = 'INVALID',
     INITIALIZED = 'INITIALIZED',
   }
-  export enum ParentMessageInfoStateTypes {
+  export enum ParentMessageStateTypes {
     NIL = 'NIL',
     LOADING = 'LOADING',
     INVALID = 'INVALID',
@@ -942,9 +942,9 @@ declare module "SendbirdUIKitGlobal" {
     currentChannel: GroupChannel;
     allThreadMessages: Array<BaseMessage>;
     parentMessage: UserMessage | FileMessage;
-    channelStatus: ChannelStateTypes;
-    parentMessageInfoStatus: ParentMessageInfoStateTypes;
-    threadListStatus: ThreadListStateTypes;
+    channelState: ChannelStateTypes;
+    parentMessageState: ParentMessageStateTypes;
+    threadListState: ThreadListStateTypes;
     hasMorePrev: boolean;
     hasMoreNext: boolean;
     emojiContainer: EmojiContainer;
@@ -959,7 +959,7 @@ declare module "SendbirdUIKitGlobal" {
     renderMessage?: (props: { message: UserMessage | FileMessage }) => React.ReactElement;
     renderMessageInput?: () => React.ReactElement;
     renderCustomSeparator?: () => React.ReactElement;
-    renderParentMessageInfoPlaceholder?: (type: ParentMessageInfoStateTypes) => React.ReactElement;
+    renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
     renderThreadListPlaceHolder?: (type: ThreadListStateTypes) => React.ReactElement;
   }
 
@@ -1501,10 +1501,24 @@ declare module '@sendbird/uikit-react/Thread/context' {
 }
 
 declare module '@sendbird/uikit-react/Thread/context/types' {
-  import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
-  export const ChannelStateTypes: SendbirdUIKitGlobal.ChannelStateTypes;
-  export const ParentMessageInfoStateTypes: SendbirdUIKitGlobal.ParentMessageInfoStateTypes;
-  export const ThreadListStateTypes: SendbirdUIKitGlobal.ThreadListStateTypes;
+  export enum ChannelStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
+  export enum ParentMessageStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
+  export enum ThreadListStateTypes {
+    NIL = 'NIL',
+    LOADING = 'LOADING',
+    INVALID = 'INVALID',
+    INITIALIZED = 'INITIALIZED',
+  }
 }
 
 declare module '@sendbird/uikit-react/Thread/components/ThreadUI' {

--- a/src/smart-components/ChannelSettings/components/ModerationPanel/MembersModal.tsx
+++ b/src/smart-components/ChannelSettings/components/ModerationPanel/MembersModal.tsx
@@ -72,7 +72,7 @@ export default function MembersModal({ onCancel }: Props): ReactElement {
               <UserListItem
                 user={member}
                 key={member.userId}
-                currentUserId={currentUser}
+                currentUser={currentUser}
                 action={({ parentRef, actionRef }) => (
                   <>
                     {channel?.myRole === 'operator' && (

--- a/src/smart-components/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
+++ b/src/smart-components/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
@@ -70,7 +70,7 @@ export default function MutedMembersModal({
         >
           { members.map((member) => (
             <UserListItem
-              currentUserId={currentUser}
+              currentUser={currentUser}
               user={member}
               key={member.userId}
               action={({ actionRef, parentRef }) => (

--- a/src/smart-components/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
+++ b/src/smart-components/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
@@ -64,7 +64,7 @@ export default function OperatorsModal({ onCancel }: Props): ReactElement {
         >
           {operators.map((member) => (
             <UserListItem
-              currentUserId={currentUserId}
+              currentUser={currentUserId}
               user={member}
               key={member.userId}
               action={({ parentRef, actionRef }) => (

--- a/src/smart-components/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/smart-components/Thread/components/ThreadList/ThreadListItem.tsx
@@ -51,7 +51,7 @@ export default function ThreadListItem({
     nicknamesMap,
     emojiContainer,
     toggleReaction,
-    threadListStatus,
+    threadListState,
     updateMessage,
     resendMessage,
     deleteMessage,
@@ -112,7 +112,7 @@ export default function ThreadListItem({
   }, [mentionedUserIds]);
 
   // edit input
-  const disabled = !(threadListStatus === ThreadListStateTypes.INITIALIZED)
+  const disabled = !(threadListState === ThreadListStateTypes.INITIALIZED)
     || !isOnline
     || isMuted
     || isChannelFrozen;

--- a/src/smart-components/Thread/components/ThreadUI/index.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/index.tsx
@@ -7,7 +7,7 @@ import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import { getChannelTitle } from '../../../Channel/components/ChannelHeader/utils';
 import { useThreadContext } from '../../context/ThreadProvider';
-import { ParentMessageInfoStateTypes, ThreadListStateTypes } from '../../types';
+import { ParentMessageStateTypes, ThreadListStateTypes } from '../../types';
 import ParentMessageInfo from '../ParentMessageInfo';
 import ThreadHeader from '../ThreadHeader';
 import ThreadList from '../ThreadList';
@@ -24,7 +24,7 @@ export interface ThreadUIProps {
   renderMessage?: (props: { message: UserMessage | FileMessage }) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderCustomSeparator?: () => React.ReactElement;
-  renderParentMessageInfoPlaceholder?: (type: ParentMessageInfoStateTypes) => React.ReactElement;
+  renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
   renderThreadListPlaceHolder?: (type: ThreadListStateTypes) => React.ReactElement;
 }
 
@@ -48,8 +48,8 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
     currentChannel,
     allThreadMessages,
     parentMessage,
-    parentMessageInfoStatus,
-    threadListStatus,
+    parentMessageState,
+    threadListState,
     hasMorePrev,
     hasMoreNext,
     fetchPrevThreads,
@@ -63,12 +63,12 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
   const MemorizedHeader = useMemorizedHeader({ renderHeader });
   const MemorizedParentMessageInfo = useMemorizedParentMessageInfo({
     parentMessage,
-    parentMessageInfoStatus,
+    parentMessageState,
     renderParentMessageInfo,
     renderParentMessageInfoPlaceholder, // nil, loading, invalid
   });
   const MemorizedThreadList = useMemorizedThreadList({
-    threadListStatus,
+    threadListState,
     renderThreadListPlaceHolder,
   });
 

--- a/src/smart-components/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
@@ -1,31 +1,31 @@
 import React, { ReactElement, useMemo } from 'react';
 
-import { ParentMessageInfoStateTypes } from '../../types';
+import { ParentMessageStateTypes } from '../../types';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import { FileMessage, UserMessage } from '@sendbird/chat/message';
 
 export interface UseMemorizedParentMessageInfoProps {
   parentMessage: UserMessage | FileMessage;
-  parentMessageInfoStatus: ParentMessageInfoStateTypes;
+  parentMessageState: ParentMessageStateTypes;
   renderParentMessageInfo?: () => React.ReactElement;
-  renderParentMessageInfoPlaceholder?: (type: ParentMessageInfoStateTypes) => React.ReactElement;
+  renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
 }
 
 const useMemorizedParentMessageInfo = ({
   parentMessage,
-  parentMessageInfoStatus,
+  parentMessageState,
   renderParentMessageInfo,
   renderParentMessageInfoPlaceholder,
 }: UseMemorizedParentMessageInfoProps): ReactElement => useMemo(() => {
-  if (parentMessageInfoStatus === ParentMessageInfoStateTypes.NIL
-    || parentMessageInfoStatus === ParentMessageInfoStateTypes.LOADING
-    || parentMessageInfoStatus === ParentMessageInfoStateTypes.INVALID
+  if (parentMessageState === ParentMessageStateTypes.NIL
+    || parentMessageState === ParentMessageStateTypes.LOADING
+    || parentMessageState === ParentMessageStateTypes.INVALID
   ) {
     if (typeof renderParentMessageInfoPlaceholder === 'function') {
-      return renderParentMessageInfoPlaceholder(parentMessageInfoStatus);
+      return renderParentMessageInfoPlaceholder(parentMessageState);
     }
-    switch (parentMessageInfoStatus) {
-      case ParentMessageInfoStateTypes.NIL: {
+    switch (parentMessageState) {
+      case ParentMessageStateTypes.NIL: {
         return (
           <PlaceHolder
             className="sendbird-thread-ui__parent-message-info placeholder-nil"
@@ -34,7 +34,7 @@ const useMemorizedParentMessageInfo = ({
           />
         );
       }
-      case ParentMessageInfoStateTypes.LOADING: {
+      case ParentMessageStateTypes.LOADING: {
         return (
           <PlaceHolder
             className="sendbird-thread-ui__parent-message-info placeholder-loading"
@@ -43,7 +43,7 @@ const useMemorizedParentMessageInfo = ({
           />
         );
       }
-      case ParentMessageInfoStateTypes.INVALID: {
+      case ParentMessageStateTypes.INVALID: {
         return (
           <PlaceHolder
             className="sendbird-thread-ui__parent-message-info placeholder-invalid"
@@ -56,7 +56,7 @@ const useMemorizedParentMessageInfo = ({
         return null;
       }
     }
-  } else if (parentMessageInfoStatus === ParentMessageInfoStateTypes.INITIALIZED) {
+  } else if (parentMessageState === ParentMessageStateTypes.INITIALIZED) {
     if (typeof renderParentMessageInfo === 'function') {
       return renderParentMessageInfo();
     }
@@ -64,7 +64,7 @@ const useMemorizedParentMessageInfo = ({
   return null;
 }, [
   parentMessage,
-  parentMessageInfoStatus,
+  parentMessageState,
   renderParentMessageInfo,
   renderParentMessageInfoPlaceholder,
 ]);

--- a/src/smart-components/Thread/components/ThreadUI/useMemorizedThreadList.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/useMemorizedThreadList.tsx
@@ -4,22 +4,22 @@ import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import { ThreadListStateTypes } from '../../types';
 
 export interface UseMemorizedThreadListProps {
-  threadListStatus: ThreadListStateTypes;
+  threadListState: ThreadListStateTypes;
   renderThreadListPlaceHolder?: (tyep: ThreadListStateTypes) => React.ReactElement;
 }
 
 const useMemorizedThreadList = ({
-  threadListStatus,
+  threadListState,
   renderThreadListPlaceHolder,
 }: UseMemorizedThreadListProps): ReactElement => useMemo(() => {
-  if (threadListStatus === ThreadListStateTypes.NIL
-    || threadListStatus === ThreadListStateTypes.LOADING
-    || threadListStatus === ThreadListStateTypes.INVALID
+  if (threadListState === ThreadListStateTypes.NIL
+    || threadListState === ThreadListStateTypes.LOADING
+    || threadListState === ThreadListStateTypes.INVALID
   ) {
     if (typeof renderThreadListPlaceHolder === 'function') {
-      return renderThreadListPlaceHolder(threadListStatus);
+      return renderThreadListPlaceHolder(threadListState);
     }
-    switch (threadListStatus) {
+    switch (threadListState) {
       case ThreadListStateTypes.LOADING: {
         return (
           <PlaceHolder
@@ -48,7 +48,7 @@ const useMemorizedThreadList = ({
   }
   return null;
 }, [
-  threadListStatus,
+  threadListState,
   renderThreadListPlaceHolder,
 ]);
 

--- a/src/smart-components/Thread/context/ThreadProvider.tsx
+++ b/src/smart-components/Thread/context/ThreadProvider.tsx
@@ -95,9 +95,9 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     currentChannel,
     allThreadMessages,
     parentMessage,
-    channelStatus,
-    threadListStatus,
-    parentMessageInfoStatus,
+    channelState,
+    threadListState,
+    parentMessageState,
     hasMorePrev,
     hasMoreNext,
     emojiContainer,
@@ -146,14 +146,14 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
   const fetchPrevThreads = useGetPrevThreadsCallback({
     hasMorePrev,
     parentMessage,
-    threadListStatus,
+    threadListState,
     isReactionEnabled,
     oldestMessageTimeStamp: allThreadMessages[0]?.createdAt || 0,
   }, { logger, threadDispatcher });
   const fetchNextThreads = useGetNextThreadsCallback({
     hasMoreNext,
     parentMessage,
-    threadListStatus,
+    threadListState,
     isReactionEnabled,
     latestMessageTimeStamp: allThreadMessages[allThreadMessages.length - 1]?.createdAt || 0
   }, { logger, threadDispatcher });
@@ -193,9 +193,9 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
         currentChannel,
         allThreadMessages,
         parentMessage,
-        channelStatus,
-        threadListStatus,
-        parentMessageInfoStatus,
+        channelState,
+        threadListState,
+        parentMessageState,
         hasMorePrev,
         hasMoreNext,
         emojiContainer,

--- a/src/smart-components/Thread/context/dux/initialState.ts
+++ b/src/smart-components/Thread/context/dux/initialState.ts
@@ -3,7 +3,7 @@ import { GroupChannel } from "@sendbird/chat/groupChannel";
 import { BaseMessage, FileMessage, UserMessage } from "@sendbird/chat/message";
 import {
   ChannelStateTypes,
-  ParentMessageInfoStateTypes,
+  ParentMessageStateTypes,
   ThreadListStateTypes,
 } from "../../types";
 
@@ -11,9 +11,9 @@ export interface ThreadContextInitialState {
   currentChannel: GroupChannel;
   allThreadMessages: Array<BaseMessage>;
   parentMessage: UserMessage | FileMessage;
-  channelStatus: ChannelStateTypes;
-  parentMessageInfoStatus: ParentMessageInfoStateTypes;
-  threadListStatus: ThreadListStateTypes;
+  channelState: ChannelStateTypes;
+  parentMessageState: ParentMessageStateTypes;
+  threadListState: ThreadListStateTypes;
   hasMorePrev: boolean;
   hasMoreNext: boolean;
   emojiContainer: EmojiContainer;
@@ -26,9 +26,9 @@ const initialState: ThreadContextInitialState = {
   currentChannel: null,
   allThreadMessages: [],
   parentMessage: null,
-  channelStatus: ChannelStateTypes.NIL,
-  parentMessageInfoStatus: ParentMessageInfoStateTypes.NIL,
-  threadListStatus: ThreadListStateTypes.NIL,
+  channelState: ChannelStateTypes.NIL,
+  parentMessageState: ParentMessageStateTypes.NIL,
+  threadListState: ThreadListStateTypes.NIL,
   hasMorePrev: false,
   hasMoreNext: false,
   emojiContainer: {} as EmojiContainer,

--- a/src/smart-components/Thread/context/dux/reducer.ts
+++ b/src/smart-components/Thread/context/dux/reducer.ts
@@ -1,7 +1,7 @@
 import { GroupChannel } from "@sendbird/chat/groupChannel";
 import { FileMessage, ReactionEvent, UserMessage } from "@sendbird/chat/message";
 import { NEXT_THREADS_FETCH_SIZE, PREV_THREADS_FETCH_SIZE } from "../../consts";
-import { ChannelStateTypes, ParentMessageInfoStateTypes, ThreadListStateTypes } from "../../types";
+import { ChannelStateTypes, ParentMessageStateTypes, ThreadListStateTypes } from "../../types";
 import { compareIds } from "../utils";
 import { ThreadContextActionTypes as actionTypes } from "./actionTypes";
 import { ThreadContextInitialState } from "./initialState";
@@ -26,7 +26,7 @@ export default function reducer(
     case actionTypes.GET_CHANNEL_START: {
       return {
         ...state,
-        channelStatus: ChannelStateTypes.LOADING,
+        channelState: ChannelStateTypes.LOADING,
         currentChannel: null,
       };
     }
@@ -34,7 +34,7 @@ export default function reducer(
       const groupChannel = action.payload.groupChannel as GroupChannel;
       return {
         ...state,
-        channelStatus: ChannelStateTypes.INITIALIZED,
+        channelState: ChannelStateTypes.INITIALIZED,
         currentChannel: groupChannel,
         // only support in normal group channel
         isMuted: groupChannel?.members?.find((member) => member?.userId === state.currentUserId)?.isMuted || false,
@@ -44,7 +44,7 @@ export default function reducer(
     case actionTypes.GET_CHANNEL_FAILURE: {
       return {
         ...state,
-        channelStatus: ChannelStateTypes.INVALID,
+        channelState: ChannelStateTypes.INVALID,
         currentChannel: null,
       };
     }
@@ -58,21 +58,21 @@ export default function reducer(
     case actionTypes.GET_PARENT_MESSAGE_START: {
       return {
         ...state,
-        parentMessageInfoStatus: ParentMessageInfoStateTypes.LOADING,
+        parentMessageState: ParentMessageStateTypes.LOADING,
         parentMessage: null,
       };
     }
     case actionTypes.GET_PARENT_MESSAGE_SUCCESS: {
       return {
         ...state,
-        parentMessageInfoStatus: ParentMessageInfoStateTypes.INITIALIZED,
+        parentMessageState: ParentMessageStateTypes.INITIALIZED,
         parentMessage: action.payload.parentMessage,
       };
     }
     case actionTypes.GET_PARENT_MESSAGE_FAILURE: {
       return {
         ...state,
-        parentMessageInfoStatus: ParentMessageInfoStateTypes.INVALID,
+        parentMessageState: ParentMessageStateTypes.INVALID,
         parentMessage: null,
       };
     }
@@ -80,7 +80,7 @@ export default function reducer(
     case actionTypes.INITIALIZE_THREAD_LIST_START: {
       return {
         ...state,
-        threadListStatus: ThreadListStateTypes.LOADING,
+        threadListState: ThreadListStateTypes.LOADING,
         allThreadMessages: [],
       };
     }
@@ -93,7 +93,7 @@ export default function reducer(
       const nextThreadMessages = anchorIndex > -1 ? threadedMessages.slice(anchorIndex) : [];
       return {
         ...state,
-        threadListStatus: ThreadListStateTypes.INITIALIZED,
+        threadListState: ThreadListStateTypes.INITIALIZED,
         hasMorePrev: anchorIndex === -1 || anchorIndex === PREV_THREADS_FETCH_SIZE,
         hasMoreNext: threadedMessages.length - anchorIndex === NEXT_THREADS_FETCH_SIZE,
         allThreadMessages: [prevThreadMessages, anchorThreadMessage, nextThreadMessages].flat(),
@@ -102,7 +102,7 @@ export default function reducer(
     case actionTypes.INITIALIZE_THREAD_LIST_FAILURE: {
       return {
         ...state,
-        threadListStatus: ThreadListStateTypes.INVALID,
+        threadListState: ThreadListStateTypes.INVALID,
         allThreadMessages: [],
       };
     }
@@ -195,7 +195,7 @@ export default function reducer(
         return {
           ...state,
           parentMessage: null,
-          parentMessageInfoStatus: ParentMessageInfoStateTypes.NIL,
+          parentMessageState: ParentMessageStateTypes.NIL,
           allThreadMessages: [],
         };
       }
@@ -254,9 +254,9 @@ export default function reducer(
     case actionTypes.ON_USER_BANNED: {
       return {
         ...state,
-        channelStatus: ChannelStateTypes.NIL,
-        threadListStatus: ThreadListStateTypes.NIL,
-        parentMessageInfoStatus: ParentMessageInfoStateTypes.NIL,
+        channelState: ChannelStateTypes.NIL,
+        threadListState: ThreadListStateTypes.NIL,
+        parentMessageState: ParentMessageStateTypes.NIL,
         currentChannel: null,
         parentMessage: null,
         allThreadMessages: [],
@@ -272,9 +272,9 @@ export default function reducer(
     case actionTypes.ON_USER_LEFT: {
       return {
         ...state,
-        channelStatus: ChannelStateTypes.NIL,
-        threadListStatus: ThreadListStateTypes.NIL,
-        parentMessageInfoStatus: ParentMessageInfoStateTypes.NIL,
+        channelState: ChannelStateTypes.NIL,
+        threadListState: ThreadListStateTypes.NIL,
+        parentMessageState: ParentMessageStateTypes.NIL,
         currentChannel: null,
         parentMessage: null,
         allThreadMessages: [],

--- a/src/smart-components/Thread/context/hooks/useGetNextThreadsCallback.ts
+++ b/src/smart-components/Thread/context/hooks/useGetNextThreadsCallback.ts
@@ -8,7 +8,7 @@ import { ThreadContextActionTypes } from "../dux/actionTypes";
 interface DynamicProps {
   hasMoreNext: boolean;
   parentMessage: UserMessage | FileMessage;
-  threadListStatus: ThreadListStateTypes;
+  threadListState: ThreadListStateTypes;
   latestMessageTimeStamp: number;
   isReactionEnabled?: boolean;
 }
@@ -20,7 +20,7 @@ interface StaticProps {
 export default function useGetNextThreadsCallback({
   hasMoreNext,
   parentMessage,
-  threadListStatus,
+  threadListState,
   latestMessageTimeStamp,
   isReactionEnabled,
 }: DynamicProps, {
@@ -29,7 +29,7 @@ export default function useGetNextThreadsCallback({
 }: StaticProps): (callback: (messages?: Array<BaseMessage>) => void) => void {
   return useCallback((callback) => {
     // validation check
-    if (threadListStatus === ThreadListStateTypes.INITIALIZED
+    if (threadListState === ThreadListStateTypes.INITIALIZED
       && parentMessage?.getThreadedMessagesByTimestamp
       && latestMessageTimeStamp !== 0
     ) {
@@ -64,7 +64,7 @@ export default function useGetNextThreadsCallback({
   }, [
     hasMoreNext,
     parentMessage,
-    threadListStatus,
+    threadListState,
     latestMessageTimeStamp,
   ]);
 }

--- a/src/smart-components/Thread/context/hooks/useGetPrevThreadsCallback.ts
+++ b/src/smart-components/Thread/context/hooks/useGetPrevThreadsCallback.ts
@@ -9,7 +9,7 @@ import { ThreadContextActionTypes } from "../dux/actionTypes";
 interface DynamicProps {
   hasMorePrev: boolean;
   parentMessage: UserMessage | FileMessage;
-  threadListStatus: ThreadListStateTypes;
+  threadListState: ThreadListStateTypes;
   oldestMessageTimeStamp: number;
   isReactionEnabled?: boolean;
 }
@@ -21,7 +21,7 @@ interface StaticProps {
 export default function useGetPrevThreadsCallback({
   hasMorePrev,
   parentMessage,
-  threadListStatus,
+  threadListState,
   oldestMessageTimeStamp,
   isReactionEnabled,
 }: DynamicProps, {
@@ -30,7 +30,7 @@ export default function useGetPrevThreadsCallback({
 }: StaticProps): (callback?: (messages?: Array<BaseMessage>) => void) => void {
   return useCallback((callback) => {
     // validation check
-    if (threadListStatus === ThreadListStateTypes.INITIALIZED
+    if (threadListState === ThreadListStateTypes.INITIALIZED
       && parentMessage?.getThreadedMessagesByTimestamp
       && oldestMessageTimeStamp !== 0
     ) {
@@ -65,7 +65,7 @@ export default function useGetPrevThreadsCallback({
   }, [
     hasMorePrev,
     parentMessage,
-    threadListStatus,
+    threadListState,
     oldestMessageTimeStamp,
   ]);
 }

--- a/src/smart-components/Thread/types.tsx
+++ b/src/smart-components/Thread/types.tsx
@@ -5,7 +5,7 @@ export enum ChannelStateTypes {
   INVALID = 'INVALID',
   INITIALIZED = 'INITIALIZED',
 }
-export enum ParentMessageInfoStateTypes {
+export enum ParentMessageStateTypes {
   NIL = 'NIL',
   LOADING = 'LOADING',
   INVALID = 'INVALID',

--- a/src/ui/UserListItem/index.tsx
+++ b/src/ui/UserListItem/index.tsx
@@ -20,7 +20,7 @@ export interface UserListItemProps {
   isOperator?: boolean;
   disabled?: boolean;
   disableMessaging?: boolean;
-  currentUserId?: string;
+  currentUser?: string;
   action?({ actionRef, parentRef }: {
     actionRef: MutableRefObject<any>,
     parentRef?: MutableRefObject<any>,
@@ -36,7 +36,7 @@ export default function UserListItem({
   isOperator,
   disabled,
   disableMessaging,
-  currentUserId,
+  currentUser,
   action,
   onChange,
 }: UserListItemProps): ReactElement {
@@ -91,14 +91,14 @@ export default function UserListItem({
               renderUserProfile
                 ? renderUserProfile({
                   user,
-                  currentUserId,
+                  currentUserId: currentUser,
                   close: closeDropdown,
                 })
                 : (
                   <UserProfile
                     disableMessaging={disableMessaging}
                     user={user}
-                    currentUserId={currentUserId}
+                    currentUserId={currentUser}
                     onSuccess={closeDropdown}
                   />
                 )
@@ -113,7 +113,7 @@ export default function UserListItem({
       >
         {user.nickname || stringSet.NO_NAME}
         {
-          (currentUserId === user.userId) && (
+          (currentUser === user.userId) && (
             ' (You)'
           )
         }


### PR DESCRIPTION
[v3.3.1] (Nov 23 2022)
Fixes:
* Rename properties of `useThreadContext`
  * `channelStatus` to `channelState`
  * `parentMessageInfoStatus` to `parentMessageState`
  * `threadListStatus` to `threadListState`
* Change the state types to enum
  ```typescript
  enum ChannelStateTypes {
    NIL = 'NIL',
    LOADING = 'LOADING',
    INVALID = 'INVALID',
    INITIALIZED = 'INITIALIZED',
  }
  enum ParentMessageStateTypes {
    NIL = 'NIL',
    LOADING = 'LOADING',
    INVALID = 'INVALID',
    INITIALIZED = 'INITIALIZED',
  }
  enum ThreadListStateTypes {
    NIL = 'NIL',
    LOADING = 'LOADING',
    INVALID = 'INVALID',
    INITIALIZED = 'INITIALIZED',
  }
  ```