### PR TITLE
[v3.4.3] (Mar 24 2023)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,36 +1,36 @@
 {
   "index.js": {
-    "bundled": 7133,
-    "minified": 6731,
-    "gzipped": 1592,
+    "bundled": 7137,
+    "minified": 6735,
+    "gzipped": 1596,
     "treeshaked": {
       "rollup": {
-        "code": 6345,
-        "import_statements": 6345
+        "code": 6349,
+        "import_statements": 6349
       },
       "webpack": {
-        "code": 13383
+        "code": 13387
       }
     }
   },
   "SendbirdProvider.js": {
-    "bundled": 25941,
-    "minified": 16384,
-    "gzipped": 4560,
+    "bundled": 25946,
+    "minified": 16394,
+    "gzipped": 4563,
     "treeshaked": {
       "rollup": {
         "code": 1406,
         "import_statements": 662
       },
       "webpack": {
-        "code": 16306
+        "code": 16311
       }
     }
   },
   "ChannelSettings.js": {
     "bundled": 3389,
     "minified": 2682,
-    "gzipped": 840,
+    "gzipped": 847,
     "treeshaked": {
       "rollup": {
         "code": 1727,
@@ -42,44 +42,44 @@
     }
   },
   "App.js": {
-    "bundled": 25042,
-    "minified": 15991,
-    "gzipped": 3870,
+    "bundled": 25046,
+    "minified": 15995,
+    "gzipped": 3864,
     "treeshaked": {
       "rollup": {
-        "code": 6030,
-        "import_statements": 5299
+        "code": 6034,
+        "import_statements": 5303
       },
       "webpack": {
-        "code": 21152
+        "code": 21156
       }
     }
   },
   "ChannelList.js": {
-    "bundled": 4575,
-    "minified": 3561,
-    "gzipped": 1080,
+    "bundled": 4606,
+    "minified": 3590,
+    "gzipped": 1086,
     "treeshaked": {
       "rollup": {
-        "code": 2229,
-        "import_statements": 2229
+        "code": 2258,
+        "import_statements": 2258
       },
       "webpack": {
-        "code": 5483
+        "code": 5546
       }
     }
   },
   "Channel.js": {
-    "bundled": 7026,
-    "minified": 5333,
-    "gzipped": 1482,
+    "bundled": 6995,
+    "minified": 5304,
+    "gzipped": 1479,
     "treeshaked": {
       "rollup": {
-        "code": 3214,
-        "import_statements": 3214
+        "code": 3185,
+        "import_statements": 3185
       },
       "webpack": {
-        "code": 7557
+        "code": 7493
       }
     }
   },
@@ -89,23 +89,23 @@
     "gzipped": 1537
   },
   "OpenChannel.js": {
-    "bundled": 3999,
-    "minified": 3157,
-    "gzipped": 976,
+    "bundled": 3968,
+    "minified": 3128,
+    "gzipped": 971,
     "treeshaked": {
       "rollup": {
-        "code": 2067,
-        "import_statements": 2067
+        "code": 2038,
+        "import_statements": 2038
       },
       "webpack": {
-        "code": 5185
+        "code": 5122
       }
     }
   },
   "OpenChannelSettings.js": {
     "bundled": 2819,
     "minified": 2294,
-    "gzipped": 771,
+    "gzipped": 770,
     "treeshaked": {
       "rollup": {
         "code": 1570,
@@ -147,7 +147,7 @@
   "sendbirdSelectors.js": {
     "bundled": 18957,
     "minified": 7661,
-    "gzipped": 1416,
+    "gzipped": 1417,
     "treeshaked": {
       "rollup": {
         "code": 57,
@@ -161,7 +161,7 @@
   "useSendbirdStateContext.js": {
     "bundled": 479,
     "minified": 244,
-    "gzipped": 166,
+    "gzipped": 165,
     "treeshaked": {
       "rollup": {
         "code": 88,
@@ -185,7 +185,7 @@
   "ChannelSettings/components/ChannelSettingsUI.js": {
     "bundled": 7023,
     "minified": 4830,
-    "gzipped": 1478,
+    "gzipped": 1479,
     "treeshaked": {
       "rollup": {
         "code": 1491,
@@ -216,51 +216,51 @@
     "gzipped": 4255
   },
   "ChannelList/components/ChannelListUI.js": {
-    "bundled": 11239,
-    "minified": 6446,
-    "gzipped": 2184,
+    "bundled": 11274,
+    "minified": 6479,
+    "gzipped": 2190,
     "treeshaked": {
       "rollup": {
-        "code": 2087,
-        "import_statements": 2087
+        "code": 2116,
+        "import_statements": 2116
       },
       "webpack": {
-        "code": 5539
+        "code": 5606
       }
     }
   },
   "OpenChannel/components/OpenChannelUI.js": {
-    "bundled": 5135,
-    "minified": 3669,
-    "gzipped": 1143,
+    "bundled": 5104,
+    "minified": 3640,
+    "gzipped": 1140,
     "treeshaked": {
       "rollup": {
-        "code": 1902,
-        "import_statements": 1902
+        "code": 1873,
+        "import_statements": 1873
       },
       "webpack": {
-        "code": 5190
+        "code": 5127
       }
     }
   },
   "Channel/components/ChannelUI.js": {
-    "bundled": 8060,
-    "minified": 5780,
-    "gzipped": 1634,
+    "bundled": 8029,
+    "minified": 5751,
+    "gzipped": 1626,
     "treeshaked": {
       "rollup": {
-        "code": 2982,
-        "import_statements": 2982
+        "code": 2953,
+        "import_statements": 2953
       },
       "webpack": {
-        "code": 7614
+        "code": 7551
       }
     }
   },
   "OpenChannelSettings/context.js": {
     "bundled": 6911,
     "minified": 3419,
-    "gzipped": 1077,
+    "gzipped": 1076,
     "treeshaked": {
       "rollup": {
         "code": 247,
@@ -274,7 +274,7 @@
   "OpenChannelSettings/components/OpenChannelSettingsUI.js": {
     "bundled": 5431,
     "minified": 4024,
-    "gzipped": 1258,
+    "gzipped": 1259,
     "treeshaked": {
       "rollup": {
         "code": 1391,
@@ -312,7 +312,7 @@
   "ui/IconButton.js": {
     "bundled": 1754,
     "minified": 946,
-    "gzipped": 516,
+    "gzipped": 515,
     "treeshaked": {
       "rollup": {
         "code": 46,
@@ -331,7 +331,7 @@
   "ui/Loader.js": {
     "bundled": 962,
     "minified": 644,
-    "gzipped": 382,
+    "gzipped": 381,
     "treeshaked": {
       "rollup": {
         "code": 83,
@@ -355,7 +355,7 @@
   "MessageSearch/context.js": {
     "bundled": 12924,
     "minified": 6444,
-    "gzipped": 1938,
+    "gzipped": 1937,
     "treeshaked": {
       "rollup": {
         "code": 221,
@@ -413,7 +413,7 @@
   "ChannelSettings/components/ChannelProfile.js": {
     "bundled": 4007,
     "minified": 2698,
-    "gzipped": 1007,
+    "gzipped": 1009,
     "treeshaked": {
       "rollup": {
         "code": 792,
@@ -441,7 +441,7 @@
   "ChannelSettings/components/ModerationPanel.js": {
     "bundled": 33236,
     "minified": 18707,
-    "gzipped": 3205,
+    "gzipped": 3203,
     "treeshaked": {
       "rollup": {
         "code": 1169,
@@ -460,7 +460,7 @@
   "ChannelSettings/components/UserPanel.js": {
     "bundled": 3403,
     "minified": 2744,
-    "gzipped": 1057,
+    "gzipped": 1058,
     "treeshaked": {
       "rollup": {
         "code": 1046,
@@ -474,7 +474,7 @@
   "ChannelList/components/ChannelListHeader.js": {
     "bundled": 3166,
     "minified": 2128,
-    "gzipped": 831,
+    "gzipped": 832,
     "treeshaked": {
       "rollup": {
         "code": 407,
@@ -500,23 +500,23 @@
     }
   },
   "ChannelList/components/ChannelPreview.js": {
-    "bundled": 10275,
-    "minified": 7101,
-    "gzipped": 2145,
+    "bundled": 10310,
+    "minified": 7134,
+    "gzipped": 2144,
     "treeshaked": {
       "rollup": {
-        "code": 1450,
-        "import_statements": 1450
+        "code": 1479,
+        "import_statements": 1479
       },
       "webpack": {
-        "code": 4196
+        "code": 4263
       }
     }
   },
   "EditUserProfile.js": {
     "bundled": 1300,
     "minified": 1077,
-    "gzipped": 483,
+    "gzipped": 480,
     "treeshaked": {
       "rollup": {
         "code": 732,
@@ -530,7 +530,7 @@
   "ChannelList/components/ChannelPreviewAction.js": {
     "bundled": 4627,
     "minified": 3081,
-    "gzipped": 1259,
+    "gzipped": 1255,
     "treeshaked": {
       "rollup": {
         "code": 865,
@@ -544,7 +544,7 @@
   "ui/ConnectionStatus.js": {
     "bundled": 928,
     "minified": 766,
-    "gzipped": 410,
+    "gzipped": 411,
     "treeshaked": {
       "rollup": {
         "code": 181,
@@ -558,7 +558,7 @@
   "Channel/components/ChannelHeader.js": {
     "bundled": 5319,
     "minified": 3717,
-    "gzipped": 1263,
+    "gzipped": 1262,
     "treeshaked": {
       "rollup": {
         "code": 1063,
@@ -572,7 +572,7 @@
   "Channel/components/TypingIndicator.js": {
     "bundled": 4065,
     "minified": 2764,
-    "gzipped": 1087,
+    "gzipped": 1085,
     "treeshaked": {
       "rollup": {
         "code": 859,
@@ -584,16 +584,16 @@
     }
   },
   "Channel/components/MessageList.js": {
-    "bundled": 12869,
-    "minified": 7319,
-    "gzipped": 2454,
+    "bundled": 12838,
+    "minified": 7290,
+    "gzipped": 2445,
     "treeshaked": {
       "rollup": {
-        "code": 2603,
-        "import_statements": 2603
+        "code": 2574,
+        "import_statements": 2574
       },
       "webpack": {
-        "code": 6795
+        "code": 6732
       }
     }
   },
@@ -614,7 +614,7 @@
   "Channel/components/UnreadCount.js": {
     "bundled": 1683,
     "minified": 1207,
-    "gzipped": 605,
+    "gzipped": 606,
     "treeshaked": {
       "rollup": {
         "code": 184,
@@ -626,37 +626,37 @@
     }
   },
   "OpenChannel/components/OpenChannelInput.js": {
-    "bundled": 2155,
-    "minified": 1658,
-    "gzipped": 728,
+    "bundled": 2124,
+    "minified": 1629,
+    "gzipped": 716,
     "treeshaked": {
       "rollup": {
-        "code": 875,
-        "import_statements": 875
+        "code": 846,
+        "import_statements": 846
       },
       "webpack": {
-        "code": 2895
+        "code": 2832
       }
     }
   },
   "Channel/components/MessageInput.js": {
-    "bundled": 10344,
-    "minified": 5698,
-    "gzipped": 2085,
+    "bundled": 10366,
+    "minified": 5688,
+    "gzipped": 2084,
     "treeshaked": {
       "rollup": {
-        "code": 1673,
-        "import_statements": 1673
+        "code": 1644,
+        "import_statements": 1644
       },
       "webpack": {
-        "code": 4669
+        "code": 4606
       }
     }
   },
   "OpenChannel/components/FrozenChannelNotification.js": {
     "bundled": 749,
     "minified": 634,
-    "gzipped": 333,
+    "gzipped": 335,
     "treeshaked": {
       "rollup": {
         "code": 163,
@@ -670,7 +670,7 @@
   "OpenChannel/components/OpenChannelHeader.js": {
     "bundled": 4072,
     "minified": 3037,
-    "gzipped": 1043,
+    "gzipped": 1045,
     "treeshaked": {
       "rollup": {
         "code": 705,
@@ -682,23 +682,23 @@
     }
   },
   "OpenChannel/components/OpenChannelMessageList.js": {
-    "bundled": 6518,
-    "minified": 4307,
-    "gzipped": 1567,
+    "bundled": 6487,
+    "minified": 4278,
+    "gzipped": 1562,
     "treeshaked": {
       "rollup": {
-        "code": 1766,
-        "import_statements": 1766
+        "code": 1737,
+        "import_statements": 1737
       },
       "webpack": {
-        "code": 4918
+        "code": 4855
       }
     }
   },
   "OpenChannelSettings/components/OperatorUI.js": {
     "bundled": 37324,
     "minified": 21582,
-    "gzipped": 3683,
+    "gzipped": 3680,
     "treeshaked": {
       "rollup": {
         "code": 1316,
@@ -712,7 +712,7 @@
   "OpenChannelSettings/components/ParticipantUI.js": {
     "bundled": 1276,
     "minified": 1201,
-    "gzipped": 469,
+    "gzipped": 468,
     "treeshaked": {
       "rollup": {
         "code": 1058,
@@ -726,7 +726,7 @@
   "ui/MessageSearchItem.js": {
     "bundled": 3393,
     "minified": 2317,
-    "gzipped": 883,
+    "gzipped": 884,
     "treeshaked": {
       "rollup": {
         "code": 371,
@@ -740,7 +740,7 @@
   "ui/MessageSearchFileItem.js": {
     "bundled": 4732,
     "minified": 3148,
-    "gzipped": 1163,
+    "gzipped": 1161,
     "treeshaked": {
       "rollup": {
         "code": 450,
@@ -754,7 +754,7 @@
   "ui/ChannelAvatar.js": {
     "bundled": 2145,
     "minified": 1352,
-    "gzipped": 598,
+    "gzipped": 599,
     "treeshaked": {
       "rollup": {
         "code": 185,
@@ -768,7 +768,7 @@
   "ui/TextButton.js": {
     "bundled": 1180,
     "minified": 774,
-    "gzipped": 439,
+    "gzipped": 438,
     "treeshaked": {
       "rollup": {
         "code": 74,
@@ -782,7 +782,7 @@
   "ui/Accordion.js": {
     "bundled": 2315,
     "minified": 1399,
-    "gzipped": 618,
+    "gzipped": 617,
     "treeshaked": {
       "rollup": {
         "code": 169,
@@ -796,7 +796,7 @@
   "ChannelSettings/components/EditDetailsModal.js": {
     "bundled": 6356,
     "minified": 3956,
-    "gzipped": 1436,
+    "gzipped": 1437,
     "treeshaked": {
       "rollup": {
         "code": 762,
@@ -869,23 +869,23 @@
     }
   },
   "ui/MentionUserLabel.js": {
-    "bundled": 585,
-    "minified": 374,
-    "gzipped": 259,
+    "bundled": 703,
+    "minified": 477,
+    "gzipped": 318,
     "treeshaked": {
       "rollup": {
-        "code": 14,
-        "import_statements": 14
+        "code": 43,
+        "import_statements": 43
       },
       "webpack": {
-        "code": 998
+        "code": 1061
       }
     }
   },
   "ui/MessageStatus.js": {
     "bundled": 511,
     "minified": 477,
-    "gzipped": 256,
+    "gzipped": 254,
     "treeshaked": {
       "rollup": {
         "code": 424,
@@ -897,16 +897,16 @@
     }
   },
   "ui/ContextMenu.js": {
-    "bundled": 10858,
-    "minified": 5681,
-    "gzipped": 1948,
+    "bundled": 11013,
+    "minified": 5714,
+    "gzipped": 1969,
     "treeshaked": {
       "rollup": {
-        "code": 2336,
+        "code": 2339,
         "import_statements": 321
       },
       "webpack": {
-        "code": 3644
+        "code": 3647
       }
     }
   },
@@ -933,7 +933,7 @@
   "ui/ReactionButton.js": {
     "bundled": 1173,
     "minified": 745,
-    "gzipped": 412,
+    "gzipped": 411,
     "treeshaked": {
       "rollup": {
         "code": 46,
@@ -964,16 +964,16 @@
     "gzipped": 206
   },
   "Channel/components/Message.js": {
-    "bundled": 17074,
-    "minified": 9120,
-    "gzipped": 2998,
+    "bundled": 17043,
+    "minified": 9091,
+    "gzipped": 2991,
     "treeshaked": {
       "rollup": {
-        "code": 2497,
-        "import_statements": 2497
+        "code": 2468,
+        "import_statements": 2468
       },
       "webpack": {
-        "code": 6549
+        "code": 6486
       }
     }
   },
@@ -994,7 +994,7 @@
   "Channel/components/SuggestedMentionList.js": {
     "bundled": 13607,
     "minified": 7187,
-    "gzipped": 2298,
+    "gzipped": 2295,
     "treeshaked": {
       "rollup": {
         "code": 1004,
@@ -1011,16 +1011,16 @@
     "gzipped": 183
   },
   "OpenChannel/components/OpenChannelMessage.js": {
-    "bundled": 12640,
-    "minified": 7357,
-    "gzipped": 2142,
+    "bundled": 12609,
+    "minified": 7328,
+    "gzipped": 2137,
     "treeshaked": {
       "rollup": {
-        "code": 1842,
-        "import_statements": 1690
+        "code": 1813,
+        "import_statements": 1661
       },
       "webpack": {
-        "code": 4896
+        "code": 4833
       }
     }
   },
@@ -1132,7 +1132,7 @@
   "ui/DateSeparator.js": {
     "bundled": 1480,
     "minified": 1127,
-    "gzipped": 502,
+    "gzipped": 503,
     "treeshaked": {
       "rollup": {
         "code": 153,
@@ -1146,7 +1146,7 @@
   "ui/MessageContent.js": {
     "bundled": 36109,
     "minified": 20940,
-    "gzipped": 4573,
+    "gzipped": 4571,
     "treeshaked": {
       "rollup": {
         "code": 1863,
@@ -1160,7 +1160,7 @@
   "Channel/components/RemoveMessageModal.js": {
     "bundled": 2168,
     "minified": 1738,
-    "gzipped": 762,
+    "gzipped": 761,
     "treeshaked": {
       "rollup": {
         "code": 999,
@@ -1174,7 +1174,7 @@
   "Channel/components/FileViewer.js": {
     "bundled": 6157,
     "minified": 4412,
-    "gzipped": 1381,
+    "gzipped": 1382,
     "treeshaked": {
       "rollup": {
         "code": 868,
@@ -1188,7 +1188,7 @@
   "ui/OpenChannelAdminMessage.js": {
     "bundled": 838,
     "minified": 670,
-    "gzipped": 383,
+    "gzipped": 384,
     "treeshaked": {
       "rollup": {
         "code": 125,
@@ -1202,7 +1202,7 @@
   "ui/OpenchannelUserMessage.js": {
     "bundled": 10941,
     "minified": 6871,
-    "gzipped": 2087,
+    "gzipped": 2083,
     "treeshaked": {
       "rollup": {
         "code": 920,
@@ -1216,7 +1216,7 @@
   "ui/OpenchannelOGMessage.js": {
     "bundled": 14602,
     "minified": 9163,
-    "gzipped": 2609,
+    "gzipped": 2606,
     "treeshaked": {
       "rollup": {
         "code": 987,
@@ -1230,7 +1230,7 @@
   "ui/OpenchannelThumbnailMessage.js": {
     "bundled": 12978,
     "minified": 8412,
-    "gzipped": 2388,
+    "gzipped": 2384,
     "treeshaked": {
       "rollup": {
         "code": 892,
@@ -1244,7 +1244,7 @@
   "ui/OpenchannelFileMessage.js": {
     "bundled": 9759,
     "minified": 6192,
-    "gzipped": 2000,
+    "gzipped": 1997,
     "treeshaked": {
       "rollup": {
         "code": 944,
@@ -1258,7 +1258,7 @@
   "ui/FileViewer.js": {
     "bundled": 5673,
     "minified": 3922,
-    "gzipped": 1191,
+    "gzipped": 1192,
     "treeshaked": {
       "rollup": {
         "code": 412,
@@ -1272,7 +1272,7 @@
   "ui/OpenChannelAvatar.js": {
     "bundled": 1345,
     "minified": 956,
-    "gzipped": 512,
+    "gzipped": 513,
     "treeshaked": {
       "rollup": {
         "code": 287,
@@ -1286,7 +1286,7 @@
   "OpenChannelSettings/components/EditDetailsModal.js": {
     "bundled": 5944,
     "minified": 3872,
-    "gzipped": 1445,
+    "gzipped": 1449,
     "treeshaked": {
       "rollup": {
         "code": 830,
@@ -1300,7 +1300,7 @@
   "ui/UserListItem.js": {
     "bundled": 4853,
     "minified": 3150,
-    "gzipped": 1186,
+    "gzipped": 1188,
     "treeshaked": {
       "rollup": {
         "code": 771,
@@ -1314,7 +1314,7 @@
   "ui/UserProfile.js": {
     "bundled": 3949,
     "minified": 2641,
-    "gzipped": 966,
+    "gzipped": 968,
     "treeshaked": {
       "rollup": {
         "code": 547,
@@ -1342,7 +1342,7 @@
   "CreateChannel/components/SelectChannelType.js": {
     "bundled": 4982,
     "minified": 3444,
-    "gzipped": 1015,
+    "gzipped": 1016,
     "treeshaked": {
       "rollup": {
         "code": 617,
@@ -1370,7 +1370,7 @@
   "CreateChannel/components/InviteUsers.js": {
     "bundled": 7642,
     "minified": 4160,
-    "gzipped": 1730,
+    "gzipped": 1729,
     "treeshaked": {
       "rollup": {
         "code": 988,
@@ -1384,7 +1384,7 @@
   "ui/MessageItemReactionMenu.js": {
     "bundled": 3902,
     "minified": 2358,
-    "gzipped": 929,
+    "gzipped": 930,
     "treeshaked": {
       "rollup": {
         "code": 394,
@@ -1398,7 +1398,7 @@
   "ui/MessageItemMenu.js": {
     "bundled": 7467,
     "minified": 3938,
-    "gzipped": 1324,
+    "gzipped": 1325,
     "treeshaked": {
       "rollup": {
         "code": 437,
@@ -1454,7 +1454,7 @@
   "ui/FileMessageItemBody.js": {
     "bundled": 2820,
     "minified": 1949,
-    "gzipped": 850,
+    "gzipped": 849,
     "treeshaked": {
       "rollup": {
         "code": 314,
@@ -1496,7 +1496,7 @@
   "ui/OGMessageItemBody.js": {
     "bundled": 7541,
     "minified": 5050,
-    "gzipped": 1512,
+    "gzipped": 1513,
     "treeshaked": {
       "rollup": {
         "code": 784,
@@ -1562,7 +1562,7 @@
   "ui/Tooltip.js": {
     "bundled": 828,
     "minified": 624,
-    "gzipped": 371,
+    "gzipped": 372,
     "treeshaked": {
       "rollup": {
         "code": 125,
@@ -1576,7 +1576,7 @@
   "ui/TooltipWrapper.js": {
     "bundled": 1735,
     "minified": 1110,
-    "gzipped": 497,
+    "gzipped": 496,
     "treeshaked": {
       "rollup": {
         "code": 46,
@@ -1604,7 +1604,7 @@
   "ui/Word.js": {
     "bundled": 3707,
     "minified": 2225,
-    "gzipped": 978,
+    "gzipped": 979,
     "treeshaked": {
       "rollup": {
         "code": 766,
@@ -1688,7 +1688,7 @@
   "ui/OpenchannelConversationHeader.js": {
     "bundled": 2679,
     "minified": 2070,
-    "gzipped": 696,
+    "gzipped": 697,
     "treeshaked": {
       "rollup": {
         "code": 311,
@@ -1702,7 +1702,7 @@
   "ChannelList/context.js": {
     "bundled": 558,
     "minified": 526,
-    "gzipped": 292,
+    "gzipped": 291,
     "treeshaked": {
       "rollup": {
         "code": 458,
@@ -1716,7 +1716,7 @@
   "Channel/context.js": {
     "bundled": 974,
     "minified": 915,
-    "gzipped": 428,
+    "gzipped": 427,
     "treeshaked": {
       "rollup": {
         "code": 817,
@@ -1730,7 +1730,7 @@
   "OpenChannel/context.js": {
     "bundled": 564,
     "minified": 530,
-    "gzipped": 282,
+    "gzipped": 280,
     "treeshaked": {
       "rollup": {
         "code": 462,
@@ -1758,7 +1758,7 @@
   "ui/PlaceHolder.js": {
     "bundled": 331,
     "minified": 307,
-    "gzipped": 201,
+    "gzipped": 203,
     "treeshaked": {
       "rollup": {
         "code": 261,
@@ -1772,7 +1772,7 @@
   "EditUserProfile/components/EditUserProfileUI.js": {
     "bundled": 897,
     "minified": 842,
-    "gzipped": 355,
+    "gzipped": 356,
     "treeshaked": {
       "rollup": {
         "code": 732,
@@ -1786,7 +1786,7 @@
   "ui/Button.js": {
     "bundled": 2426,
     "minified": 1688,
-    "gzipped": 704,
+    "gzipped": 703,
     "treeshaked": {
       "rollup": {
         "code": 273,
@@ -1817,16 +1817,16 @@
     "gzipped": 28329
   },
   "ui/MessageInput.js": {
-    "bundled": 30616,
-    "minified": 14869,
-    "gzipped": 4696,
+    "bundled": 31060,
+    "minified": 15005,
+    "gzipped": 4805,
     "treeshaked": {
       "rollup": {
-        "code": 12494,
-        "import_statements": 875
+        "code": 12655,
+        "import_statements": 824
       },
       "webpack": {
-        "code": 14485
+        "code": 14550
       }
     }
   },
@@ -4333,7 +4333,7 @@
   "withSendbird.js": {
     "bundled": 1218,
     "minified": 629,
-    "gzipped": 344,
+    "gzipped": 343,
     "treeshaked": {
       "rollup": {
         "code": 62,
@@ -5133,16 +5133,16 @@
     }
   },
   "Thread.js": {
-    "bundled": 4925,
-    "minified": 3809,
-    "gzipped": 1222,
+    "bundled": 4894,
+    "minified": 3780,
+    "gzipped": 1215,
     "treeshaked": {
       "rollup": {
-        "code": 2862,
-        "import_statements": 2862
+        "code": 2833,
+        "import_statements": 2833
       },
       "webpack": {
-        "code": 6864
+        "code": 6801
       }
     }
   },
@@ -5207,16 +5207,16 @@
     "gzipped": 315
   },
   "Thread/components/ThreadUI.js": {
-    "bundled": 13005,
-    "minified": 8129,
-    "gzipped": 2375,
+    "bundled": 12974,
+    "minified": 8100,
+    "gzipped": 2368,
     "treeshaked": {
       "rollup": {
-        "code": 2707,
-        "import_statements": 2707
+        "code": 2678,
+        "import_statements": 2678
       },
       "webpack": {
-        "code": 6968
+        "code": 6905
       }
     }
   },
@@ -5253,7 +5253,7 @@
   "VoicePlayer/useVoicePlayer.js": {
     "bundled": 2937,
     "minified": 1321,
-    "gzipped": 638,
+    "gzipped": 639,
     "treeshaked": {
       "rollup": {
         "code": 160,
@@ -5267,7 +5267,7 @@
   "VoiceRecorder/useVoiceRecorder.js": {
     "bundled": 3184,
     "minified": 1534,
-    "gzipped": 661,
+    "gzipped": 663,
     "treeshaked": {
       "rollup": {
         "code": 197,
@@ -5286,7 +5286,7 @@
   "Thread/components/ThreadHeader.js": {
     "bundled": 2262,
     "minified": 1590,
-    "gzipped": 646,
+    "gzipped": 647,
     "treeshaked": {
       "rollup": {
         "code": 298,
@@ -5298,51 +5298,51 @@
     }
   },
   "Thread/components/ParentMessageInfo.js": {
-    "bundled": 15697,
-    "minified": 8700,
-    "gzipped": 2861,
+    "bundled": 15666,
+    "minified": 8671,
+    "gzipped": 2857,
     "treeshaked": {
       "rollup": {
-        "code": 2074,
-        "import_statements": 2074
+        "code": 2045,
+        "import_statements": 2045
       },
       "webpack": {
-        "code": 5599
+        "code": 5536
       }
     }
   },
   "Thread/components/ThreadList.js": {
-    "bundled": 5431,
-    "minified": 3866,
-    "gzipped": 1344,
+    "bundled": 5400,
+    "minified": 3837,
+    "gzipped": 1337,
     "treeshaked": {
       "rollup": {
-        "code": 2384,
-        "import_statements": 2384
+        "code": 2355,
+        "import_statements": 2355
       },
       "webpack": {
-        "code": 6285
+        "code": 6222
       }
     }
   },
   "Thread/components/ThreadMessageInput.js": {
-    "bundled": 10106,
-    "minified": 5464,
+    "bundled": 10130,
+    "minified": 5451,
     "gzipped": 2036,
     "treeshaked": {
       "rollup": {
-        "code": 1679,
-        "import_statements": 1679
+        "code": 1650,
+        "import_statements": 1650
       },
       "webpack": {
-        "code": 4676
+        "code": 4613
       }
     }
   },
   "ui/ThreadReplies.js": {
     "bundled": 3315,
     "minified": 2317,
-    "gzipped": 829,
+    "gzipped": 828,
     "treeshaked": {
       "rollup": {
         "code": 287,
@@ -5444,23 +5444,23 @@
     }
   },
   "Thread/components/ThreadListItem.js": {
-    "bundled": 24945,
-    "minified": 14176,
-    "gzipped": 3931,
+    "bundled": 24914,
+    "minified": 14147,
+    "gzipped": 3925,
     "treeshaked": {
       "rollup": {
-        "code": 2339,
-        "import_statements": 2339
+        "code": 2310,
+        "import_statements": 2310
       },
       "webpack": {
-        "code": 6172
+        "code": 6109
       }
     }
   },
   "ui/BottomSheet.js": {
     "bundled": 1369,
     "minified": 856,
-    "gzipped": 432,
+    "gzipped": 433,
     "treeshaked": {
       "rollup": {
         "code": 60,
@@ -5544,7 +5544,7 @@
   "utils/message/isVoiceMessage.js": {
     "bundled": 209,
     "minified": 191,
-    "gzipped": 140,
+    "gzipped": 139,
     "treeshaked": {
       "rollup": {
         "code": 97,
@@ -5558,7 +5558,7 @@
   "OpenChannelList.js": {
     "bundled": 2116,
     "minified": 1604,
-    "gzipped": 594,
+    "gzipped": 598,
     "treeshaked": {
       "rollup": {
         "code": 1017,
@@ -5577,7 +5577,7 @@
   "OpenChannelList/components/OpenChannelPreview.js": {
     "bundled": 3171,
     "minified": 2351,
-    "gzipped": 737,
+    "gzipped": 738,
     "treeshaked": {
       "rollup": {
         "code": 226,
@@ -5591,7 +5591,7 @@
   "CreateOpenChannel.js": {
     "bundled": 1577,
     "minified": 1225,
-    "gzipped": 501,
+    "gzipped": 502,
     "treeshaked": {
       "rollup": {
         "code": 743,
@@ -5605,7 +5605,7 @@
   "CreateOpenChannel/context.js": {
     "bundled": 2517,
     "minified": 1464,
-    "gzipped": 617,
+    "gzipped": 616,
     "treeshaked": {
       "rollup": {
         "code": 125,
@@ -5619,7 +5619,7 @@
   "CreateOpenChannel/components/CreateOpenChannelUI.js": {
     "bundled": 5327,
     "minified": 3821,
-    "gzipped": 1282,
+    "gzipped": 1283,
     "treeshaked": {
       "rollup": {
         "code": 663,
@@ -5633,7 +5633,7 @@
   "OpenChannelList/components/OpenChannelListUI.js": {
     "bundled": 8198,
     "minified": 4819,
-    "gzipped": 1502,
+    "gzipped": 1503,
     "treeshaked": {
       "rollup": {
         "code": 932,
@@ -5661,7 +5661,7 @@
   "Thread/context.js": {
     "bundled": 662,
     "minified": 622,
-    "gzipped": 317,
+    "gzipped": 318,
     "treeshaked": {
       "rollup": {
         "code": 563,
@@ -5675,7 +5675,7 @@
   "ui/VoiceMessgeInput.js": {
     "bundled": 440,
     "minified": 409,
-    "gzipped": 237,
+    "gzipped": 238,
     "treeshaked": {
       "rollup": {
         "code": 373,
@@ -5689,7 +5689,7 @@
   "OpenChannelList/context.js": {
     "bundled": 335,
     "minified": 316,
-    "gzipped": 206,
+    "gzipped": 203,
     "treeshaked": {
       "rollup": {
         "code": 232,
@@ -8828,6 +8828,861 @@
     "bundled": 84721,
     "minified": 39404,
     "gzipped": 9253,
+    "treeshaked": {
+      "rollup": {
+        "code": 656,
+        "import_statements": 582
+      },
+      "webpack": {
+        "code": 2282
+      }
+    }
+  },
+  "stringSet-1db37c33.js": {
+    "bundled": 9970,
+    "minified": 7894,
+    "gzipped": 2136
+  },
+  "_rollupPluginBabelHelpers-61859095.js": {
+    "bundled": 1660,
+    "minified": 1072,
+    "gzipped": 445
+  },
+  "LocalizationContext-5aceab76.js": {
+    "bundled": 950,
+    "minified": 757,
+    "gzipped": 334
+  },
+  "index-8eecbe24.js": {
+    "bundled": 8845,
+    "minified": 4857,
+    "gzipped": 1524
+  },
+  "MediaQueryContext-9a083dcf.js": {
+    "bundled": 3607,
+    "minified": 2103,
+    "gzipped": 738
+  },
+  "consts-75b91fe9.js": {
+    "bundled": 1627,
+    "minified": 1304,
+    "gzipped": 388
+  },
+  "ChannelListProvider-5e580dea.js": {
+    "bundled": 41327,
+    "minified": 21104,
+    "gzipped": 4638
+  },
+  "ChannelProvider-a57db975.js": {
+    "bundled": 86829,
+    "minified": 41430,
+    "gzipped": 9292
+  },
+  "OpenChannelProvider-784fb34f.js": {
+    "bundled": 74112,
+    "minified": 33836,
+    "gzipped": 7039
+  },
+  "index-cd6b2f18.js": {
+    "bundled": 3955,
+    "minified": 3164,
+    "gzipped": 888
+  },
+  "utils-e4a28ce3.js": {
+    "bundled": 59,
+    "minified": 49,
+    "gzipped": 63
+  },
+  "topics-81f12567.js": {
+    "bundled": 781,
+    "minified": 655,
+    "gzipped": 195
+  },
+  "actionTypes-21f9ec1f.js": {
+    "bundled": 233,
+    "minified": 201,
+    "gzipped": 108
+  },
+  "uuid-7bd43bd5.js": {
+    "bundled": 441,
+    "minified": 197,
+    "gzipped": 167
+  },
+  "tslib.es6-446fe5c6.js": {
+    "bundled": 4746,
+    "minified": 2463,
+    "gzipped": 1106
+  },
+  "index-8ef480b0.js": {
+    "bundled": 27260,
+    "minified": 14749,
+    "gzipped": 3851
+  },
+  "index-8ebd2891.js": {
+    "bundled": 6136,
+    "minified": 4724,
+    "gzipped": 1088
+  },
+  "index-a427c01e.js": {
+    "bundled": 13553,
+    "minified": 8463,
+    "gzipped": 2563
+  },
+  "UserProfileContext-b8b5eb47.js": {
+    "bundled": 1815,
+    "minified": 1193,
+    "gzipped": 398
+  },
+  "index-e189366a.js": {
+    "bundled": 16572,
+    "minified": 9198,
+    "gzipped": 2181
+  },
+  "MemberList-eef196d1.js": {
+    "bundled": 18891,
+    "minified": 9607,
+    "gzipped": 2316
+  },
+  "index-c9c315e3.js": {
+    "bundled": 7289,
+    "minified": 4824,
+    "gzipped": 1547
+  },
+  "useLongPress-fbeff7f1.js": {
+    "bundled": 3053,
+    "minified": 1397,
+    "gzipped": 649
+  },
+  "index-66355429.js": {
+    "bundled": 8125,
+    "minified": 5059,
+    "gzipped": 1511
+  },
+  "compareIds-71d08649.js": {
+    "bundled": 369,
+    "minified": 163,
+    "gzipped": 135
+  },
+  "const-e6cae521.js": {
+    "bundled": 770,
+    "minified": 621,
+    "gzipped": 258
+  },
+  "index-484849cf.js": {
+    "bundled": 74245,
+    "minified": 19439,
+    "gzipped": 4464
+  },
+  "utils-b7734ec6.js": {
+    "bundled": 1051,
+    "minified": 502,
+    "gzipped": 295
+  },
+  "const-8e07f353.js": {
+    "bundled": 356,
+    "minified": 289,
+    "gzipped": 183
+  },
+  "index-09d115c8.js": {
+    "bundled": 1993,
+    "minified": 313,
+    "gzipped": 198
+  },
+  "VoiceMessageInputWrapper-3efa0e59.js": {
+    "bundled": 6782,
+    "minified": 3964,
+    "gzipped": 1324
+  },
+  "utils-85bae6f4.js": {
+    "bundled": 1195,
+    "minified": 717,
+    "gzipped": 315
+  },
+  "color-c824d292.js": {
+    "bundled": 1181,
+    "minified": 918,
+    "gzipped": 312
+  },
+  "context-399dd8e2.js": {
+    "bundled": 506,
+    "minified": 400,
+    "gzipped": 238
+  },
+  "index-a81b3157.js": {
+    "bundled": 154,
+    "minified": 99,
+    "gzipped": 99
+  },
+  "ThreadProvider-245cb356.js": {
+    "bundled": 68179,
+    "minified": 35364,
+    "gzipped": 6753
+  },
+  "CreateChannelProvider-745ed46a.js": {
+    "bundled": 2087,
+    "minified": 1327,
+    "gzipped": 558
+  },
+  "index-8528ba15.js": {
+    "bundled": 5140,
+    "minified": 861,
+    "gzipped": 327
+  },
+  "consts-439bb436.js": {
+    "bundled": 150,
+    "minified": 142,
+    "gzipped": 108
+  },
+  "index-dd6c0902.js": {
+    "bundled": 7240,
+    "minified": 4544,
+    "gzipped": 1240
+  },
+  "utils-68decdd6.js": {
+    "bundled": 971,
+    "minified": 488,
+    "gzipped": 269
+  },
+  "index-98dedc70.js": {
+    "bundled": 7122,
+    "minified": 4345,
+    "gzipped": 1188
+  },
+  "types-6cf92c48.js": {
+    "bundled": 186,
+    "minified": 74,
+    "gzipped": 88
+  },
+  "RemoveMessageModal-31a33f76.js": {
+    "bundled": 1434,
+    "minified": 937,
+    "gzipped": 490
+  },
+  "OpenChannelListProvider-e36d9f33.js": {
+    "bundled": 17683,
+    "minified": 10606,
+    "gzipped": 2102
+  },
+  "stringSet-f4c04194.js": {
+    "bundled": 9948,
+    "minified": 7873,
+    "gzipped": 2131,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "consts-bf94452f.js": {
+    "bundled": 1239,
+    "minified": 939,
+    "gzipped": 367,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "_rollupPluginBabelHelpers-a6fb8db9.js": {
+    "bundled": 1622,
+    "minified": 1037,
+    "gzipped": 437,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "utils-1d822c74.js": {
+    "bundled": 45,
+    "minified": 36,
+    "gzipped": 54,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "uuid-9dda9b20.js": {
+    "bundled": 425,
+    "minified": 182,
+    "gzipped": 161,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "actionTypes-b2910bb9.js": {
+    "bundled": 176,
+    "minified": 149,
+    "gzipped": 95,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "MediaQueryContext-f1d24f7b.js": {
+    "bundled": 3358,
+    "minified": 1907,
+    "gzipped": 678,
+    "treeshaked": {
+      "rollup": {
+        "code": 14,
+        "import_statements": 14
+      },
+      "webpack": {
+        "code": 998
+      }
+    }
+  },
+  "compareIds-0df93c10.js": {
+    "bundled": 349,
+    "minified": 144,
+    "gzipped": 127,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "index-0598a3f8.js": {
+    "bundled": 13530,
+    "minified": 8441,
+    "gzipped": 2556,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 7189
+      }
+    }
+  },
+  "tslib.es6-0d507bec.js": {
+    "bundled": 4671,
+    "minified": 2386,
+    "gzipped": 1098,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "UserProfileContext-798ff1f9.js": {
+    "bundled": 1310,
+    "minified": 791,
+    "gzipped": 322,
+    "treeshaked": {
+      "rollup": {
+        "code": 131,
+        "import_statements": 40
+      },
+      "webpack": {
+        "code": 1578
+      }
+    }
+  },
+  "color-3ea2f32a.js": {
+    "bundled": 1077,
+    "minified": 817,
+    "gzipped": 304,
+    "treeshaked": {
+      "rollup": {
+        "code": 259,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 1209
+      }
+    }
+  },
+  "const-3e90ab6a.js": {
+    "bundled": 607,
+    "minified": 467,
+    "gzipped": 243,
+    "treeshaked": {
+      "rollup": {
+        "code": 67,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 1018
+      }
+    }
+  },
+  "index-245c7032.js": {
+    "bundled": 132,
+    "minified": 77,
+    "gzipped": 86,
+    "treeshaked": {
+      "rollup": {
+        "code": 14,
+        "import_statements": 14
+      },
+      "webpack": {
+        "code": 998
+      }
+    }
+  },
+  "const-15b18d4f.js": {
+    "bundled": 300,
+    "minified": 238,
+    "gzipped": 174,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "utils-b438b300.js": {
+    "bundled": 1110,
+    "minified": 637,
+    "gzipped": 304,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "topics-34615bc5.js": {
+    "bundled": 598,
+    "minified": 487,
+    "gzipped": 182,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "CreateChannelProvider-b5261b6f.js": {
+    "bundled": 1787,
+    "minified": 1085,
+    "gzipped": 495,
+    "treeshaked": {
+      "rollup": {
+        "code": 179,
+        "import_statements": 82
+      },
+      "webpack": {
+        "code": 1229
+      }
+    }
+  },
+  "utils-b7331548.js": {
+    "bundled": 946,
+    "minified": 464,
+    "gzipped": 263,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "types-277b33ab.js": {
+    "bundled": 172,
+    "minified": 61,
+    "gzipped": 79,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "consts-bdb24796.js": {
+    "bundled": 112,
+    "minified": 105,
+    "gzipped": 99,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "context-77ebb473.js": {
+    "bundled": 287,
+    "minified": 234,
+    "gzipped": 168,
+    "treeshaked": {
+      "rollup": {
+        "code": 130,
+        "import_statements": 61
+      },
+      "webpack": {
+        "code": 1145
+      }
+    }
+  },
+  "utils-889ef91c.js": {
+    "bundled": 1029,
+    "minified": 482,
+    "gzipped": 288,
+    "treeshaked": {
+      "rollup": {
+        "code": 28,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1012
+      }
+    }
+  },
+  "RemoveMessageModal-513fca41.js": {
+    "bundled": 1187,
+    "minified": 747,
+    "gzipped": 423,
+    "treeshaked": {
+      "rollup": {
+        "code": 138,
+        "import_statements": 138
+      },
+      "webpack": {
+        "code": 1254
+      }
+    }
+  },
+  "index-47bacf36.js": {
+    "bundled": 5058,
+    "minified": 780,
+    "gzipped": 323,
+    "treeshaked": {
+      "rollup": {
+        "code": 56,
+        "import_statements": 56
+      },
+      "webpack": {
+        "code": 1073
+      }
+    }
+  },
+  "useLongPress-932defe8.js": {
+    "bundled": 3006,
+    "minified": 1352,
+    "gzipped": 643,
+    "treeshaked": {
+      "rollup": {
+        "code": 86,
+        "import_statements": 86
+      },
+      "webpack": {
+        "code": 1136
+      }
+    }
+  },
+  "index-efddd5d1.js": {
+    "bundled": 1982,
+    "minified": 299,
+    "gzipped": 195,
+    "treeshaked": {
+      "rollup": {
+        "code": 28,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1012
+      }
+    }
+  },
+  "LocalizationContext-faa869e6.js": {
+    "bundled": 673,
+    "minified": 542,
+    "gzipped": 270,
+    "treeshaked": {
+      "rollup": {
+        "code": 113,
+        "import_statements": 105
+      },
+      "webpack": {
+        "code": 1165
+      }
+    }
+  },
+  "index-40fcb60b.js": {
+    "bundled": 3372,
+    "minified": 2694,
+    "gzipped": 809,
+    "treeshaked": {
+      "rollup": {
+        "code": 203,
+        "import_statements": 84
+      },
+      "webpack": {
+        "code": 3200
+      }
+    }
+  },
+  "index-14887308.js": {
+    "bundled": 5398,
+    "minified": 4104,
+    "gzipped": 1029,
+    "treeshaked": {
+      "rollup": {
+        "code": 160,
+        "import_statements": 160
+      },
+      "webpack": {
+        "code": 1309
+      }
+    }
+  },
+  "index-5ebdd2f3.js": {
+    "bundled": 6275,
+    "minified": 3891,
+    "gzipped": 1468,
+    "treeshaked": {
+      "rollup": {
+        "code": 295,
+        "import_statements": 295
+      },
+      "webpack": {
+        "code": 1607
+      }
+    }
+  },
+  "index-dc60c446.js": {
+    "bundled": 7496,
+    "minified": 4584,
+    "gzipped": 1470,
+    "treeshaked": {
+      "rollup": {
+        "code": 321,
+        "import_statements": 321
+      },
+      "webpack": {
+        "code": 1671
+      }
+    }
+  },
+  "index-82bbd3a5.js": {
+    "bundled": 6463,
+    "minified": 3808,
+    "gzipped": 1118,
+    "treeshaked": {
+      "rollup": {
+        "code": 121,
+        "import_statements": 121
+      },
+      "webpack": {
+        "code": 1204
+      }
+    }
+  },
+  "VoiceMessageInputWrapper-4a79cd88.js": {
+    "bundled": 6092,
+    "minified": 3356,
+    "gzipped": 1252,
+    "treeshaked": {
+      "rollup": {
+        "code": 372,
+        "import_statements": 372
+      },
+      "webpack": {
+        "code": 1722
+      }
+    }
+  },
+  "index-9e13245e.js": {
+    "bundled": 6726,
+    "minified": 4143,
+    "gzipped": 1181,
+    "treeshaked": {
+      "rollup": {
+        "code": 218,
+        "import_statements": 218
+      },
+      "webpack": {
+        "code": 1433
+      }
+    }
+  },
+  "MemberList-a13a5723.js": {
+    "bundled": 17744,
+    "minified": 8644,
+    "gzipped": 2258,
+    "treeshaked": {
+      "rollup": {
+        "code": 420,
+        "import_statements": 420
+      },
+      "webpack": {
+        "code": 1838
+      }
+    }
+  },
+  "index-dad39ace.js": {
+    "bundled": 26096,
+    "minified": 13662,
+    "gzipped": 3802,
+    "treeshaked": {
+      "rollup": {
+        "code": 164,
+        "import_statements": 83
+      },
+      "webpack": {
+        "code": 1181
+      }
+    }
+  },
+  "ChannelListProvider-b9b9b8b8.js": {
+    "bundled": 39248,
+    "minified": 19092,
+    "gzipped": 4584,
+    "treeshaked": {
+      "rollup": {
+        "code": 320,
+        "import_statements": 320
+      },
+      "webpack": {
+        "code": 1602
+      }
+    }
+  },
+  "OpenChannelListProvider-d2d1d70c.js": {
+    "bundled": 17135,
+    "minified": 10116,
+    "gzipped": 2043,
+    "treeshaked": {
+      "rollup": {
+        "code": 914,
+        "import_statements": 119
+      },
+      "webpack": {
+        "code": 2001
+      }
+    }
+  },
+  "index-021c461b.js": {
+    "bundled": 15445,
+    "minified": 8256,
+    "gzipped": 2127,
+    "treeshaked": {
+      "rollup": {
+        "code": 547,
+        "import_statements": 547
+      },
+      "webpack": {
+        "code": 2135
+      }
+    }
+  },
+  "index-ba0f687e.js": {
+    "bundled": 8451,
+    "minified": 4515,
+    "gzipped": 1478,
+    "treeshaked": {
+      "rollup": {
+        "code": 75,
+        "import_statements": 75
+      },
+      "webpack": {
+        "code": 1125
+      }
+    }
+  },
+  "ThreadProvider-ad0690f5.js": {
+    "bundled": 66649,
+    "minified": 33889,
+    "gzipped": 6709,
+    "treeshaked": {
+      "rollup": {
+        "code": 2144,
+        "import_statements": 495
+      },
+      "webpack": {
+        "code": 3514
+      }
+    }
+  },
+  "index-9d1fdd2f.js": {
+    "bundled": 74192,
+    "minified": 19390,
+    "gzipped": 4465,
+    "treeshaked": {
+      "rollup": {
+        "code": 28,
+        "import_statements": 28
+      },
+      "webpack": {
+        "code": 1012
+      }
+    }
+  },
+  "OpenChannelProvider-2aeb8bad.js": {
+    "bundled": 72829,
+    "minified": 32613,
+    "gzipped": 6997,
+    "treeshaked": {
+      "rollup": {
+        "code": 299,
+        "import_statements": 299
+      },
+      "webpack": {
+        "code": 1581
+      }
+    }
+  },
+  "ChannelProvider-e8beff2d.js": {
+    "bundled": 84721,
+    "minified": 39404,
+    "gzipped": 9254,
     "treeshaked": {
       "rollup": {
         "code": 656,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog - v3
 
-## [v3.4.1] (Mar 17 2023)
+## [v3.4.3] (Mar 24 2023)
+
+Features:
+* Add rollup-plugin-size-snapshot for bundle-size
+  Run rollup-plugin-size-snapshot on build,
+  we will check bundle size before every release
+* Move old samples to use vite
+  React team these days are using vite for their samples,
+  CRA is discourged
+* Run code coverage on commenting `./coverage`
+  Check code coverage on PR comment
+* Add prop to disable Channel & Thread inputs
+  Add prop: `disabled?: false` for Channel & Thread MessageInputWrapper
+* Replace renderToString(react-dom) with custom fn
+  Replace renderToString from react-dom/server with custom function
+  This function was creating issue in customers with cra@4 & react@17
+
+Fixes:
+* Replace outdated CSS rules
+  `justify-content: start;` and  `height: fill-available;`
+* Menu position in tight screens
+  * Condition where some menus get clipped in left side:
+    * Usually user profile in channel moderation
+  * Context menu of last item in channel gets clipped in the bottom
+
+
+## [v3.4.2] (Mar 17 2023)
 
 Features:
 * Mentions should be preserved when copy pasted from sendbird-messages and message input

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/uikit-react",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@sendbird/chat": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "React based UI kit for sendbird",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
Features:
* Add rollup-plugin-size-snapshot for bundle-size Run rollup-plugin-size-snapshot on build, we will check bundle size before every release
* Move old samples to use vite React team these days are using vite for their samples, CRA is discourged
* Run code coverage on commenting `./coverage` Check code coverage on PR comment
* Add prop to disable Channel & Thread inputs Add prop: `disabled?: false` for Channel & Thread MessageInputWrapper
* Replace renderToString(react-dom) with custom fn Replace renderToString from react-dom/server with custom function This function was creating issue in customers with cra@4 & react@17

Fixes:
* Replace outdated CSS rules `justify-content: start;` and  `height: fill-available;`
* Menu position in tight screens
  * Condition where some menus get clipped in left side: * Usually user profile in channel moderation
  * Context menu of last item in channel gets clipped in the bottom

