### PR TITLE
fix: Add types for renderMessage of ThreadUI

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -956,7 +956,12 @@ declare module "SendbirdUIKitGlobal" {
   export interface ThreadUIProps {
     renderHeader?: () => React.ReactElement;
     renderParentMessageInfo?: () => React.ReactElement;
-    renderMessage?: (props: { message: UserMessage | FileMessage }) => React.ReactElement;
+    renderMessage?: (props: {
+      message: UserMessage | FileMessage,
+      chainTop: boolean,
+      chainBottom: boolean,
+      hasSeparator: boolean,
+    }) => React.ReactElement;
     renderMessageInput?: () => React.ReactElement;
     renderCustomSeparator?: () => React.ReactElement;
     renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;

--- a/src/smart-components/Thread/components/ThreadUI/index.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/index.tsx
@@ -21,7 +21,12 @@ import { isAboutSame } from '../../context/utils';
 export interface ThreadUIProps {
   renderHeader?: () => React.ReactElement;
   renderParentMessageInfo?: () => React.ReactElement;
-  renderMessage?: (props: { message: UserMessage | FileMessage }) => React.ReactElement;
+  renderMessage?: (props: {
+    message: UserMessage | FileMessage,
+    chainTop: boolean,
+    chainBottom: boolean,
+    hasSeparator: boolean,
+  }) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderCustomSeparator?: () => React.ReactElement;
   renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2646](https://sendbird.atlassian.net/browse/UIKIT-2646)

## Description Of Changes

### Current
renderMessage?: (props: { message: UserMessage | FileMessage }) => React.ReactElement;

### Change to
  renderMessage?: (props: {
    message: UserMessage | FileMessage,
    chainTop: boolean,
    chainBottom: boolean,
    hasSeparator: boolean,
  }) => React.ReactElement;

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
