### PR TITLE
fix: Use same word break and URL activation logic on messages

### DIFF
--- a/src/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
+++ b/src/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
@@ -52,7 +52,21 @@ exports[`ui/MessageContent should do a snapshot test of the MessageContent DOM 1
           <div
             class="sendbird-message-content__middle__message-item-body sendbird-text-message-item-body incoming  "
           >
-            First second third
+            <span
+              class="sendbird-word"
+            >
+              First
+            </span>
+            <span
+              class="sendbird-word"
+            >
+              second
+            </span>
+            <span
+              class="sendbird-word"
+            >
+              third
+            </span>
           </div>
         </span>
         <span

--- a/src/ui/OGMessageItemBody/index.scss
+++ b/src/ui/OGMessageItemBody/index.scss
@@ -18,6 +18,7 @@
     box-sizing: border-box;
     border-radius: 16px 16px 0px 0px;
     word-break: break-word;
+    white-space: pre-line;
 
     .sendbird-og-message-item-body__text-bubble__message {
       display: inline;

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -53,9 +53,9 @@ export default function OGMessageItemBody({
       >
         <div className="sendbird-og-message-item-body__text-bubble">
           {
-            sentences.map((sentence, index) => {
+            sentences?.map((sentence, index) => {
               return [
-                sentence.map((word) => {
+                sentence?.map((word) => {
                   return (
                     <Word
                       key={uuidv4()}

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import type { UserMessage } from '@sendbird/chat/message';
 
 import Word from '../Word';
@@ -32,6 +32,12 @@ export default function OGMessageItemBody({
     if (message?.ogMetaData?.url) window.open(message?.ogMetaData?.url);
   };
   const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
+  const sentences: Array<Array<string>> = useMemo(() => {
+    if (isMessageMentioned) {
+      return message?.mentionedMessageTemplate?.split(/\n/).map((sentence) => sentence.split(/\s/));
+    }
+    return message?.message?.split(/\n/).map((sentence) => sentence.split(/\s/));
+  }, [message?.mentionedMessageTemplate]);
   return (
     <div className={getClassName([
       className,
@@ -47,27 +53,21 @@ export default function OGMessageItemBody({
       >
         <div className="sendbird-og-message-item-body__text-bubble">
           {
-            isMessageMentioned
-              ? (
-                message?.mentionedMessageTemplate.split(' ').map((word: string) => (
-                  <Word
-                    key={uuidv4()}
-                    word={word}
-                    message={message}
-                    isByMe={isByMe}
-                  />
-                ))
-              )
-              : (
-                message?.message.split(' ').map((word: string) => (
-                  <Word
-                    key={uuidv4()}
-                    word={word}
-                    message={message}
-                    isByMe={isByMe}
-                  />
-                ))
-              )
+            sentences.map((sentence, index) => {
+              return [
+                sentence.map((word) => {
+                  return (
+                    <Word
+                      key={uuidv4()}
+                      word={word}
+                      message={message}
+                      isByMe={isByMe}
+                    />
+                  );
+                }),
+                sentences?.[index + 1] ? <br /> : null,
+              ]
+            })
           }
           {
             isEditedMessage(message) && (

--- a/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
+++ b/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
@@ -8,7 +8,31 @@ exports[`ui/TextMessageItemBody should do a snapshot test of the TextMessageItem
     <div
       class="class-name-for-snapshot sendbird-text-message-item-body outgoing mouse-hover "
     >
-      First second third fourth fifth
+      <span
+        class="sendbird-word"
+      >
+        First
+      </span>
+      <span
+        class="sendbird-word"
+      >
+        second
+      </span>
+      <span
+        class="sendbird-word"
+      >
+        third
+      </span>
+      <span
+        class="sendbird-word"
+      >
+        fourth
+      </span>
+      <span
+        class="sendbird-word"
+      >
+        fifth
+      </span>
       <span
         class="sendbird-text-message-item-body__message edited sendbird-label sendbird-label--body-1 sendbird-label--color-oncontent-2"
       >

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import type { UserMessage } from '@sendbird/chat/message';
 
 import Label, { LabelTypography, LabelColors } from '../Label';
@@ -27,6 +27,12 @@ export default function TextMessageItemBody({
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
+  const sentences: Array<Array<string>> = useMemo(() => {
+    if (isMessageMentioned) {
+      return message?.mentionedMessageTemplate?.split(/\n/).map((sentence) => sentence.split(/\s/));
+    }
+    return message?.message?.split(/\n/).map((sentence) => sentence.split(/\s/));
+  }, [message?.mentionedMessageTemplate]);
   return (
     <Label
       type={LabelTypography.BODY_1}
@@ -40,27 +46,21 @@ export default function TextMessageItemBody({
         (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
       ])}>
         {
-          isMessageMentioned
-            ? (
-              message?.mentionedMessageTemplate.split(' ').map((word: string) => (
-                <Word
-                  key={uuidv4()}
-                  word={word}
-                  message={message}
-                  isByMe={isByMe}
-                />
-              ))
-            )
-            : (
-              message?.message.split(' ').map((word: string) => (
-                <Word
-                  key={uuidv4()}
-                  word={word}
-                  message={message}
-                  isByMe={isByMe}
-                />
-              ))
-            )
+          sentences.map((sentence, index) => {
+            return [
+              sentence.map((word) => {
+                return (
+                  <Word
+                    key={uuidv4()}
+                    word={word}
+                    message={message}
+                    isByMe={isByMe}
+                  />
+                );
+              }),
+              sentences?.[index + 1] ? <br /> : null,
+            ]
+          })
         }
         {
           isEditedMessage(message) && (

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React, { ReactElement, useContext, useMemo } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import type { UserMessage } from '@sendbird/chat/message';
 
 import Label, { LabelTypography, LabelColors } from '../Label';
@@ -27,9 +27,6 @@ export default function TextMessageItemBody({
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
-  const sentences: Array<Array<string>> = useMemo(() => {
-    return message?.mentionedMessageTemplate?.split(/\n/).map((sentence) => sentence.split(/\s/));
-  }, [message?.mentionedMessageTemplate]);
   return (
     <Label
       type={LabelTypography.BODY_1}
@@ -44,24 +41,26 @@ export default function TextMessageItemBody({
       ])}>
         {
           isMessageMentioned
-           ? (
-              sentences.map((sentence, index) => {
-                return [
-                  sentence.map((word) => {
-                    return (
-                      <Word
-                        key={uuidv4()}
-                        word={word}
-                        message={message}
-                        isByMe={isByMe}
-                      />
-                    );
-                  }),
-                  sentences?.[index + 1] ? <br /> : null,
-                ]
-              })
-           )
-           : message?.message
+            ? (
+              message?.mentionedMessageTemplate.split(' ').map((word: string) => (
+                <Word
+                  key={uuidv4()}
+                  word={word}
+                  message={message}
+                  isByMe={isByMe}
+                />
+              ))
+            )
+            : (
+              message?.message.split(' ').map((word: string) => (
+                <Word
+                  key={uuidv4()}
+                  word={word}
+                  message={message}
+                  isByMe={isByMe}
+                />
+              ))
+            )
         }
         {
           isEditedMessage(message) && (

--- a/src/ui/Word/index.scss
+++ b/src/ui/Word/index.scss
@@ -4,6 +4,7 @@
   display: inline;
   margin-right: 4px;
   height: fit-content;
+  white-space: nowrap;
   .sendbird-word__url,
   .sendbird-word__normal {
     display: inline-block;


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2759](https://sendbird.atlassian.net/browse/UIKIT-2759)

## Description Of Changes

* Use the same word-splitting logic on the TextMessage and OGMessage
  * TextMessage will also allow opening the URL links
* Use the same word wrapping style on the TextMessage and OGMessage

### Word split
#### Before
<img width="418" alt="image" src="https://user-images.githubusercontent.com/46333979/215984611-1ac40d14-018b-4b07-b525-987abd3d5acb.png">

#### After
<img width="425" alt="image" src="https://user-images.githubusercontent.com/46333979/216022499-34e8cfe0-7ac2-4f45-865d-42797f4d0c0e.png">

### Activate URL
#### Before
<img width="426" alt="image" src="https://user-images.githubusercontent.com/46333979/216023462-ad34bfbe-209e-4264-a2d7-2f3ef7514e4e.png">

#### After
<img width="419" alt="image" src="https://user-images.githubusercontent.com/46333979/216023038-88a916be-f9fd-4e51-9dd3-781d0c5e85a9.png">

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)


[UIKIT-2759]: https://sendbird.atlassian.net/browse/UIKIT-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ