### PR TITLE
fix: Checkbox: set checked as false

### DIFF
--- a/src/ui/Checkbox/index.tsx
+++ b/src/ui/Checkbox/index.tsx
@@ -10,7 +10,7 @@ export interface CheckboxProps {
 
 export default function Checkbox({
   id,
-  checked,
+  checked = false,
   disabled,
   onChange,
 }: CheckboxProps): ReactElement {


### PR DESCRIPTION
To remove warning:
A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component.

