### PR TITLE
fix: Update the default maximum recording time to 10 minutes

### DIFF
--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -2,8 +2,8 @@ export const SCROLL_BUFFER = 10;
 
 // voice message record
 export const VOICE_RECORDER_CLICK_BUFFER_TIME = 250;
-export const VOICE_RECORDER_DEFAULT_MIN = 1000;
-export const VOICE_RECORDER_DEFAULT_MAX = 60000;
+export const VOICE_RECORDER_DEFAULT_MIN = 1000; // 1 seconds
+export const VOICE_RECORDER_DEFAULT_MAX = 600000; // 10 minutes
 export const VOICE_RECORDER_MIME_TYPE = 'audio/webm';
 export const VOICE_RECORDER_AUDIO_BITS = 128000;
 


### PR DESCRIPTION
Performance
* It takes 5~6 seconds to convert 10 minute audio file  
  ![image](https://user-images.githubusercontent.com/46333979/229026976-1176b592-9cc3-4f63-ba6a-ee47b2e73fc9.png)
* It takes 2 seconds to send a voice message
  ![image](https://user-images.githubusercontent.com/46333979/229027036-8926acaf-7404-4f42-bd23-9899f7caf9e7.png)

[UIKIT-3514](https://sendbird.atlassian.net/browse/UIKIT-3514)


[UIKIT-3514]: https://sendbird.atlassian.net/browse/UIKIT-3514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ