### PR TITLE
fix: Allow overriding entire message search query

### DIFF
--- a/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
+++ b/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
@@ -47,11 +47,11 @@ function useGetSearchedMessages(
     if (sdk && channelUrl && sdk.createMessageSearchQuery && currentChannel) {
       if (requestString) {
         const inputSearchMessageQueryObject: MessageSearchQueryParams = {
-          ...messageSearchQuery,
           order: MessageSearchOrder.TIMESTAMP,
           channelUrl,
           messageTimestampFrom: currentChannel.invitedAt,
           keyword: requestString,
+          ...messageSearchQuery,
         };
         const createdQuery = sdk.createMessageSearchQuery(inputSearchMessageQueryObject);
         createdQuery.next().then((messages) => {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2666](https://sendbird.atlassian.net/browse/UIKIT-2666)

## Description Of Changes

### Issue
Couldn't search messages in multiple channels by using `messageSearchQuery`

### Fix
Allow overriding entire message search query

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
