### PR TITLE
chore: add workaround for ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ You need to install:
 * nodejs 16 LTS https://nodejs.org/en/download/
 * npm 8 or above
 
-We tried development on Mac OS / Linux systems. You might encounter problems in running `npm run build` in Windows machines
+**Caveats**
+ - We tried development on Mac OS / Linux systems. You might encounter problems in running `npm run build` in Windows machines
+ - If you use node.js >= 17 and see `ERR_OSSL_EVP_UNSUPPORTED` error on any run cmd, try to set `export NODE_OPTIONS=--openssl-legacy-provider` in the terminal
 
 ### Development
-
 We use storybook for development and rollup for building the npm distribution(bundled JS file)
 Make sure you have nodejs and npm installed and run
 


### PR DESCRIPTION
### Description Of Changes
When I try to run `npm run ...`, I encountered below error since I'm using node.js 19
```
at sendbird-uikit-react/.yarn/cache/loader-runner-npm-2.4.0-c414104c2f-e27eebbca5.zip/node_modules/loader-runner/lib/LoaderRunner.js:205:4 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

Seems it happens in node.js >= 17 version. So I'm adding a solution how other ppl can avoid it.  
Referred this https://github.com/webpack/webpack/issues/14532#issuecomment-947012063