### PR TITLE
fix: Set the default image compression rate to 70%

### DIFF
--- a/src/lib/Sendbird.jsx
+++ b/src/lib/Sendbird.jsx
@@ -194,7 +194,10 @@ export default function Sendbird(props) {
           userListQuery,
           logger,
           pubSub,
-          imageCompression,
+          imageCompression: {
+            compressionRate: 0.7,
+            ...imageCompression,
+          },
           isReactionEnabled,
           isMentionEnabled: isMentionEnabled || false,
           userMention: {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2714](https://sendbird.atlassian.net/browse/UIKIT-2714)

## Description Of Changes

Set the default value of the image compression rate to 70%

#### Before
<img width="380" alt="image" src="https://user-images.githubusercontent.com/46333979/206942681-624efd1d-91d4-4a98-811c-e79270027f3a.png">
#### After
<img width="384" alt="image" src="https://user-images.githubusercontent.com/46333979/206942703-81b4a877-8de9-42a6-80e9-9c142ba73fed.png">

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [x] Improvement (refactor code)
