### PR TITLE
fix: Reduce sending two messages from VoiceMessageInputWrapper

### DIFF
--- a/src/smart-components/Channel/components/MessageInput/VoiceMessageInputWrapper.tsx
+++ b/src/smart-components/Channel/components/MessageInput/VoiceMessageInputWrapper.tsx
@@ -77,6 +77,8 @@ export const VoiceMessageInputWrapper = ({
     if (isSubmited && audioFile) {
       onSubmitClick(audioFile, recordingTime);
     }
+  }, [isSubmited, audioFile, recordingTime]);
+  useEffect(() => {
     if (audioFile) {
       if (recordingTime < minRecordingTime) {
         setVoiceInputState(VoiceMessageInputStatus.READY_TO_RECORD);

--- a/src/smart-components/Channel/components/MessageInput/VoiceMessageInputWrapper.tsx
+++ b/src/smart-components/Channel/components/MessageInput/VoiceMessageInputWrapper.tsx
@@ -76,6 +76,8 @@ export const VoiceMessageInputWrapper = ({
   useEffect(() => {
     if (isSubmited && audioFile) {
       onSubmitClick(audioFile, recordingTime);
+      setSubmit(false);
+      setAudioFile(null);
     }
   }, [isSubmited, audioFile, recordingTime]);
   useEffect(() => {


### PR DESCRIPTION
## For Internal Contributors

[UIKIT-3260](https://sendbird.atlassian.net/browse/UIKIT-3260)

## Description Of Changes

Issue:
* Sending two voice messages when the playing status has been changed before sending voice message

Fixes:
* Remove the dependency `playingStatus` from onSubmitClick in the VoiceMessageInputWrapper component
* Clean up the states after sending a voice message in the VoiceMessageInputWrapper component

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)


[UIKIT-3260]: https://sendbird.atlassian.net/browse/UIKIT-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ