### PR TITLE
fix: Rename useMessageScrollRef to messageScrollRef

### DIFF
--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -98,7 +98,7 @@ const Message = ({
   const [mentionSuggestedUsers, setMentionSuggestedUsers] = useState([]);
   const [ableMention, setAbleMention] = useState(true);
   const editMessageInputRef = useRef(null);
-  const useMessageScrollRef = useRef(null);
+  const messageScrollRef = useRef(null);
   const displaySuggestedMentionList = isOnline
     && isMentionEnabled
     && mentionNickname.length > 0
@@ -138,8 +138,8 @@ const Message = ({
   useLayoutEffect(() => {
     let animationTimeout = null;
     let messageHighlightedTimeout = null;
-    if (highLightedMessageId === message.messageId && useMessageScrollRef?.current) {
-      useMessageScrollRef.current.scrollIntoView({ block: 'center', inline: 'center' });
+    if (highLightedMessageId === message.messageId && messageScrollRef?.current) {
+      messageScrollRef.current.scrollIntoView({ block: 'center', inline: 'center' });
       setIsAnimated(false);
       animationTimeout = setTimeout(() => {
         setIsHighlighted(true);
@@ -155,13 +155,13 @@ const Message = ({
       clearTimeout(animationTimeout);
       clearTimeout(messageHighlightedTimeout);
     }
-  }, [highLightedMessageId, useMessageScrollRef.current, message.messageId]);
+  }, [highLightedMessageId, messageScrollRef.current, message.messageId]);
 
   useLayoutEffect(() => {
     let animationTimeout = null;
     let messageAnimatedTimeout = null;
-    if (animatedMessageId === message.messageId && useMessageScrollRef?.current) {
-      useMessageScrollRef.current.scrollIntoView({ block: 'center', inline: 'center' });
+    if (animatedMessageId === message.messageId && messageScrollRef?.current) {
+      messageScrollRef.current.scrollIntoView({ block: 'center', inline: 'center' });
       setIsHighlighted(false);
       animationTimeout = setTimeout(() => {
         setIsAnimated(true);
@@ -177,7 +177,7 @@ const Message = ({
       clearTimeout(animationTimeout);
       clearTimeout(messageAnimatedTimeout);
     }
-  }, [animatedMessageId, useMessageScrollRef.current, message.messageId, onMessageAnimated]);
+  }, [animatedMessageId, messageScrollRef.current, message.messageId, onMessageAnimated]);
   const renderedMessage = useMemo(() => {
     return renderMessage?.({
       message,
@@ -195,7 +195,7 @@ const Message = ({
   if (renderedMessage) {
     return (
       <div
-        ref={useMessageScrollRef}
+        ref={messageScrollRef}
         className={getClassName([
           'sendbird-msg-hoc sendbird-msg--scroll-ref',
           isAnimated ? 'sendbird-msg-hoc__animated' : '',
@@ -311,7 +311,7 @@ const Message = ({
         isHighlighted ? 'sendbird-msg-hoc__highlighted' : '',
       ])}
       style={{ marginBottom: '2px' }}
-      ref={useMessageScrollRef}
+      ref={messageScrollRef}
     >
       {/* date-separator */}
       {


### PR DESCRIPTION
## External Contributions

Contributed from https://github.com/sendbird/sendbird-uikit-react/pull/470 AND Thanks @angelhcp 

The origin description
```
I'm proposing a variable renaming.

The current variable name is: `useMessageScrollRef`. This is not ideal, because React treats it as a custom hook. Since it is not a custom hook, it doesn't follow the [rules of hooks](https://legacy.reactjs.org/docs/hooks-rules.html), and so it produces a bunch of error messages in the console, making it so hard to debug.

![image](https://user-images.githubusercontent.com/81598119/229584747-b57ae63a-fbbc-4f33-b872-c28ca17d9901.png)
```

### Description Of Changes

Issue:
* The variable name `useMessageScrollRef` is not ideal, because it's not a custom hook but follows its naming rule. So it produces a bunch of error messages in the console, making it hard to debug.

Fix:
* Rename `useMessageScrollRef` to `messageScrollRef` in the Message of Channel component

