### PR TITLE
Set current channel on ChannelList when opening channel from Thread

### DIFF
--- a/src/smart-components/App/DesktopLayout.tsx
+++ b/src/smart-components/App/DesktopLayout.tsx
@@ -40,6 +40,7 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (
       <div className="sendbird-app__channellist-wrap">
         <ChannelList
           allowProfileEdit={allowProfileEdit}
+          activeChannelUrl={currentChannel?.url}
           onProfileEditSuccess={onProfileEditSuccess}
           disableAutoSelect={disableAutoSelect}
           onChannelSelect={(channel) => {


### PR DESCRIPTION
### Description Of Changes

Issue:
* The ChannelPreview item is not selected when opening the channel from the ParentMessage of the Thread
Fix:
* Set activeChannelUrl of ChannelList

[QM-2277](https://sendbird.atlassian.net/browse/QM-2277)


[QM-2277]: https://sendbird.atlassian.net/browse/QM-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ