### PR TITLE
fix: Refresh channel before fetching message search list

### DIFF
--- a/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
+++ b/src/smart-components/MessageSearch/context/hooks/useGetSearchedMessages.ts
@@ -46,39 +46,41 @@ function useGetSearchedMessages(
     });
     if (sdk && channelUrl && sdk.createMessageSearchQuery && currentChannel) {
       if (requestString) {
-        const inputSearchMessageQueryObject: MessageSearchQueryParams = {
-          order: MessageSearchOrder.TIMESTAMP,
-          channelUrl,
-          messageTimestampFrom: currentChannel.invitedAt,
-          keyword: requestString,
-          ...messageSearchQuery,
-        };
-        const createdQuery = sdk.createMessageSearchQuery(inputSearchMessageQueryObject);
-        createdQuery.next().then((messages) => {
-          logger.info('MessageSearch | useGetSearchedMessages: succeeded getting messages', messages);
-          messageSearchDispatcher({
-            type: messageActionTypes.GET_SEARCHED_MESSAGES,
-            payload: {
-              messages,
-              createdQuery,
-            },
+        currentChannel.refresh().then((channel) => {
+          const inputSearchMessageQueryObject: MessageSearchQueryParams = {
+            order: MessageSearchOrder.TIMESTAMP,
+            channelUrl,
+            messageTimestampFrom: channel.invitedAt,
+            keyword: requestString,
+            ...messageSearchQuery,
+          };
+          const createdQuery = sdk.createMessageSearchQuery(inputSearchMessageQueryObject);
+          createdQuery.next().then((messages) => {
+            logger.info('MessageSearch | useGetSearchedMessages: succeeded getting messages', messages);
+            messageSearchDispatcher({
+              type: messageActionTypes.GET_SEARCHED_MESSAGES,
+              payload: {
+                messages,
+                createdQuery,
+              },
+            });
+            if (onResultLoaded && typeof onResultLoaded === 'function') {
+              onResultLoaded(messages, null);
+            }
+          }).catch((error) => {
+            logger.warning('MessageSearch | useGetSearchedMessages: getting failed', error);
+            messageSearchDispatcher({
+              type: messageActionTypes.SET_QUERY_INVALID,
+              payload: null,
+            });
+            if (onResultLoaded && typeof onResultLoaded === 'function') {
+              onResultLoaded(null, error);
+            }
           });
-          if (onResultLoaded && typeof onResultLoaded === 'function') {
-            onResultLoaded(messages, null);
-          }
-        }).catch((error) => {
-          logger.warning('MessageSearch | useGetSearchedMessages: getting failed', error);
           messageSearchDispatcher({
-            type: messageActionTypes.SET_QUERY_INVALID,
-            payload: null,
+            type: messageActionTypes.START_GETTING_SEARCHED_MESSAGES,
+            payload: createdQuery,
           });
-          if (onResultLoaded && typeof onResultLoaded === 'function') {
-            onResultLoaded(null, error);
-          }
-        });
-        messageSearchDispatcher({
-          type: messageActionTypes.START_GETTING_SEARCHED_MESSAGES,
-          payload: createdQuery,
         });
       } else {
         logger.info('MessageSearch | useGetSeasrchedMessages: search string is empty');


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-2979](https://sendbird.atlassian.net/browse/UIKIT-2979)

## Description Of Changes

#### Issue
* If you set the `channel.invitedAt` with the other timestamp by force, you will get the message search list which is fetched from the timestamp

#### Solution
* Refresh the channel before fetching message search list, to get the real value of the channel property

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)


[UIKIT-2979]: https://sendbird.atlassian.net/browse/UIKIT-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ