### PR TITLE
fix: New channel interrupts the current conversation

### DIFF
--- a/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
+++ b/src/smart-components/ChannelList/dux/__tests__/reducers.spec.js
@@ -22,13 +22,25 @@ describe('Channels-Reducers', () => {
     });
 
   it('should handle create new channel using CREATE_CHANNEL', () => {
+    const newChannel = mockData.allChannels[1];
     const nextState = reducers(mockData, {
       type: actionTypes.CREATE_CHANNEL,
-      payload: mockData.allChannels[1],
+      payload: newChannel,
     });
 
-    expect(nextState.allChannels[0].url).toEqual(mockData.allChannels[1].url);
-    expect(nextState.currentChannel.url).toEqual(mockData.allChannels[1].url);
+    expect(nextState.allChannels[0].url).toEqual(newChannel.url);
+    expect(nextState.currentChannel.url).toEqual(newChannel.url);
+  });
+
+  it('should not set with new channel when calling USER_INVITED', () => {
+    const newChannel = mockData.allChannels[1];
+    const nextState = reducers(mockData, {
+      type: actionTypes.USER_INVITED,
+      payload: newChannel,
+    });
+
+    expect(nextState.allChannels[0].url).toEqual(newChannel.url);
+    expect(nextState.currentChannel.url).not.toEqual(newChannel.url);
   });
 
   it('should handle leave channel action LEAVE_CHANNEL_SUCCESS', () => {

--- a/src/smart-components/ChannelList/dux/reducers.js
+++ b/src/smart-components/ChannelList/dux/reducers.js
@@ -42,7 +42,25 @@ export default function reducer(state, action) {
         ],
       };
     }
-    case actions.USER_INVITED:
+    case actions.USER_INVITED: {
+      const channel = action.payload;
+      if (state.channelListQuery) {
+        if (filterChannelListParams(state.channelListQuery, channel, state.currentUserId)) {
+          return {
+            ...state,
+            allChannels: getChannelsWithUpsertedChannel(state.allChannels, channel),
+          };
+        }
+        return {
+          ...state,
+          currentChannel: channel,
+        };
+      }
+      return {
+        ...state,
+        allChannels: [channel, ...state.allChannels.filter((ch) => ch.url !== channel?.url)],
+      };
+    }
     case actions.CREATE_CHANNEL: {
       const channel = action.payload;
       if (state.channelListQuery) {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2790](https://sendbird.atlassian.net/browse/UIKIT-2790)

## Description Of Changes

* Do not set the current channel with newly created channel
  * when the current user receives the invitation from it

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)


[UIKIT-2790]: https://sendbird.atlassian.net/browse/UIKIT-2790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ