### PR TITLE
fix: Include renderIconButton into the renderHeader range

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -369,6 +369,7 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface ChannelListHeaderInterface {
     renderHeader?: (props: void) => React.ReactNode | React.ReactElement;
+    renderTitle?: (props: void) => React.ReactNode | React.ReactElement;
     renderIconButton?: (props: void) => React.ReactNode | React.ReactElement;
     onEdit?: (props: void) => void;
     allowProfileEdit?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -377,6 +377,7 @@ interface ChannelListProps extends ChannelListProviderInterface, ChannelListUIPr
 
 interface ChannelListHeaderInterface {
   renderHeader?: (props: void) => React.ReactElement;
+  renderTitle?: (props: void) => React.ReactElement;
   renderIconButton?: (props: void) => React.ReactElement;
   onEdit?: (props: void) => void;
   allowProfileEdit?: boolean;

--- a/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
@@ -29,7 +29,7 @@ const ChannelListHeader: React.FC<ChannelListHeaderInterface> = ({
   const { stringSet } = useContext(LocalizationContext);
 
   if (renderHeader) {
-    logger?.warning('Recomend to use "renderTitle" instead of "renderHeader".');
+    logger?.warning('Recomend to use "renderTitle" instead of "renderHeader". It will be deprecated.');
   }
   // renderTitle should have higher priority
   const titleRenderer = renderHeader || renderTitle;

--- a/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
@@ -15,7 +15,7 @@ interface ChannelListHeaderInterface {
   allowProfileEdit?: boolean;
 }
 
-const ChannelListHeader : React.FC<ChannelListHeaderInterface> = ({
+const ChannelListHeader: React.FC<ChannelListHeaderInterface> = ({
   renderHeader,
   renderIconButton,
   onEdit,
@@ -25,56 +25,52 @@ const ChannelListHeader : React.FC<ChannelListHeaderInterface> = ({
   const { user } = sbState?.stores?.userStore;
 
   const { stringSet } = useContext(LocalizationContext);
-  return (
-    <div
-      className={[
-        'sendbird-channel-header',
-        allowProfileEdit ? 'sendbird-channel-header--allow-edit' : '',
-      ].join(' ')}
-    >
-      {
-        renderHeader
-          ? renderHeader()
-          : (
-            <div
-              className="sendbird-channel-header__title"
-              role="button"
-              onClick={() => { onEdit() }}
-              onKeyDown={() => { onEdit() }}
-              tabIndex={0}
+  return renderHeader
+    ? renderHeader?.()
+    : (
+      <div
+        className={[
+          'sendbird-channel-header',
+          allowProfileEdit ? 'sendbird-channel-header--allow-edit' : '',
+        ].join(' ')}
+      >
+        <div
+          className="sendbird-channel-header__title"
+          role="button"
+          onClick={() => { onEdit() }}
+          onKeyDown={() => { onEdit() }}
+          tabIndex={0}
+        >
+          <div className="sendbird-channel-header__title__left">
+            <Avatar
+              width="32px"
+              height="32px"
+              src={user.profileUrl}
+              alt={user.nickname}
+            />
+          </div>
+          <div className="sendbird-channel-header__title__right">
+            <Label
+              className="sendbird-channel-header__title__right__name"
+              type={LabelTypography.SUBTITLE_2}
+              color={LabelColors.ONBACKGROUND_1}
             >
-              <div className="sendbird-channel-header__title__left">
-                <Avatar
-                  width="32px"
-                  height="32px"
-                  src={user.profileUrl}
-                  alt={user.nickname}
-                />
-              </div>
-              <div className="sendbird-channel-header__title__right">
-                <Label
-                  className="sendbird-channel-header__title__right__name"
-                  type={LabelTypography.SUBTITLE_2}
-                  color={LabelColors.ONBACKGROUND_1}
-                >
-                  {user.nickname || stringSet.NO_NAME}
-                </Label>
-                <Label
-                  className="sendbird-channel-header__title__right__user-id"
-                  type={LabelTypography.BODY_2}
-                  color={LabelColors.ONBACKGROUND_2}
-                >
-                  {user.userId}
-                </Label>
-              </div>
-            </div>
-          )
-      }
-      <div className="sendbird-channel-header__right-icon">
-        {renderIconButton() || <IconButton />}
+              {user.nickname || stringSet.NO_NAME}
+            </Label>
+            <Label
+              className="sendbird-channel-header__title__right__user-id"
+              type={LabelTypography.BODY_2}
+              color={LabelColors.ONBACKGROUND_2}
+            >
+              {user.userId}
+            </Label>
+          </div>
+        </div>
+        <div className="sendbird-channel-header__right-icon">
+          {renderIconButton() || <IconButton />}
+        </div>
       </div>
-    </div>
-  );
+    );
 }
 
 export default ChannelListHeader;

--- a/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListHeader/index.tsx
@@ -3,13 +3,13 @@ import React, { useContext } from 'react';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
-import IconButton from '../../../../ui/IconButton';
 
 import './index.scss';
 import Avatar from '../../../../ui/Avatar';
 
 interface ChannelListHeaderInterface {
   renderHeader?: (props: void) => React.ReactElement;
+  renderTitle?: () => React.ReactElement;
   renderIconButton?: (props: void) => React.ReactElement;
   onEdit?: (props: void) => void;
   allowProfileEdit?: boolean;
@@ -17,60 +17,71 @@ interface ChannelListHeaderInterface {
 
 const ChannelListHeader: React.FC<ChannelListHeaderInterface> = ({
   renderHeader,
+  renderTitle,
   renderIconButton,
   onEdit,
   allowProfileEdit,
 }: ChannelListHeaderInterface) => {
-  const sbState = useSendbirdStateContext();
-  const { user } = sbState?.stores?.userStore;
+  const { stores, config } = useSendbirdStateContext?.();
+  const { user } = stores?.userStore;
+  const { logger } = config;
 
   const { stringSet } = useContext(LocalizationContext);
-  return renderHeader
-    ? renderHeader?.()
-    : (
-      <div
-        className={[
-          'sendbird-channel-header',
-          allowProfileEdit ? 'sendbird-channel-header--allow-edit' : '',
-        ].join(' ')}
-      >
-        <div
-          className="sendbird-channel-header__title"
-          role="button"
-          onClick={() => { onEdit() }}
-          onKeyDown={() => { onEdit() }}
-          tabIndex={0}
-        >
-          <div className="sendbird-channel-header__title__left">
-            <Avatar
-              width="32px"
-              height="32px"
-              src={user.profileUrl}
-              alt={user.nickname}
-            />
+
+  if (renderHeader) {
+    logger?.warning('Recomend to use "renderTitle" instead of "renderHeader".');
+  }
+  // renderTitle should have higher priority
+  const titleRenderer = renderHeader || renderTitle;
+
+  return (
+    <div
+      className={[
+        'sendbird-channel-header',
+        allowProfileEdit ? 'sendbird-channel-header--allow-edit' : '',
+      ].join(' ')}
+    >
+      {
+        titleRenderer?.() || (
+          <div
+            className="sendbird-channel-header__title"
+            role="button"
+            onClick={() => { onEdit?.() }}
+            onKeyDown={() => { onEdit?.() }}
+            tabIndex={0}
+          >
+            <div className="sendbird-channel-header__title__left">
+              <Avatar
+                width="32px"
+                height="32px"
+                src={user.profileUrl}
+                alt={user.nickname}
+              />
+            </div>
+            <div className="sendbird-channel-header__title__right">
+              <Label
+                className="sendbird-channel-header__title__right__name"
+                type={LabelTypography.SUBTITLE_2}
+                color={LabelColors.ONBACKGROUND_1}
+              >
+                {user.nickname || stringSet.NO_NAME}
+              </Label>
+              <Label
+                className="sendbird-channel-header__title__right__user-id"
+                type={LabelTypography.BODY_2}
+                color={LabelColors.ONBACKGROUND_2}
+              >
+                {user.userId}
+              </Label>
+            </div>
           </div>
-          <div className="sendbird-channel-header__title__right">
-            <Label
-              className="sendbird-channel-header__title__right__name"
-              type={LabelTypography.SUBTITLE_2}
-              color={LabelColors.ONBACKGROUND_1}
-            >
-              {user.nickname || stringSet.NO_NAME}
-            </Label>
-            <Label
-              className="sendbird-channel-header__title__right__user-id"
-              type={LabelTypography.BODY_2}
-              color={LabelColors.ONBACKGROUND_2}
-            >
-              {user.userId}
-            </Label>
-          </div>
-        </div>
-        <div className="sendbird-channel-header__right-icon">
-          {renderIconButton() || <IconButton />}
-        </div>
+        )
+      }
+      <div className="sendbird-channel-header__right-icon">
+        {renderIconButton?.()}
       </div>
-    );
+    </div>
+  );
 }
 
 export default ChannelListHeader;

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -99,18 +99,21 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (props: ChannelListUIProps) 
   return (
     <>
       <div className="sendbird-channel-list__header">
-        <ChannelListHeader
-          renderHeader={renderHeader}
-          onEdit={() => {
-            if (allowProfileEdit) {
-              setShowProfileEdit(true);
-            }
-          }}
-          allowProfileEdit={allowProfileEdit}
-          renderIconButton={() => (
-            <AddChannel />
-          )}
-        />
+        {
+          renderHeader?.() || (
+            <ChannelListHeader
+              onEdit={() => {
+                if (allowProfileEdit) {
+                  setShowProfileEdit(true);
+                }
+              }}
+              allowProfileEdit={allowProfileEdit}
+              renderIconButton={() => (
+                <AddChannel />
+              )}
+            />
+          )
+        }
       </div>
       {
         showProfileEdit && (


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2654](https://sendbird.atlassian.net/browse/UIKIT-2654)

## Description Of Changes

### Issue
The create channel button range has been displayed even `renderHeader` props are set

### Fix
Include the `create channel button & renderIconButton` into the `renderHeader and ChannelListHeader` range

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
