### PR TITLE
fix: create channel sometimes had empty operatorID

### DIFF
--- a/src/smart-components/App/index.jsx
+++ b/src/smart-components/App/index.jsx
@@ -67,7 +67,7 @@ export default function App(props) {
       isReactionEnabled={isReactionEnabled}
       isMentionEnabled={isMentionEnabled}
       onUserProfileMessage={(channel) => {
-        currentChannel(channel);
+        setCurrentChannel(channel);
       }}
       isTypingIndicatorEnabledOnChannelList={isTypingIndicatorEnabledOnChannelList}
       isMessageReceiptStatusEnabledOnChannelList={isMessageReceiptStatusEnabledOnChannelList}


### PR DESCRIPTION
use sendbird state to access currentUserID and use it incase prop value is empty
Also, remove legacy HOC pattern
