### PR TITLE
fix: add classname for empty OG-image

### DIFF
--- a/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
+++ b/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
@@ -6,7 +6,19 @@ import OGMessageItemBody from "../index";
 describe('ui/OGMessageItemBody', () => {
   it('should do a snapshot test of the OGMessageItemBody DOM', function() {
     const text = "example-text";
-    const { asFragment } = render(<OGMessageItemBody />);
+    const { asFragment } = render(<OGMessageItemBody message={{
+      ogMetaData: {
+        title: text,
+        description: text,
+        url: text,
+        image: text,
+      },
+    }} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should add .sendbird-og-message-item-body__og-thumbnail__image-empty classname when image is empty', () => {
+    const { container } = render(<OGMessageItemBody />);
+    expect(container.getElementsByClassName('sendbird-og-message-item-body__og-thumbnail__empty').length).toBe(1);
   });
 });

--- a/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -13,7 +13,9 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
       />
     </span>
     <div
-      class="sendbird-og-message-item-body__og-thumbnail"
+      class="sendbird-og-message-item-body__og-thumbnail
+          sendbird-og-message-item-body__og-thumbnail__empty
+        "
     >
       <div
         class="sendbird-og-message-item-body__og-thumbnail__image sendbird-image-renderer"
@@ -32,7 +34,23 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
     </div>
     <div
       class="sendbird-og-message-item-body__description"
-    />
+    >
+      <span
+        class="sendbird-og-message-item-body__description__title sendbird-label sendbird-label--subtitle-2 sendbird-label--color-onbackground-1"
+      >
+        example-text
+      </span>
+      <span
+        class="sendbird-og-message-item-body__description__description sendbird-label sendbird-label--body-2 sendbird-label--color-onbackground-1"
+      >
+        example-text
+      </span>
+      <span
+        class="sendbird-og-message-item-body__description__url sendbird-label sendbird-label--caption-3 sendbird-label--color-onbackground-2"
+      >
+        example-text
+      </span>
+    </div>
     <div
       class="sendbird-og-message-item-body__cover"
     />

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -1,5 +1,10 @@
 import './index.scss';
-import React, { ReactElement, useContext, useMemo } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react';
 import type { UserMessage } from '@sendbird/chat/message';
 
 import Word from '../Word';
@@ -27,6 +32,7 @@ export default function OGMessageItemBody({
   isMentionEnabled = false,
   isReactionEnabled = false,
 }: Props): ReactElement {
+  const imageRef = useRef<HTMLDivElement>(null);
   const { stringSet } = useContext(LocalizationContext);
   const openOGUrl = (): void => {
     if (message?.ogMetaData?.url) window.open(message?.ogMetaData?.url);
@@ -83,10 +89,20 @@ export default function OGMessageItemBody({
         </div>
       </Label>
       <div
-        className="sendbird-og-message-item-body__og-thumbnail"
+        ref={imageRef}
+        className={`sendbird-og-message-item-body__og-thumbnail
+          ${message?.ogMetaData?.defaultImage?.url ? '' : 'sendbird-og-message-item-body__og-thumbnail__empty'}
+        `}
         onClick={openOGUrl}
       >
         <ImageRenderer
+          onError={() => {
+            try {
+              imageRef?.current?.classList?.add('sendbird-og-message-item-body__og-thumbnail__empty');
+            } catch (error) {
+              // do nothing
+            }
+          }}
           className="sendbird-og-message-item-body__og-thumbnail__image"
           url={message?.ogMetaData?.defaultImage?.url || ''}
           alt={message?.ogMetaData?.defaultImage?.alt}


### PR DESCRIPTION
Add classname: `sendbird-og-message-item-body__og-thumbnail__empty` to
identify faulty images in OG message

Clients can use CSS to target this class~

```
.sendbird-og-message-item-body__og-thumbnail__empty {
  display: none;
}
```

fixes: https://sendbird.atlassian.net/browse/UIKIT-3304