### PR TITLE
feat: options to render icons on MessageInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "files": [
     "release/**/*",
     "dist/**/*",
-    "package-lock.json",
     "LICENSE",
     "CHANGELOG.md"
   ],

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -518,6 +518,9 @@ declare module "SendbirdUIKitGlobal" {
     renderMessageInput?: () => React.ReactNode | React.ReactElement;
     renderTypingIndicator?: () => React.ReactNode | React.ReactElement;
     renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactNode | React.ReactElement;
+    renderFileUploadIcon?: () =>  React.ReactElement;
+    renderVoiceMessageIcon?: () =>  React.ReactElement;
+    renderSendMessageIcon?: () =>  React.ReactElement;
   }
 
   export type CoreMessageType = AdminMessage | UserMessage | FileMessage;
@@ -576,6 +579,9 @@ declare module "SendbirdUIKitGlobal" {
     // value is removed when channelURL changes
     value?: string;
     ref?: React.MutableRefObject<any>;
+    renderFileUploadIcon?: () =>  React.ReactElement;
+    renderVoiceMessageIcon?: () =>  React.ReactElement;
+    renderSendMessageIcon?: () =>  React.ReactElement;
   };
 
   export type MessageListProps = {
@@ -984,6 +990,9 @@ declare module "SendbirdUIKitGlobal" {
     renderCustomSeparator?: () => React.ReactElement;
     renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
     renderThreadListPlaceHolder?: (type: ThreadListStateTypes) => React.ReactElement;
+    renderFileUploadIcon?: () =>  React.ReactElement;
+    renderVoiceMessageIcon?: () =>  React.ReactElement;
+    renderSendMessageIcon?: () =>  React.ReactElement;
   }
 
   type EventType = React.MouseEvent<HTMLDivElement | HTMLButtonElement> | React.KeyboardEvent<HTMLDivElement>;
@@ -1030,6 +1039,9 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface ThreadMessageInputProps {
     className?: string;
+    renderFileUploadIcon?: () =>  React.ReactElement;
+    renderVoiceMessageIcon?: () =>  React.ReactElement;
+    renderSendMessageIcon?: () =>  React.ReactElement;
   }
 
   /**
@@ -2009,6 +2021,9 @@ declare module '@sendbird/uikit-react/ui/MessageInput' {
     onMentionedUserIdsUpdated?: (userIds: Array<string>) => void,
     onKeyUp?: (e: React.KeyboardEvent<HTMLDivElement>) => void,
     onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void,
+    renderFileUploadIcon?: () =>  React.ReactElement;
+    renderVoiceMessageIcon?: () =>  React.ReactElement;
+    renderSendMessageIcon?: () =>  React.ReactElement;
   }
   const MessageInput: React.FC<MessageInputProps>;
   export default MessageInput;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,13 @@ import { UikitMessageHandler } from './selectors';
 import { Logger } from './SendbirdState';
 import { ReplyType } from 'SendbirdUIKitGlobal';
 
+// note to SDK team:
+// using enum inside .d.ts won’t work for jest, but const enum will work.
+export const Role = {
+  OPERATOR: 'operator',
+  NONE: 'none',
+} as const;
+
 export interface SendBirdProviderProps {
   userId: string;
   appId: string;

--- a/src/smart-components/Channel/components/ChannelUI/index.tsx
+++ b/src/smart-components/Channel/components/ChannelUI/index.tsx
@@ -23,6 +23,9 @@ export interface ChannelUIProps {
   renderChannelHeader?: () => React.ReactElement;
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
+  renderFileUploadIcon?: () =>  React.ReactElement;
+  renderVoiceMessageIcon?: () =>  React.ReactElement;
+  renderSendMessageIcon?: () =>  React.ReactElement;
   renderTypingIndicator?: () => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
 }
@@ -37,6 +40,9 @@ const ChannelUI: React.FC<ChannelUIProps> = ({
   renderMessageInput,
   renderTypingIndicator,
   renderCustomSeparator,
+  renderFileUploadIcon,
+  renderVoiceMessageIcon,
+  renderSendMessageIcon,
 }: ChannelUIProps) => {
   const {
     currentGroupChannel,
@@ -175,7 +181,11 @@ const ChannelUI: React.FC<ChannelUIProps> = ({
       <div className="sendbird-conversation__footer">
         {
           renderMessageInput?.() || (
-            <MessageInputWrapper />
+            <MessageInputWrapper
+              renderFileUploadIcon={renderFileUploadIcon}
+              renderVoiceMessageIcon={renderVoiceMessageIcon}
+              renderSendMessageIcon={renderSendMessageIcon}
+            />
           )
         }
         <div className="sendbird-conversation__footer__typing-indicator">

--- a/src/smart-components/Channel/components/MessageInput/index.tsx
+++ b/src/smart-components/Channel/components/MessageInput/index.tsx
@@ -14,13 +14,21 @@ import VoiceMessageInputWrapper from './VoiceMessageInputWrapper';
 
 export type MessageInputWrapperProps = {
   value?: string;
+  renderFileUploadIcon?: () =>  React.ReactElement;
+  renderVoiceMessageIcon?: () =>  React.ReactElement;
+  renderSendMessageIcon?: () =>  React.ReactElement;
 };
 
 const MessageInputWrapper = (
   props: MessageInputWrapperProps,
   ref: React.MutableRefObject<any>,
 ): JSX.Element => {
-  const { value } = props;
+  const {
+    value,
+    renderFileUploadIcon,
+    renderVoiceMessageIcon,
+    renderSendMessageIcon,
+  } = props;
   const {
     currentGroupChannel,
     initialized,
@@ -172,6 +180,9 @@ const MessageInputWrapper = (
               }
               ref={ref || messageInputRef}
               disabled={disabled}
+              renderFileUploadIcon={renderFileUploadIcon}
+              renderVoiceMessageIcon={renderVoiceMessageIcon}
+              renderSendMessageIcon={renderSendMessageIcon}
               onStartTyping={() => {
                 channel?.startTyping();
               }}

--- a/src/smart-components/Channel/components/MessageInput/index.tsx
+++ b/src/smart-components/Channel/components/MessageInput/index.tsx
@@ -181,8 +181,8 @@ const MessageInputWrapper = (
               ref={ref || messageInputRef}
               disabled={disabled}
               renderFileUploadIcon={renderFileUploadIcon}
-              renderVoiceMessageIcon={renderVoiceMessageIcon}
               renderSendMessageIcon={renderSendMessageIcon}
+              renderVoiceMessageIcon={renderVoiceMessageIcon}
               onStartTyping={() => {
                 channel?.startTyping();
               }}

--- a/src/smart-components/Channel/index.tsx
+++ b/src/smart-components/Channel/index.tsx
@@ -45,6 +45,9 @@ const Channel: React.FC<ChannelProps> = (props: ChannelProps) => {
         renderMessageInput={props?.renderMessageInput}
         renderTypingIndicator={props?.renderTypingIndicator}
         renderCustomSeparator={props?.renderCustomSeparator}
+        renderFileUploadIcon={props?.renderFileUploadIcon}
+        renderVoiceMessageIcon={props?.renderVoiceMessageIcon}
+        renderSendMessageIcon={props?.renderSendMessageIcon}
       />
     </ChannelProvider>
   );

--- a/src/smart-components/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/smart-components/Thread/components/ParentMessageInfo/index.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import { FileMessage, UserMessage } from '@sendbird/chat/message';
-import { Role } from '@sendbird/chat';
 
 import './index.scss';
 import RemoveMessage from '../RemoveMessageModal';
@@ -26,6 +25,7 @@ import ConnectedUserProfile from '../../../../ui/UserProfile';
 import { UserProfileContextInterface } from '../../../../ui/MessageContent';
 import MessageInput from '../../../../ui/MessageInput';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
+import { Role } from '../../../../lib/types';
 
 export interface ParentMessageInfoProps {
   className?: string;

--- a/src/smart-components/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/smart-components/Thread/components/ThreadList/ThreadListItem.tsx
@@ -14,7 +14,7 @@ import MessageInput from '../../../../ui/MessageInput';
 import { ThreadListStateTypes } from '../../types';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 import ThreadListItemContent from './ThreadListItemContent';
-import { Role } from '@sendbird/chat';
+import { Role } from '../../../../lib/types';
 import { useVoicePlayerContext } from '../../../../hooks/VoicePlayer';
 import { generateGroupKey } from '../../../../hooks/VoicePlayer/voicePlayerEvent';
 

--- a/src/smart-components/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/smart-components/Thread/components/ThreadMessageInput/index.tsx
@@ -14,13 +14,21 @@ import VoiceMessageInputWrapper from '../../../Channel/components/MessageInput/V
 
 export interface ThreadMessageInputProps {
   className?: string;
+  renderFileUploadIcon?: () =>  React.ReactElement;
+  renderVoiceMessageIcon?: () =>  React.ReactElement;
+  renderSendMessageIcon?: () =>  React.ReactElement;
 }
 
 const ThreadMessageInput = (
   props: ThreadMessageInputProps,
   ref: React.MutableRefObject<any>,
 ): React.ReactElement => {
-  const { className } = props;
+  const {
+    className,
+    renderFileUploadIcon,
+    renderVoiceMessageIcon,
+    renderSendMessageIcon,
+  } = props;
   const { config } = useSendbirdStateContext();
   const { stringSet } = useLocalization();
   const {
@@ -140,6 +148,9 @@ const ThreadMessageInput = (
               onVoiceMessageIconClick={() => {
                 setShowVoiceMessageInput(true);
               }}
+              renderFileUploadIcon={renderFileUploadIcon}
+              renderVoiceMessageIcon={renderVoiceMessageIcon}
+              renderSendMessageIcon={renderSendMessageIcon}
               ref={ref || messageInputRef}
               placeholder={
                 (currentChannel?.isFrozen && !(currentChannel?.myRole === Role.OPERATOR) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED)

--- a/src/smart-components/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/smart-components/Thread/components/ThreadMessageInput/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Role } from '@sendbird/chat';
 import { MutedState } from '@sendbird/chat/groupChannel';
 
 import './index.scss';
@@ -11,6 +10,7 @@ import SuggestedMentionList from '../../../Channel/components/SuggestedMentionLi
 import { useThreadContext } from '../../context/ThreadProvider';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import VoiceMessageInputWrapper from '../../../Channel/components/MessageInput/VoiceMessageInputWrapper';
+import { Role } from '../../../../lib/types';
 
 export interface ThreadMessageInputProps {
   className?: string;

--- a/src/smart-components/Thread/components/ThreadUI/index.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/index.tsx
@@ -27,6 +27,9 @@ export interface ThreadUIProps {
     chainBottom: boolean,
     hasSeparator: boolean,
   }) => React.ReactElement;
+  renderFileUploadIcon?: () =>  React.ReactElement;
+  renderVoiceMessageIcon?: () =>  React.ReactElement;
+  renderSendMessageIcon?: () =>  React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderCustomSeparator?: () => React.ReactElement;
   renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
@@ -41,6 +44,9 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
   renderCustomSeparator,
   renderParentMessageInfoPlaceholder,
   renderThreadListPlaceHolder,
+  renderFileUploadIcon,
+  renderVoiceMessageIcon,
+  renderSendMessageIcon,
 }: ThreadUIProps): React.ReactElement => {
   const {
     stores,
@@ -176,6 +182,9 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
           renderMessageInput?.() || (
             <ThreadMessageInput
               className="sendbird-thread-ui__message-input"
+              renderFileUploadIcon={renderFileUploadIcon}
+              renderVoiceMessageIcon={renderVoiceMessageIcon}
+              renderSendMessageIcon={renderSendMessageIcon}
             />
           )
         }

--- a/src/smart-components/Thread/index.tsx
+++ b/src/smart-components/Thread/index.tsx
@@ -27,6 +27,9 @@ const Thread: React.FC<ThreadProps> = (props: ThreadProps) => {
     renderCustomSeparator,
     renderParentMessageInfoPlaceholder,
     renderThreadListPlaceHolder,
+    renderFileUploadIcon,
+    renderVoiceMessageIcon,
+    renderSendMessageIcon,
   } = props;
   return (
     <div className={`sendbird-thread ${className}`}>
@@ -44,6 +47,9 @@ const Thread: React.FC<ThreadProps> = (props: ThreadProps) => {
           renderCustomSeparator={renderCustomSeparator}
           renderParentMessageInfoPlaceholder={renderParentMessageInfoPlaceholder}
           renderThreadListPlaceHolder={renderThreadListPlaceHolder}
+          renderFileUploadIcon={renderFileUploadIcon}
+          renderVoiceMessageIcon={renderVoiceMessageIcon}
+          renderSendMessageIcon={renderSendMessageIcon}
         />
       </ThreadProvider>
     </div>

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -374,18 +374,6 @@ const MessageInput = React.forwardRef((props, ref) => {
     }
   };
 
-  const MemoizedSendIcon = useMemo(() => {
-    return renderSendMessageIcon?.();
-  }, [renderSendMessageIcon]);
-
-  const MemoizedUploadIcon = useMemo(() => {
-    return renderFileUploadIcon?.();
-  }, [renderSendMessageIcon]);
-
-  const MemoizedVoiceIcon = useMemo(() => {
-    return renderVoiceMessageIcon?.();
-  }, [renderVoiceMessageIcon]);
-
   return (
     <form
       className={getClassName([
@@ -468,40 +456,46 @@ const MessageInput = React.forwardRef((props, ref) => {
               width="32px"
               onClick={() => sendMessage()}
             >
-              <Icon
-                type={IconTypes.SEND}
-                fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.PRIMARY}
-                width="20px"
-                height="20px"
-              />
+              {
+                renderSendMessageIcon?.() || (
+                  <Icon
+                    type={IconTypes.SEND}
+                    fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.PRIMARY}
+                    width="20px"
+                    height="20px"
+                  />
+                )
+              }
             </IconButton>
           )
         }
         {/* file upload icon */}
         {
           (!isEdit && !isInput) && (
-            <IconButton
-              className={`sendbird-message-input--attach ${isVoiceMessageEnabled ? 'is-voice-message-enabled' : ''}`}
-              height="32px"
-              width="32px"
-              onClick={() => {
-                // todo: clear previous input
-                fileInputRef?.current?.click?.();
-              }}
-            >
-              <Icon
-                type={IconTypes.ATTACH}
-                fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.CONTENT_INVERSE}
-                width="20px"
-                height="20px"
-              />
-              <input
-                className="sendbird-message-input--attach-input"
-                type="file"
-                ref={fileInputRef}
-                onChange={handleUploadFile(onFileUpload)}
-              />
-            </IconButton>
+            (renderFileUploadIcon?.() || (
+              <IconButton
+                className={`sendbird-message-input--attach ${isVoiceMessageEnabled ? 'is-voice-message-enabled' : ''}`}
+                height="32px"
+                width="32px"
+                onClick={() => {
+                  // todo: clear previous input
+                  fileInputRef?.current?.click?.();
+                }}
+              >
+                <Icon
+                  type={IconTypes.ATTACH}
+                  fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.CONTENT_INVERSE}
+                  width="20px"
+                  height="20px"
+                />
+                <input
+                  className="sendbird-message-input--attach-input"
+                  type="file"
+                  ref={fileInputRef}
+                  onChange={handleUploadFile(onFileUpload)}
+                />
+              </IconButton>
+            ))
           )
         }
         {/* voice message input trigger */}
@@ -512,12 +506,16 @@ const MessageInput = React.forwardRef((props, ref) => {
             height="32px"
             onClick={onVoiceMessageIconClick}
           >
-            <Icon
-              type={IconTypes.AUDIO_ON_LINED}
-              fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.CONTENT_INVERSE}
-              width="20px"
-              height="20px"
-            />
+            {
+              renderVoiceMessageIcon?.() || (
+                <Icon
+                  type={IconTypes.AUDIO_ON_LINED}
+                  fillColor={disabled ? IconColors.ON_BACKGROUND_4 : IconColors.CONTENT_INVERSE}
+                  width="20px"
+                  height="20px"
+                />
+              )
+            }
           </IconButton>
         )}
       </div>

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -88,6 +88,9 @@ const MessageInput = React.forwardRef((props, ref) => {
     onVoiceMessageIconClick,
     onKeyUp,
     onKeyDown,
+    renderFileUploadIcon,
+    renderVoiceMessageIcon,
+    renderSendMessageIcon,
   } = props;
   const textFieldId = messageFieldId || TEXT_FIELD_ID;
   const { stringSet } = useContext(LocalizationContext);
@@ -370,6 +373,18 @@ const MessageInput = React.forwardRef((props, ref) => {
       resetInput(ref);
     }
   };
+
+  const MemoizedSendIcon = useMemo(() => {
+    return renderSendMessageIcon?.();
+  }, [renderSendMessageIcon]);
+
+  const MemoizedUploadIcon = useMemo(() => {
+    return renderFileUploadIcon?.();
+  }, [renderSendMessageIcon]);
+
+  const MemoizedVoiceIcon = useMemo(() => {
+    return renderVoiceMessageIcon?.();
+  }, [renderVoiceMessageIcon]);
 
   return (
     <form

--- a/src/ui/MessageItemMenu/index.tsx
+++ b/src/ui/MessageItemMenu/index.tsx
@@ -1,6 +1,5 @@
 import './index.scss';
 import React, { ReactElement, useContext, useRef } from 'react';
-import { Role } from '@sendbird/chat';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
@@ -18,6 +17,7 @@ import {
 } from '../../utils/index';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import { ReplyType } from '../../index';
+import { Role } from '../../lib/types';
 
 interface Props {
   className?: string | Array<string>;

--- a/src/ui/MessageItemMenu/index.tsx
+++ b/src/ui/MessageItemMenu/index.tsx
@@ -1,6 +1,6 @@
 import './index.scss';
 import React, { ReactElement, useContext, useRef } from 'react';
-import type { Role } from '@sendbird/chat';
+import { Role } from '@sendbird/chat';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';


### PR DESCRIPTION
Add props:
```
  renderFileUploadIcon?: () =>  React.ReactElement;
  renderVoiceMessageIcon?: () =>  React.ReactElement;
  renderSendMessageIcon?: () =>  React.ReactElement;
```

To Channel & Thread
> Important: renderVoiceMessageIcon and renderSendMessageIcon only customizes IconUI
But, renderFileUploadIcon helps you customize/extend functionality
For example: it can be extended to open camera, open a new modal to drag and drop files, convert files before upload ~