### PR TITLE
fix: Modify condition of checking parent and thread messages

### DIFF
--- a/src/smart-components/Thread/context/ThreadProvider.tsx
+++ b/src/smart-components/Thread/context/ThreadProvider.tsx
@@ -145,7 +145,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     sdkInit,
     currentChannel,
     parentMessage,
-  }, { logger, pubSub, threadDispatcher })
+  }, { logger, pubSub, threadDispatcher });
 
   // callbacks
   const fetchPrevThreads = useGetPrevThreadsCallback({

--- a/src/smart-components/Thread/context/__test__/utils.spec.ts
+++ b/src/smart-components/Thread/context/__test__/utils.spec.ts
@@ -2,20 +2,20 @@ import { UserMessage } from "@sendbird/chat/message";
 import { getParentMessageFrom, isParentMessage, isThreadMessage } from "../utils";
 
 const mockParentMessage = {
-  messageId: 1,
+  messageId: 111111,
   parentMessage: null,
-  parentMessageId: null,
+  parentMessageId: 0,
   threadInfo: {
-    lastRepliedAt: 100000,
+    lastRepliedAt: 1000,
     replyCount: 1,
     mostRepliedUsers: [],
-    updatedAt: 100000,
+    updatedAt: 1000,
   },
 };
 const mockThreadMessage = {
-  messageId: 2,
+  messageId: 111112,
   parentMessage: mockParentMessage,
-  parentMessageId: 1,
+  parentMessageId: 111111,
   threadInfo: null,
 };
 
@@ -26,6 +26,9 @@ describe('Thread/utils - isParentMessage', () => {
   it('should confirm if the message is not a parent message', () => {
     expect(isParentMessage(mockThreadMessage as UserMessage)).toBe(false);
   });
+  it('should check type of the parentMessageId', () => {
+    expect(isParentMessage({ ...mockParentMessage, parentMessageId: '1' } as UserMessage)).toBe(false);
+  });
 });
 
 describe('Thread/utils - isThreadMessage', () => {
@@ -34,6 +37,9 @@ describe('Thread/utils - isThreadMessage', () => {
   });
   it('should comfirm if the message is not a thread message', () => {
     expect(isThreadMessage(mockParentMessage as UserMessage)).toBe(false);
+  });
+  it('should check type of the parentMessageId', () => {
+    expect(isThreadMessage({ ...mockThreadMessage, parentMessageId: '1' } as UserMessage)).toBe(false);
   });
 });
 

--- a/src/smart-components/Thread/context/utils.ts
+++ b/src/smart-components/Thread/context/utils.ts
@@ -25,15 +25,14 @@ export const getParentMessageFrom = (message: UserMessage | FileMessage): UserMe
 export const isParentMessage = (message: UserMessage | FileMessage): boolean => {
   return (
     message?.parentMessage === null
-    && message?.parentMessageId === null
-    && message?.threadInfo !== null
+    && !message?.parentMessageId
   );
 };
 
 export const isThreadMessage = (message: UserMessage | FileMessage): boolean => {
   return (
     message?.parentMessage !== null
-    && message?.parentMessageId !== null
+    && message?.parentMessageId
     && message?.threadInfo === null
   );
 };

--- a/src/smart-components/Thread/context/utils.ts
+++ b/src/smart-components/Thread/context/utils.ts
@@ -25,6 +25,7 @@ export const getParentMessageFrom = (message: UserMessage | FileMessage): UserMe
 export const isParentMessage = (message: UserMessage | FileMessage): boolean => {
   return (
     message?.parentMessage === null
+    && typeof message?.parentMessageId === 'number'
     && !message?.parentMessageId
   );
 };
@@ -32,7 +33,8 @@ export const isParentMessage = (message: UserMessage | FileMessage): boolean => 
 export const isThreadMessage = (message: UserMessage | FileMessage): boolean => {
   return (
     message?.parentMessage !== null
-    && message?.parentMessageId
+    && typeof message?.parentMessageId === 'number'
+    && message?.parentMessageId > 0
     && message?.threadInfo === null
   );
 };


### PR DESCRIPTION
### Description Of Changes

* Do not check threadInfo to improve the parent message, because every normal messages potentially can be a parent message
* The type of messageId should be the number
