### PR TITLE
feat: improve structure of message UI for copying

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,6 +7,8 @@
 
     const modalRoot = document.createElement('div');
     modalRoot.setAttribute('id', 'sendbird-modal-root');
+    modalRoot.style.position = 'fixed';
+    modalRoot.style.zIndex = '99999999999';
     body.appendChild(modalRoot);
   });
 </script>

--- a/exports.js
+++ b/exports.js
@@ -102,6 +102,9 @@ export default {
   'MessageSearch/context': 'src/smart-components/MessageSearch/context/MessageSearchProvider.tsx',
   'MessageSearch/components/MessageSearchUI': 'src/smart-components/MessageSearch/components/MessageSearchUI/index.tsx',
 
+  // Message
+  'Message/context': 'src/smart-components/Message/context/index.tsx',
+
   // Thread
   Thread: 'src/smart-components/Thread/index.tsx',
   'Thread/context': 'src/smart-components/Thread/context/ThreadProvider.tsx',

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -939,6 +939,16 @@ declare module "SendbirdUIKitGlobal" {
   }
 
   /**
+   * Message
+   */
+  export interface MessageProviderProps {
+    message: BaseMessage;
+    isByMe?: boolean;
+    children?: React.ReactElement;
+  }
+  export type MessageProviderInterface = Exclude<MessageProviderProps, 'children'>;
+
+  /**
    * Thread
    */
   export enum ChannelStateTypes {
@@ -1556,6 +1566,15 @@ declare module '@sendbird/uikit-react/MessageSearch/components/MessageSearchUI' 
   import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
   const MessageSearchUI: React.FC<SendbirdUIKitGlobal.MessageSearchUIProps>;
   export default MessageSearchUI;
+}
+
+/**
+ * Message
+ */
+declare module '@sendbird/uikit-react/Message/context' {
+  import SendbirdUIKitGlobal from 'SendbirdUIKitGlobal';
+  export const useMessageContext: () => SendbirdUIKitGlobal.MessageProviderInterface;
+  export const MessageProvider: React.FC<SendbirdUIKitGlobal.MessageProviderProps>;
 }
 
 /**

--- a/src/lib/hooks/__tests__/schedulerFactory.spec.ts
+++ b/src/lib/hooks/__tests__/schedulerFactory.spec.ts
@@ -6,7 +6,7 @@ import { LoggerFactory } from '../../Logger';
 jest.useFakeTimers();
 jest.spyOn(global, 'setInterval');
 
-const logger = LoggerFactory('all');
+const logger = LoggerFactory('info');
 
 describe('schedulerFactory', () => {
   it('should return a scheduler with push and clear methods', () => {

--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -109,9 +109,6 @@ const Message = ({
     || isDisabledBecauseMuted(currentGroupChannel)
     || !isOnline;
 
-  // @ts-ignore
-  const senderId = message?.sender?.userId;
-
   useEffect(() => {
     if (mentionedUsers?.length >= maxUserMentionCount) {
       setAbleMention(false);

--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -25,7 +25,6 @@ import RemoveMessageModal from '../RemoveMessageModal';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 import { EveryMessage, RenderCustomSeparatorProps, RenderMessageProps } from '../../../../types';
 import { useLocalization } from '../../../../lib/LocalizationContext';
-import { MessageProvider } from '../../../Message/context/MessageProvider';
 
 type MessageUIProps = {
   message: EveryMessage;

--- a/src/smart-components/Channel/components/Message/index.tsx
+++ b/src/smart-components/Channel/components/Message/index.tsx
@@ -25,6 +25,7 @@ import RemoveMessageModal from '../RemoveMessageModal';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 import { EveryMessage, RenderCustomSeparatorProps, RenderMessageProps } from '../../../../types';
 import { useLocalization } from '../../../../lib/LocalizationContext';
+import { MessageProvider } from '../../../Message/context/MessageProvider';
 
 type MessageUIProps = {
   message: EveryMessage;
@@ -108,6 +109,9 @@ const Message = ({
     || isDisabledBecauseFrozen(currentGroupChannel)
     || isDisabledBecauseMuted(currentGroupChannel)
     || !isOnline;
+
+  // @ts-ignore
+  const senderId = message?.sender?.userId;
 
   useEffect(() => {
     if (mentionedUsers?.length >= maxUserMentionCount) {

--- a/src/smart-components/Channel/components/MessageList/index.tsx
+++ b/src/smart-components/Channel/components/MessageList/index.tsx
@@ -14,6 +14,8 @@ import FrozenNotification from '../FrozenNotification';
 import { SCROLL_BUFFER } from '../../../../utils/consts';
 import { EveryMessage } from '../../../..';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
+import { UserMessage } from '@sendbird/chat/message';
+import { MessageProvider } from '../../../Message/context/MessageProvider';
 
 export interface MessageListProps {
   className?: string;
@@ -51,6 +53,7 @@ const MessageList: React.FC<MessageListProps> = ({
     loading,
     unreadSince,
   } = useChannelContext();
+  const store = useSendbirdStateContext();
   const [scrollBottom, setScrollBottom] = useState(0);
   const allMessagesFiltered = (typeof filterMessageList === 'function')
     ? allMessages.filter((filterMessageList as (message: EveryMessage) => boolean))
@@ -165,17 +168,19 @@ const MessageList: React.FC<MessageListProps> = ({
               currentMessage: m,
               currentChannel: currentGroupChannel,
             });
+            const isByMe = (m as UserMessage)?.sender?.userId === store?.config?.userId;
             return (
-              <Message
-                key={m?.messageId}
-                handleScroll={handleScroll}
-                renderMessage={renderMessage}
-                message={m}
-                hasSeparator={hasSeparator}
-                chainTop={chainTop}
-                chainBottom={chainBottom}
-                renderCustomSeparator={renderCustomSeparator}
-              />
+              <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
+                <Message
+                  handleScroll={handleScroll}
+                  renderMessage={renderMessage}
+                  message={m}
+                  hasSeparator={hasSeparator}
+                  chainTop={chainTop}
+                  chainBottom={chainBottom}
+                  renderCustomSeparator={renderCustomSeparator}
+                />
+              </MessageProvider>
             );
           })}
           {/* show frozen notifications */}

--- a/src/smart-components/Channel/components/MessageList/index.tsx
+++ b/src/smart-components/Channel/components/MessageList/index.tsx
@@ -58,7 +58,6 @@ const MessageList: React.FC<MessageListProps> = ({
   const allMessagesFiltered = (typeof filterMessageList === 'function')
     ? allMessages.filter((filterMessageList as (message: EveryMessage) => boolean))
     : allMessages;
-  const store = useSendbirdStateContext();
   const markAsReadScheduler = store.config.markAsReadScheduler;
 
   const onScroll = (e) => {

--- a/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/smart-components/ChannelList/components/ChannelListUI/index.tsx
@@ -1,6 +1,6 @@
 import './channel-list-ui.scss';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { GroupChannel, Member, SendbirdGroupChat } from '@sendbird/chat/groupChannel';
 import type { User } from '@sendbird/chat';
 

--- a/src/smart-components/Message/README.md
+++ b/src/smart-components/Message/README.md
@@ -1,0 +1,23 @@
+# Message Module
+
+When we first started UIKit, messages were a simple component that was used to display a file/text message.
+As we started to build more complex applications, we realized that we needed a more robust way to display messages.
+The Message module was created to address this need.
+
+We plan to deprecate other message components in the future(UIKit@v4) and replace them with the Message module.
+
+For now, we will keep the old message components and the new Message module in parallel. And try to add new components to the Message module.
+
+Message
+  -> UserMessage
+    -> NotificationMessage / TemplateMessage
+  -> FileMessage
+    -> ThumbnailMessage(image/video)
+    -> VoiceMessage
+    -> FileMessage(others)
+  -> AdminMessage
+
+A UserMessage can have 3 components.
+-> Simple Text
+-> Mention
+-> OGMessage

--- a/src/smart-components/Message/components/TextFragment/index.tsx
+++ b/src/smart-components/Message/components/TextFragment/index.tsx
@@ -13,7 +13,9 @@ export type TextFragmentProps = {
   tokens: Token[];
 }
 
-export default function TextFragment({ tokens }: TextFragmentProps) {
+export default function TextFragment({
+  tokens,
+}: TextFragmentProps): React.ReactElement {
   const messageStore = useMessageContext();
 
   const message = messageStore?.message as UserMessage;

--- a/src/smart-components/Message/components/TextFragment/index.tsx
+++ b/src/smart-components/Message/components/TextFragment/index.tsx
@@ -27,9 +27,8 @@ export default function TextFragment({ tokens }: TextFragmentProps) {
           switch (token.type) {
             case TOKEN_TYPES.mention:
               return (
-                <span className="sendbird-word">
+                <span className="sendbird-word" key={key}>
                   <MentionLabel
-                    key={key}
                     mentionTemplate={USER_MENTION_PREFIX}
                     mentionedUserId={token.userId}
                     mentionedUserNickname={token.value}
@@ -39,9 +38,8 @@ export default function TextFragment({ tokens }: TextFragmentProps) {
               );
             case TOKEN_TYPES.url:
               return (
-                <span className='sendbird-word'>
+                <span className='sendbird-word' key={key}>
                   <LinkLabel
-                    key={key}
                     className="sendbird-word__url"
                     src={token.value}
                     type={LabelTypography.BODY_1}

--- a/src/smart-components/Message/components/TextFragment/index.tsx
+++ b/src/smart-components/Message/components/TextFragment/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { UserMessage } from '@sendbird/chat/message';
+
+import { TOKEN_TYPES, Token } from '../../utils/tokens/types'
+import { useMessageContext } from '../../context/MessageProvider';
+import { keyGenerator } from '../../utils/tokens/keyGenerator';
+import MentionLabel from '../../../../ui/MentionLabel';
+import { USER_MENTION_PREFIX } from '../../consts';
+import LinkLabel from '../../../../ui/LinkLabel';
+import { LabelTypography } from '../../../../ui//Label';
+
+export type TextFragmentProps = {
+  tokens: Token[];
+}
+
+export default function TextFragment({ tokens }: TextFragmentProps) {
+  const messageStore = useMessageContext();
+
+  const message = messageStore?.message as UserMessage;
+  const isByMe = messageStore?.isByMe;
+  const { updatedAt, createdAt } = message;
+  return (
+    <>
+      {
+        tokens.map((token, idx) => {
+          const key = keyGenerator(createdAt, updatedAt, idx);
+          switch (token.type) {
+            case TOKEN_TYPES.mention:
+              return (
+                <span className='sendbird-word'>
+                  <MentionLabel
+                    key={key}
+                    mentionTemplate={USER_MENTION_PREFIX}
+                    mentionedUserId={token.userId}
+                    mentionedUserNickname={token.value}
+                    isByMe={isByMe}
+                  />
+                </span>
+              );
+            case TOKEN_TYPES.url:
+              return (
+                <span className='sendbird-word'>
+                  <LinkLabel
+                    key={key}
+                    className="sendbird-word__url"
+                    src={token.value}
+                    type={LabelTypography.BODY_1}
+                  >
+                    {token.value}
+                  </LinkLabel>
+                </span>
+              );
+            case TOKEN_TYPES.string:
+            default:
+              return (
+                <React.Fragment key={key}>{token.value}</React.Fragment>
+              );
+          }
+        })
+      }
+    </>
+  );
+}

--- a/src/smart-components/Message/components/TextFragment/index.tsx
+++ b/src/smart-components/Message/components/TextFragment/index.tsx
@@ -27,7 +27,7 @@ export default function TextFragment({ tokens }: TextFragmentProps) {
           switch (token.type) {
             case TOKEN_TYPES.mention:
               return (
-                <span className='sendbird-word'>
+                <span className="sendbird-word">
                   <MentionLabel
                     key={key}
                     mentionTemplate={USER_MENTION_PREFIX}

--- a/src/smart-components/Message/components/TextFragment/index.tsx
+++ b/src/smart-components/Message/components/TextFragment/index.tsx
@@ -24,7 +24,7 @@ export default function TextFragment({
   return (
     <>
       {
-        tokens.map((token, idx) => {
+        tokens?.map((token, idx) => {
           const key = keyGenerator(createdAt, updatedAt, idx);
           switch (token.type) {
             case TOKEN_TYPES.mention:

--- a/src/smart-components/Message/consts.ts
+++ b/src/smart-components/Message/consts.ts
@@ -1,0 +1,1 @@
+export const USER_MENTION_PREFIX = "@";

--- a/src/smart-components/Message/context/MessageProvider.tsx
+++ b/src/smart-components/Message/context/MessageProvider.tsx
@@ -1,0 +1,45 @@
+// todo@v4.0.0: combine with the provider in core-ts, see:
+// https://github.com/sendbird/sendbird-uikit-core-ts
+// packages/react-uikit-message-template-view/src/context/MessageContextProvider.tsx
+import React from 'react';
+import { BaseMessage } from '@sendbird/chat/message';
+
+export type MessageProviderProps = {
+  children: React.ReactNode;
+  message: BaseMessage;
+  isByMe?: boolean;
+}
+
+export type MessageProviderInterface = Exclude<MessageProviderProps, 'children'>;
+
+const MessageContext = React.createContext(undefined);
+
+const MessageProvider: React.FC<MessageProviderInterface> = (props: MessageProviderProps) => {
+  const {
+    children,
+    message,
+    isByMe = false,
+  } = props;
+
+  return (
+    <MessageContext.Provider value={{
+      message,
+      isByMe,
+    }}>
+      {children}
+    </MessageContext.Provider>
+  );
+}
+
+const useMessageContext = (): MessageProviderInterface => {
+  const value = React.useContext(MessageContext);
+  if (value === undefined) {
+    throw new Error('useMessageContext must be used within a MessageProvider');
+  }
+  return value;
+};
+
+export {
+  MessageProvider,
+  useMessageContext,
+};

--- a/src/smart-components/Message/utils/tokens/__tests__/tokenizeMessage.spec.ts
+++ b/src/smart-components/Message/utils/tokens/__tests__/tokenizeMessage.spec.ts
@@ -1,0 +1,58 @@
+import { User } from '@sendbird/chat';
+import { tokenizeMessage } from '../tokenize';
+
+describe('tokenizeMessage', () => {
+  it('should tokenize a simple string', () => {
+    const tokens = tokenizeMessage({
+      messageText: 'Hello world',
+    });
+    expect(tokens).toEqual([
+      { type: 'string', value: 'Hello world' },
+    ]);
+  });
+
+  it('should tokenize a string with a url', () => {
+    const tokens = tokenizeMessage({
+      messageText: 'Hello world https://example.com',
+    });
+    expect(tokens).toEqual([
+      { type: 'string', value: 'Hello world' },
+      { type: 'url', value: 'https://example.com' },
+    ]);
+  });
+
+  it('should tokenize a string with a url and a string', () => {
+    const tokens = tokenizeMessage({
+      messageText: 'Hello world https://example.com and more',
+    });
+    expect(tokens).toEqual([
+      { type: 'string', value: 'Hello world' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'string', value: 'and more' },
+    ]);
+  });
+
+  it('should tokenize a string with mention and a string', () => {
+    const tokens = tokenizeMessage({
+      messageText: 'Hello world @{userA} and more https://example.com',
+      mentionedUsers: [
+        ({ userId: 'userA', nickname: 'User A' } as User),
+      ],
+    });
+
+    expect(tokens).toEqual([{
+      value: 'Hello world ',
+      type: 'string',
+    }, {
+      value: 'User A',
+      type: 'mention',
+      userId: 'userA',
+    }, {
+      value: ' and more',
+      type: 'string',
+    }, {
+      value: 'https://example.com',
+      type: 'url',
+    }]);
+  });
+});

--- a/src/smart-components/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
+++ b/src/smart-components/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
@@ -1,0 +1,103 @@
+import { User } from '@sendbird/chat';
+import {
+  getUserMentionRegex,
+  identifyMentions,
+  identifyUrlsAndStrings,
+  combineNearbyStrings,
+} from '../tokenize';
+import { Token, UndeterminedToken } from '../types';
+
+describe('getUserMentionRegex', () => {
+  it('should return a regex with the correct pattern', () => {
+    const mentionedUsers = [
+      { userId: '1', nickname: 'user1' },
+      { userId: '2', nickname: 'user2' },
+    ] as User[];
+    const templatePrefix = '@';
+    const result = getUserMentionRegex(mentionedUsers, templatePrefix);
+    expect(result).toEqual(/(@{1}|@{2})/g);
+  });
+});
+
+describe('identifyMentions', () => {
+  it('should return a token with type mention', () => {
+    const tokens = [{
+      type: 'undetermined',
+      value: 'abc @{userA} 123',
+    }] as UndeterminedToken[];
+    const mentionedUsers = [
+      { userId: 'userA', nickname: 'User A' },
+    ] as User[];
+    const templatePrefix = '@';
+    const result = identifyMentions({ tokens, mentionedUsers, templatePrefix });
+    expect(result).toEqual([{
+      type: 'undetermined',
+      value: 'abc ',
+    }, {
+      type: 'mention',
+      value: 'User A',
+      userId: 'userA',
+    }, {
+      type: 'undetermined',
+      value: ' 123',
+    }]);
+  });
+});
+
+describe('identifyUrlsAndStrings', () => {
+  it('should return a token with type url', () => {
+    const tokens = [{
+      type: 'undetermined',
+      value: 'abc https://www.google.com 123',
+    }] as UndeterminedToken[];
+    const result = identifyUrlsAndStrings(tokens);
+    expect(result).toEqual([{
+      type: 'string',
+      value: 'abc',
+    }, {
+      type: 'url',
+      value: 'https://www.google.com',
+    }, {
+      type: 'string',
+      value: '123',
+    }]);
+  });
+});
+
+describe('combineNearbyStrings', () => {
+  it('should combine nearby strings', () => {
+    const tokens = [{
+      type: 'string',
+      value: 'abc ',
+    }, {
+      type: 'string',
+      value: ' pqr',
+    }, {
+      type: 'url',
+      value: 'https://www.google.com',
+    }, {
+      type: 'mention',
+      value: 'User A',
+      userId: 'userA',
+    }, {
+      type: 'string',
+      value: '123',
+    }] as Token[];
+    const expected = [{
+      type: 'string',
+      value: 'abc   pqr',
+    }, {
+      type: 'url',
+      value: 'https://www.google.com',
+    }, {
+      type: 'mention',
+      value: 'User A',
+      userId: 'userA',
+    }, {
+      type: 'string',
+      value: '123',
+    }];
+    const result = combineNearbyStrings(tokens);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/smart-components/Message/utils/tokens/keyGenerator.ts
+++ b/src/smart-components/Message/utils/tokens/keyGenerator.ts
@@ -1,0 +1,7 @@
+export function keyGenerator(
+  createdAt: number,
+  messageUpdatedAt: number,
+  index: number,
+) {
+  return `sb-msg_${createdAt}_${messageUpdatedAt}_${index}`;
+}

--- a/src/smart-components/Message/utils/tokens/keyGenerator.ts
+++ b/src/smart-components/Message/utils/tokens/keyGenerator.ts
@@ -1,7 +1,10 @@
+// this function is used to generate a unique key for token in message
+// it changes with updated time and index
+// messageUpdatedAt is the key part of this key generator
 export function keyGenerator(
   createdAt: number,
   messageUpdatedAt: number,
   index: number,
-) {
+): string {
   return `sb-msg_${createdAt}_${messageUpdatedAt}_${index}`;
 }

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -43,7 +43,7 @@ export function identifyUrlsAndStrings(token: Token[]): Token[] {
     if (token.type !== TOKEN_TYPES.undetermined) {
       return token;
     }
-    const { value } = token;
+    const { value = "" } = token;
     const parts = value.split(' ');
     const tokens = parts.map((part) => {
       if (isUrl(part)) {

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -1,0 +1,106 @@
+import { User } from "@sendbird/chat";
+import { USER_MENTION_PREFIX } from "../../consts";
+import { Token, TOKEN_TYPES, TokenParams } from "./types";
+import { isUrl } from "../../../../utils";
+
+export function getUserMentionRegex(mentionedUsers: User[], templatePrefix: string): RegExp {
+  // return RegExp(`${templatePrefix}{(${mentionedUsers.map((user) => user?.userId).join('|')})}`, 'g');
+  return RegExp(`(${mentionedUsers.map(u => `@{${u.userId}}`).join('|')})`, 'g');
+}
+
+export function identifyMentions({
+  tokens,
+  mentionedUsers = [],
+  templatePrefix = USER_MENTION_PREFIX,
+}): Token[] {
+  if (!mentionedUsers?.length) {
+    return tokens;
+  }
+  const userMentionRegex = getUserMentionRegex(mentionedUsers, templatePrefix);
+  const results: Token[] = tokens.map((token) => {
+    // if the token is not undetermined, return it as is
+    if (token.type !== TOKEN_TYPES.undetermined) {
+      return token;
+    }
+    const { value } = token;
+    const parts = value.split(userMentionRegex);
+    const tokens = parts.map((part) => {
+      if (part.match(userMentionRegex)) {
+        const matchedUser = mentionedUsers.find((user) => `@{${user?.userId}}` === part);
+        const nickname = matchedUser?.nickname || '(No name)'
+        return { value: nickname, type: TOKEN_TYPES.mention, userId: matchedUser?.userId };
+      } else {
+        return { value: part, type: TOKEN_TYPES.undetermined };
+      }
+    });
+    return tokens;
+  }).flat();
+  return results;
+}
+
+export function identifyUrlsAndStrings(token: Token[]): Token[] {
+  const results: Token[] = token.map((token) => {
+    if (token.type !== TOKEN_TYPES.undetermined) {
+      return token;
+    }
+    const { value } = token;
+    const parts = value.split(' ');
+    const tokens = parts.map((part) => {
+      if (isUrl(part)) {
+        return { value: part, type: TOKEN_TYPES.url };
+      } else {
+        return { value: part, type: TOKEN_TYPES.string };
+      }
+    });
+    return tokens;
+  }).flat();
+
+  return results;
+}
+
+export function combineNearbyStrings(tokens: Token[]): Token[] {
+  const results: Token[] = tokens.reduce((acc, token) => {
+    const lastToken = acc[acc.length - 1];
+    if (lastToken?.type === TOKEN_TYPES.string && token.type === TOKEN_TYPES.string) {
+      lastToken.value = `${lastToken.value} ${token.value}`;
+      return acc;
+    }
+    return [...acc, token];
+  }, []);
+  return results;
+}
+
+/**
+ * Converts text into set of rich tokens
+ */
+export function tokenizeMessage({
+  messageText,
+  mentionedUsers = [],
+  templatePrefix = USER_MENTION_PREFIX,
+}: TokenParams): Token[] {
+  // mention can be merged with other mentions and urls
+  // urls cannot be merged with other urls or normal text
+  // if no users are mentioned, return the messageText as a single token
+
+  // const tokenize = pipe(
+  //   identifyMentions,
+  //   identifyUrlsAndStrings,
+  //   combineNearbyStrings,
+  // );
+  // const result = tokenize(messageText);
+  const partialResult = [{
+    type: TOKEN_TYPES.undetermined,
+    value: messageText,
+  }];
+
+  const partialWithMentions = identifyMentions({
+    tokens: partialResult,
+    mentionedUsers,
+    templatePrefix,
+  });
+  const partialsWithUrlsAndMentions = identifyUrlsAndStrings(partialWithMentions);
+  const result = combineNearbyStrings(partialsWithUrlsAndMentions);
+
+  return result;
+}
+

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -1,6 +1,6 @@
 import { User } from "@sendbird/chat";
 import { USER_MENTION_PREFIX } from "../../consts";
-import { IdentifyMentionsType, Token, TOKEN_TYPES, TokenParams } from "./types";
+import { IdentifyMentionsType, MentionToken, Token, TOKEN_TYPES, TokenParams, UndeterminedToken } from "./types";
 import { isUrl } from "../../../../utils";
 
 export function getUserMentionRegex(mentionedUsers: User[], templatePrefix_: string): RegExp {
@@ -12,13 +12,14 @@ export function identifyMentions({
   tokens,
   mentionedUsers = [],
   templatePrefix = USER_MENTION_PREFIX,
-}: IdentifyMentionsType): Token[] {
+}: IdentifyMentionsType): (MentionToken|UndeterminedToken)[] {
   if (!mentionedUsers?.length) {
     return tokens;
   }
   const userMentionRegex = getUserMentionRegex(mentionedUsers, templatePrefix);
-  const results: Token[] = tokens.map((token) => {
+  const results: (UndeterminedToken | MentionToken)[] = tokens.map((token) => {
     // if the token is not undetermined, return it as is
+    // is kinda unnecessary with TS, but just in case
     if (token.type !== TOKEN_TYPES.undetermined) {
       return token;
     }
@@ -85,6 +86,8 @@ export function tokenizeMessage({
     value: messageText,
   }];
 
+  // order is important because we want to identify mentions first
+  // identifyMentions will return a token with type mention or undetermined
   const partialWithMentions = identifyMentions({
     tokens: partialResult,
     mentionedUsers,

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -27,7 +27,7 @@ export function identifyMentions({
     const tokens = parts.map((part) => {
       if (part.match(userMentionRegex)) {
         const matchedUser = mentionedUsers.find((user) => `@{${user?.userId}}` === part);
-        const nickname = matchedUser?.nickname || '(No name)'
+        const nickname = matchedUser?.nickname || '(No name)';
         return { value: nickname, type: TOKEN_TYPES.mention, userId: matchedUser?.userId };
       } else {
         return { value: part, type: TOKEN_TYPES.undetermined };
@@ -80,13 +80,6 @@ export function tokenizeMessage({
 }: TokenParams): Token[] {
   // mention can be squeezed-in(no-space-between) with other mentions and urls
   // if no users are mentioned, return the messageText as a single token
-
-  // const tokenize = pipe(
-  //   identifyMentions,
-  //   identifyUrlsAndStrings,
-  //   combineNearbyStrings,
-  // );
-  // const result = tokenize(messageText);
   const partialResult = [{
     type: TOKEN_TYPES.undetermined,
     value: messageText,

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -1,18 +1,18 @@
 import { User } from "@sendbird/chat";
 import { USER_MENTION_PREFIX } from "../../consts";
-import { Token, TOKEN_TYPES, TokenParams } from "./types";
+import { IdentifyMentionsType, Token, TOKEN_TYPES, TokenParams } from "./types";
 import { isUrl } from "../../../../utils";
 
-export function getUserMentionRegex(mentionedUsers: User[], templatePrefix: string): RegExp {
-  // return RegExp(`${templatePrefix}{(${mentionedUsers.map((user) => user?.userId).join('|')})}`, 'g');
-  return RegExp(`(${mentionedUsers.map(u => `@{${u.userId}}`).join('|')})`, 'g');
+export function getUserMentionRegex(mentionedUsers: User[], templatePrefix_: string): RegExp {
+  const templatePrefix = templatePrefix_ || USER_MENTION_PREFIX;
+  return RegExp(`(${mentionedUsers.map(u => `${templatePrefix}{${u.userId}}`).join('|')})`, 'g');
 }
 
 export function identifyMentions({
   tokens,
   mentionedUsers = [],
   templatePrefix = USER_MENTION_PREFIX,
-}): Token[] {
+}: IdentifyMentionsType): Token[] {
   if (!mentionedUsers?.length) {
     return tokens;
   }
@@ -78,8 +78,7 @@ export function tokenizeMessage({
   mentionedUsers = [],
   templatePrefix = USER_MENTION_PREFIX,
 }: TokenParams): Token[] {
-  // mention can be merged with other mentions and urls
-  // urls cannot be merged with other urls or normal text
+  // mention can be squeezed-in(no-space-between) with other mentions and urls
   // if no users are mentioned, return the messageText as a single token
 
   // const tokenize = pipe(

--- a/src/smart-components/Message/utils/tokens/types.ts
+++ b/src/smart-components/Message/utils/tokens/types.ts
@@ -1,0 +1,41 @@
+import { User } from "@sendbird/chat";
+import { ObjectValues } from "../../../../utils/typeHelpers/objectValues";
+
+export const TOKEN_TYPES = {
+  string: 'string',
+  mention: 'mention',
+  url: 'url',
+  undetermined: 'undetermined',
+} as const;
+
+export type TokenType = ObjectValues<typeof TOKEN_TYPES>;
+
+
+export type StringToken = {
+  type: typeof TOKEN_TYPES.string,
+  value: string,
+};
+
+export type MentionToken = {
+  type: typeof TOKEN_TYPES.mention,
+  value: string,
+  userId: string,
+};
+
+export type UrlToken = {
+  type: typeof TOKEN_TYPES.url,
+  value: string,
+};
+
+export type UndeterminedToken = {
+  type: typeof TOKEN_TYPES.undetermined,
+  value: string,
+};
+
+export type Token = StringToken | MentionToken | UrlToken | UndeterminedToken;
+
+export type TokenParams = {
+  messageText: string,
+  mentionedUsers?: User[],
+  templatePrefix?: string,
+};

--- a/src/smart-components/Message/utils/tokens/types.ts
+++ b/src/smart-components/Message/utils/tokens/types.ts
@@ -40,7 +40,7 @@ export type TokenParams = {
 };
 
 export type IdentifyMentionsType = {
-  tokens: Token[];
+  tokens: (UndeterminedToken)[];
   mentionedUsers: User[];
   templatePrefix: string;
 };

--- a/src/smart-components/Message/utils/tokens/types.ts
+++ b/src/smart-components/Message/utils/tokens/types.ts
@@ -10,32 +10,37 @@ export const TOKEN_TYPES = {
 
 export type TokenType = ObjectValues<typeof TOKEN_TYPES>;
 
-
 export type StringToken = {
-  type: typeof TOKEN_TYPES.string,
-  value: string,
+  type: typeof TOKEN_TYPES.string;
+  value: string;
 };
 
 export type MentionToken = {
-  type: typeof TOKEN_TYPES.mention,
-  value: string,
-  userId: string,
+  type: typeof TOKEN_TYPES.mention;
+  value: string;
+  userId: string;
 };
 
 export type UrlToken = {
-  type: typeof TOKEN_TYPES.url,
-  value: string,
+  type: typeof TOKEN_TYPES.url;
+  value: string;
 };
 
 export type UndeterminedToken = {
-  type: typeof TOKEN_TYPES.undetermined,
-  value: string,
+  type: typeof TOKEN_TYPES.undetermined;
+  value: string;
 };
 
 export type Token = StringToken | MentionToken | UrlToken | UndeterminedToken;
 
 export type TokenParams = {
-  messageText: string,
-  mentionedUsers?: User[],
-  templatePrefix?: string,
+  messageText: string;
+  mentionedUsers?: User[];
+  templatePrefix?: string;
+};
+
+export type IdentifyMentionsType = {
+  tokens: Token[];
+  mentionedUsers: User[];
+  templatePrefix: string;
 };

--- a/src/smart-components/Message/utils/tokens/types.ts
+++ b/src/smart-components/Message/utils/tokens/types.ts
@@ -40,7 +40,7 @@ export type TokenParams = {
 };
 
 export type IdentifyMentionsType = {
-  tokens: (UndeterminedToken)[];
+  tokens: UndeterminedToken[];
   mentionedUsers: User[];
   templatePrefix: string;
 };

--- a/src/smart-components/OpenChannel/components/OpenChannelMessageList/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelMessageList/index.tsx
@@ -12,6 +12,8 @@ import { useOpenChannelContext } from '../../context/OpenChannelProvider';
 import OpenChannelMessage from '../OpenChannelMessage';
 import { RenderMessageProps } from '../../../../types';
 import { useHandleOnScrollCallback } from './useHandleOnScrollCallback';
+import { MessageProvider } from '../../../Message/context/MessageProvider';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export type OpenchannelMessageListProps = {
   renderMessage?: (props: RenderMessageProps) => React.ElementType<RenderMessageProps>;
@@ -28,6 +30,8 @@ function OpenchannelMessageList(
     hasMore,
     onScroll,
   } = useOpenChannelContext();
+  const store = useSendbirdStateContext();
+  const userId = store.config.userId;
   const scrollRef = ref || useRef(null);
   const [showScrollDownButton, setShowScrollDownButton] = useState(false);
 
@@ -62,15 +66,18 @@ function OpenchannelMessageList(
           const [chainTop, chainBottom] = isMessageGroupingEnabled
             ? compareMessagesForGrouping(previousMessage, message, nextMessage)
             : [false, false];
+          const isByMe = (message as UserMessage)?.sender?.userId === userId;
           return (
-            <OpenChannelMessage
-              key={message?.messageId || (message as UserMessage | FileMessage)?.reqId}
-              message={message}
-              chainTop={chainTop}
-              chainBottom={chainBottom}
-              hasSeparator={hasSeparator}
-              renderMessage={props?.renderMessage}
-            />
+            <MessageProvider message={message} isByMe={isByMe}>
+              <OpenChannelMessage
+                key={message?.messageId || (message as UserMessage | FileMessage)?.reqId}
+                message={message}
+                chainTop={chainTop}
+                chainBottom={chainBottom}
+                hasSeparator={hasSeparator}
+                renderMessage={props?.renderMessage}
+              />
+            </MessageProvider>
           )
         })
       );

--- a/src/smart-components/OpenChannel/components/OpenChannelMessageList/index.tsx
+++ b/src/smart-components/OpenChannel/components/OpenChannelMessageList/index.tsx
@@ -67,10 +67,10 @@ function OpenchannelMessageList(
             ? compareMessagesForGrouping(previousMessage, message, nextMessage)
             : [false, false];
           const isByMe = (message as UserMessage)?.sender?.userId === userId;
+          const key = message?.messageId || (message as UserMessage)?.reqId;
           return (
-            <MessageProvider message={message} isByMe={isByMe}>
+            <MessageProvider message={message} isByMe={isByMe} key={key}>
               <OpenChannelMessage
-                key={message?.messageId || (message as UserMessage | FileMessage)?.reqId}
                 message={message}
                 chainTop={chainTop}
                 chainBottom={chainBottom}

--- a/src/smart-components/Thread/components/ThreadList/index.tsx
+++ b/src/smart-components/Thread/components/ThreadList/index.tsx
@@ -58,8 +58,7 @@ export default function ThreadList({
   return (
     <div className={`sendbird-thread-list ${className}`}>
       {allThreadMessages.map((message, idx) => {
-        // @ts-ignore
-        const isByMe = message?.sender?.userId === userId;
+        const isByMe = (message as UserMessage)?.sender?.userId === userId;
         const prevMessage = allThreadMessages[idx - 1];
         const nextMessage = allThreadMessages[idx + 1];
         const [chainTop, chainBottom] = true// isMessageGroupingEnabled

--- a/src/smart-components/Thread/components/ThreadList/index.tsx
+++ b/src/smart-components/Thread/components/ThreadList/index.tsx
@@ -7,6 +7,7 @@ import { useThreadContext } from '../../context/ThreadProvider';
 import { compareMessagesForGrouping } from '../../context/utils';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { isSameDay } from 'date-fns';
+import { MessageProvider } from '../../../Message/context/MessageProvider';
 
 export interface ThreadListProps {
   className?: string;
@@ -31,7 +32,7 @@ export default function ThreadList({
   scrollBottom,
 }: ThreadListProps): React.ReactElement {
   const { config } = useSendbirdStateContext();
-  const { replyType } = config;
+  const { replyType, userId } = config;
   const {
     currentChannel,
   } = useThreadContext();
@@ -57,6 +58,8 @@ export default function ThreadList({
   return (
     <div className={`sendbird-thread-list ${className}`}>
       {allThreadMessages.map((message, idx) => {
+        // @ts-ignore
+        const isByMe = message?.sender?.userId === userId;
         const prevMessage = allThreadMessages[idx - 1];
         const nextMessage = allThreadMessages[idx + 1];
         const [chainTop, chainBottom] = true// isMessageGroupingEnabled
@@ -88,14 +91,16 @@ export default function ThreadList({
           chainBottom,
           hasSeparator,
         }) || (
-            <ThreadListItem
-              message={message as UserMessage | FileMessage}
-              chainTop={chainTop}
-              chainBottom={chainBottom}
-              hasSeparator={hasSeparator}
-              renderCustomSeparator={renderCustomSeparator}
-              handleScroll={handleScroll}
-            />
+            <MessageProvider message={message} isByMe={isByMe}>
+              <ThreadListItem
+                message={message as UserMessage | FileMessage}
+                chainTop={chainTop}
+                chainBottom={chainBottom}
+                hasSeparator={hasSeparator}
+                renderCustomSeparator={renderCustomSeparator}
+                handleScroll={handleScroll}
+              />
+            </MessageProvider>
           );
       })}
     </div>

--- a/src/smart-components/Thread/components/ThreadList/index.tsx
+++ b/src/smart-components/Thread/components/ThreadList/index.tsx
@@ -91,7 +91,7 @@ export default function ThreadList({
           chainBottom,
           hasSeparator,
         }) || (
-            <MessageProvider message={message} isByMe={isByMe}>
+            <MessageProvider message={message} isByMe={isByMe} key={message?.messageId}>
               <ThreadListItem
                 message={message as UserMessage | FileMessage}
                 chainTop={chainTop}

--- a/src/smart-components/Thread/components/ThreadList/index.tsx
+++ b/src/smart-components/Thread/components/ThreadList/index.tsx
@@ -84,23 +84,27 @@ export default function ThreadList({
           }
         };
 
-        return MemorizedMessage({
-          message,
-          chainTop,
-          chainBottom,
-          hasSeparator,
-        }) || (
-            <MessageProvider message={message} isByMe={isByMe} key={message?.messageId}>
-              <ThreadListItem
-                message={message as UserMessage | FileMessage}
-                chainTop={chainTop}
-                chainBottom={chainBottom}
-                hasSeparator={hasSeparator}
-                renderCustomSeparator={renderCustomSeparator}
-                handleScroll={handleScroll}
-              />
-            </MessageProvider>
-          );
+        return(
+          <MessageProvider message={message} isByMe={isByMe} key={message?.messageId}>
+            {
+              MemorizedMessage({
+                message,
+                chainTop,
+                chainBottom,
+                hasSeparator,
+              }) || (
+                <ThreadListItem
+                  message={message as UserMessage | FileMessage}
+                  chainTop={chainTop}
+                  chainBottom={chainBottom}
+                  hasSeparator={hasSeparator}
+                  renderCustomSeparator={renderCustomSeparator}
+                  handleScroll={handleScroll}
+                />
+              )
+            }
+          </MessageProvider>
+        );
       })}
     </div>
   );

--- a/src/smart-components/Thread/components/ThreadUI/index.scss
+++ b/src/smart-components/Thread/components/ThreadUI/index.scss
@@ -36,6 +36,13 @@
   @include themed() {
     border-top: 1px solid t(on-bg-4);
   }
+  .sendbird-word__mention {
+    .sendbird-label {
+      @include themed() {
+        color: t(on-bg-1);
+      }
+    }
+  }
 }
 
 .sendbird-thread-ui__reply-counts {

--- a/src/smart-components/Thread/components/ThreadUI/index.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/index.tsx
@@ -148,15 +148,15 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
         ref={scrollRef}
         onScroll={onScroll}
       >
-        {
-          MemorizedParentMessageInfo || (
-            <MessageProvider message={parentMessage} isByMe={isByMe}>
+        <MessageProvider message={parentMessage} isByMe={isByMe}>
+          {
+            MemorizedParentMessageInfo || (
               <ParentMessageInfo
                 className="sendbird-thread-ui__parent-message-info"
               />
-            </MessageProvider>
-          )
-        }
+            )
+          }
+        </MessageProvider>
         {
           replyCount > 0 && (
             <div className="sendbird-thread-ui__reply-counts">

--- a/src/smart-components/Thread/components/ThreadUI/index.tsx
+++ b/src/smart-components/Thread/components/ThreadUI/index.tsx
@@ -17,6 +17,7 @@ import useMemorizedParentMessageInfo from './useMemorizedParentMessageInfo';
 import useMemorizedThreadList from './useMemorizedThreadList';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import { isAboutSame } from '../../context/utils';
+import { MessageProvider } from '../../../Message/context/MessageProvider';
 
 export interface ThreadUIProps {
   renderHeader?: () => React.ReactElement;
@@ -69,6 +70,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
     onMoveToParentMessage,
   } = useThreadContext();
   const replyCount = allThreadMessages.length;
+  const isByMe = currentUserId === parentMessage?.sender?.userId;
 
   // Memoized custom components
   const MemorizedHeader = useMemorizedHeader({ renderHeader });
@@ -148,9 +150,11 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
       >
         {
           MemorizedParentMessageInfo || (
-            <ParentMessageInfo
-              className="sendbird-thread-ui__parent-message-info"
-            />
+            <MessageProvider message={parentMessage} isByMe={isByMe}>
+              <ParentMessageInfo
+                className="sendbird-thread-ui__parent-message-info"
+              />
+            </MessageProvider>
           )
         }
         {

--- a/src/ui/Label/index.jsx
+++ b/src/ui/Label/index.jsx
@@ -13,6 +13,9 @@ export default function Label({
   children,
 }) {
   return (
+    // Donot make this into div
+    // Mention uses Label. If we use div, it would break the mention detection on Paste
+    // https://github.com/sendbird/sendbird-uikit-react/pull/479
     <span
       className={[
         ...(Array.isArray(className) ? className : [className]),

--- a/src/ui/MentionLabel/index.scss
+++ b/src/ui/MentionLabel/index.scss
@@ -1,6 +1,7 @@
 @import '../../styles/variables';
 
 .sendbird-word {
+  white-space: break-spaces;
   .sendbird-word__mention {
     &:hover {
       cursor: pointer;

--- a/src/ui/MentionLabel/index.tsx
+++ b/src/ui/MentionLabel/index.tsx
@@ -65,6 +65,7 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
           ref={mentionRef}
           data-userid={mentionedUserId}
           data-nickname={mentionedUserNickname}
+          data-sb-mention={true}
         >
           <Label
             type={LabelTypography.CAPTION_1}

--- a/src/ui/MessageContent/__tests__/MessageContent.spec.js
+++ b/src/ui/MessageContent/__tests__/MessageContent.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import MessageContent from "../index";
+import { MessageProvider } from '../../../smart-components/Message/context/MessageProvider';
 jest.mock('date-fns/format', () => () => ('mock-date'));
 
 const createMockChannel = (process) => {
@@ -48,13 +49,16 @@ describe('ui/MessageContent', () => {
 
   it('should have class names by own user basic status', () => {
     const className = "test-classname";
+    const message = createMockMessage();
     const { container, queryByTestId } = render(
-      <MessageContent
-        className={className}
-        userId="sendbird-user-000"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          className={className}
+          userId="sendbird-user-000"
+          message={message}
+          channel={createMockChannel()}
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-message-content')[0].className
@@ -110,13 +114,16 @@ describe('ui/MessageContent', () => {
   });
 
   it('should render components when isByMe is true', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <MessageContent
-        userId="user-id-001"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        isByMe
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          userId="user-id-001"
+          message={message}
+          channel={createMockChannel()}
+          isByMe
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelector('.sendbird-message-content.outgoing')
@@ -138,13 +145,16 @@ describe('ui/MessageContent', () => {
     ).toBeNull();
   });
   it('should render components when isByMe is false', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <MessageContent
-        userId="user-id-002"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        isByMe={false}
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          userId="user-id-002"
+          message={message}
+          channel={createMockChannel()}
+          isByMe={false}
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelector('.sendbird-message-content.outgoing')
@@ -167,13 +177,16 @@ describe('ui/MessageContent', () => {
   });
 
   it('should not render components when chainTop is true', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <MessageContent
-        userId="sendbird-user-000"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        chainTop
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          userId="sendbird-user-000"
+          message={message}
+          channel={createMockChannel()}
+          chainTop
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-message-content__middle__sender-name').length
@@ -187,14 +200,17 @@ describe('ui/MessageContent', () => {
   });
 
   it('should not render components when chainBottom is true & isByMe is true', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <MessageContent
-        userId="sendbird-user-001"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        isByMe
-        chainBottom
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          userId="sendbird-user-001"
+          message={message}
+          channel={createMockChannel()}
+          isByMe
+          chainBottom
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-message-content__left__avatar').length
@@ -204,14 +220,17 @@ describe('ui/MessageContent', () => {
     ).toBe(0);
   });
   it('should not render components when chainBottom is true & isByMe is false', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <MessageContent
-        userId="sendbird-user-002"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        isByMe={false}
-        chainBottom
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          userId="sendbird-user-002"
+          message={message}
+          channel={createMockChannel()}
+          isByMe={false}
+          chainBottom
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-message-content__left__avatar').length
@@ -224,13 +243,16 @@ describe('ui/MessageContent', () => {
   // it('should render components by isReactionEnabled and reactions', () => {});
 
   it('should do a snapshot test of the MessageContent DOM', function () {
+    const message = createMockMessage();
     const { asFragment }  = render(
-      <MessageContent
-        className="classname-for-snapshot"
-        message={createMockMessage()}
-        channel={createMockChannel()}
-        userId="user-id-000"
-      />
+      <MessageProvider message={message}>
+        <MessageContent
+          className="classname-for-snapshot"
+          message={message}
+          channel={createMockChannel()}
+          userId="user-id-000"
+        />
+      </MessageProvider>
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
+++ b/src/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
@@ -52,21 +52,7 @@ exports[`ui/MessageContent should do a snapshot test of the MessageContent DOM 1
           <div
             class="sendbird-message-content__middle__message-item-body sendbird-text-message-item-body incoming  "
           >
-            <span
-              class="sendbird-word"
-            >
-              First
-            </span>
-            <span
-              class="sendbird-word"
-            >
-              second
-            </span>
-            <span
-              class="sendbird-word"
-            >
-              third
-            </span>
+            First second third
           </div>
         </span>
         <span

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -4,7 +4,6 @@ import DOMPurify from 'dompurify';
 import { inserTemplateToDOM } from './insertTemplate';
 import { sanitizeString } from '../../utils';
 import { DynamicProps } from './types';
-import { MENTION_CLASS_COMBINED_QUERY, MENTION_CLASS_IN_INPUT, TEXT_MESSAGE_CLASS } from './consts';
 import {
   createPasteNode,
   hasMention,

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -11,6 +11,7 @@ import {
   domToMessageTemplate,
   getUsersFromWords,
   extractTextFromNodes,
+  getLeafNodes,
 } from './utils';
 
 // conditions to test:
@@ -55,26 +56,17 @@ export default function usePaste({
       return;
     }
 
-    // has mention, sanitize and insert
-    let childNodes = pasteNode.querySelectorAll(`.${TEXT_MESSAGE_CLASS}`) as NodeListOf<HTMLSpanElement>;
-    if (pasteNode.querySelectorAll(`.${MENTION_CLASS_IN_INPUT}`).length > 0) {
-      // @ts-ignore
-      childNodes = pasteNode.children;
-    }
-    let nodeArray = Array.from(childNodes);
-    // handle paste when there is only one child
-    if (pasteNode.children.length === 1 && pasteNode.querySelectorAll(MENTION_CLASS_COMBINED_QUERY).length === 1) {
-      nodeArray = Array.from(pasteNode.children) as HTMLSpanElement[];
-    }
-    const words = domToMessageTemplate(nodeArray);
-
+    // has mention, collect leaf nodes and parse words
+    const leafNodes = getLeafNodes(pasteNode);
+    const words = domToMessageTemplate(leafNodes);
     const mentionedUsers = getUsersFromWords(words, channel);
+
+    // side effects
     setMentionedUsers(mentionedUsers);
     inserTemplateToDOM(words);
     pasteNode.remove();
     setIsInput(true);
     setHeight();
     return;
-
   }, [ref, setIsInput, setHeight, channel, setMentionedUsers]);
 }

--- a/src/ui/MessageInput/hooks/usePaste/utils.ts
+++ b/src/ui/MessageInput/hooks/usePaste/utils.ts
@@ -9,6 +9,37 @@ import {
   MENTION_CLASS_IN_INPUT,
 } from './consts';
 import { Word } from './types';
+import { TEXT_MESSAGE_BODY_CLASSNAME } from "../../../TextMessageItemBody/consts";
+import { OG_MESSAGE_BODY_CLASSNAME } from '../../../OGMessageItemBody/consts';
+
+export function querySelectorIncludingSelf(
+  master: HTMLElement,
+  selector: string,
+): HTMLElement | null {
+  const result = [
+    master,
+    ...Array.from(master.querySelectorAll(selector))
+  ].find((el) => el.matches(selector)) as HTMLElement | null;
+  return result;
+}
+
+// Pasted dom node can be OG_MESSAGE or partial message or full message
+// full messsage would have TEXT_MESSAGE_BODY_CLASSNAME and have childNodes
+// partial message would not have TEXT_MESSAGE_BODY_CLASSNAME
+export function getLeafNodes(master: HTMLElement): ChildNode[] {
+  // og message
+  const ogMessage = querySelectorIncludingSelf(master, `.${OG_MESSAGE_BODY_CLASSNAME}`);
+  if (ogMessage) {
+    return Array.from(ogMessage.childNodes);
+  }
+
+  const textMessageBody = querySelectorIncludingSelf(master, `.${TEXT_MESSAGE_BODY_CLASSNAME}`);
+  if (textMessageBody) {
+    return Array.from(textMessageBody.childNodes);
+  }
+
+  return Array.from(master.childNodes);
+}
 
 export function createPasteNode(): HTMLDivElement | null {
   const pasteNode = document.body.querySelector(`#${PASTE_NODE}`);
@@ -41,19 +72,28 @@ export const extractTextFromNodes = (nodes: HTMLSpanElement[]): string => {
   return text;
 }
 
-export function domToMessageTemplate(nodeArray: HTMLSpanElement[]): Word[] {
+export function domToMessageTemplate(nodeArray: ChildNode[]): Word[] {
   const templates: Word[] = nodeArray?.reduce((accumulator, currentValue) => {
-    let mentionNode = currentValue.querySelector(MENTION_CLASS_COMBINED_QUERY) as HTMLSpanElement;
-    // sometimes the mention node is the parent node
-    // in this case querySelector will return null
-    if (!mentionNode) {
-      mentionNode = (
-        currentValue.classList.contains(MENTION_CLASS)  // for nodes copied from message
-        || currentValue.classList.contains(MENTION_CLASS_IN_INPUT) // for nodes copied from input
-      ) ? currentValue : null;
+    // currentValue can be node(from messageBody or messageInput) or text
+    let mentionNode;
+    // this looks awkward, but it is a fallback to set default text
+    let text = (currentValue as HTMLSpanElement)?.innerText;
+
+    // if text node, set text
+    if (currentValue instanceof Text) {
+      mentionNode = false;
+      text = currentValue.textContent;
     }
-    const text = currentValue.innerText;
+
+    if (currentValue instanceof HTMLElement) {
+      mentionNode = (currentValue.classList.contains(MENTION_CLASS) || currentValue.classList.contains(MENTION_CLASS_IN_INPUT))
+        ? currentValue
+        : currentValue.querySelector(MENTION_CLASS_COMBINED_QUERY);
+    }
+
+    // if mentionNode is not null, it is a mention
     if (mentionNode) {
+      const text = (currentValue as HTMLSpanElement)?.innerText;
       const userId = mentionNode.dataset?.userid;
       return [
         ...accumulator,
@@ -79,7 +119,11 @@ export function getUsersFromWords(templates: Word[], channel: GroupChannel): Use
   const users = channel.members;
   templates.forEach((template) => {
     if (template.userId) {
-      userMap[template.userId] = users.find((user) => user.userId === template.userId);
+      const mentionedMember = users.find((user) => user.userId === template.userId);
+      // Object.values would return array-> [undefined] if the user is not in the channel
+      if (mentionedMember) {
+        userMap[template.userId] = mentionedMember;
+      }
     }
   });
   return Object.values(userMap);

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -26,6 +26,9 @@ import {
   convertWordToStringObj,
 } from '../../utils';
 import usePaste from './hooks/usePaste';
+import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
+import { USER_MENTION_PREFIX } from '../../smart-components/Message/consts';
+import { TOKEN_TYPES } from '../../smart-components/Message/utils/tokens/types';
 
 const TEXT_FIELD_ID = 'sendbird-message-input-text-field';
 const LINE_HEIGHT = 76;
@@ -156,19 +159,21 @@ const MessageInput = React.forwardRef((props, ref) => {
       ) {
         /* mention enabled */
         const { mentionedUsers = [] } = message;
-        textField.innerHTML = message?.mentionedMessageTemplate?.split(' ').map((word) => (
-          convertWordToStringObj(word, mentionedUsers).map((stringObj) => {
-            const { type, value, userId } = stringObj;
-            if (type === StringObjType.mention && mentionedUsers.some((user) => user?.userId === userId)) {
-              const nickname = `${USER_MENTION_TEMP_CHAR}${mentionedUsers.find((user) => user?.userId === userId)?.nickname
-                || value
-                || stringSet.MENTION_NAME__NO_NAME
-              }`
-              return renderMentionLabelToString({ userId, nickname });
-            }
-            return sanitizeString(value);
-          }).join('')
-        )).join(' ');
+        const tokens = tokenizeMessage({
+          message: message?.mentionedMessageTemplate,
+          mentionedUsers,
+        });
+        textField.innerHTML = tokens.map((token) => {
+          if (token.type === TOKEN_TYPES.mention) {
+            const mentionedUser = mentionedUsers.find((user) => user.userId === token.userId);
+            const nickname = `${USER_MENTION_PREFIX}${mentionedUser?.nickname || token.value || stringSet.MENTION_NAME__NO_NAME}`;
+            return renderMentionLabelToString({
+              userId: token.userId,
+              nickname,
+            });
+          }
+          return sanitizeString(token.value);
+        }).join(' ');
       } else {
         /* mention disabled */
         try {

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -160,7 +160,7 @@ const MessageInput = React.forwardRef((props, ref) => {
         /* mention enabled */
         const { mentionedUsers = [] } = message;
         const tokens = tokenizeMessage({
-          message: message?.mentionedMessageTemplate,
+          messageText: message?.mentionedMessageTemplate,
           mentionedUsers,
         });
         textField.innerHTML = tokens.map((token) => {

--- a/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
+++ b/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
@@ -2,23 +2,35 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import OGMessageItemBody from "../index";
+import { MessageProvider } from '../../../smart-components/Message/context/MessageProvider';
 
 describe('ui/OGMessageItemBody', () => {
   it('should do a snapshot test of the OGMessageItemBody DOM', function() {
     const text = "example-text";
-    const { asFragment } = render(<OGMessageItemBody message={{
+    const message = {
       ogMetaData: {
         title: text,
         description: text,
         url: text,
         image: text,
       },
-    }} />);
+      message: text,
+    };
+    const { asFragment } = render(
+      <MessageProvider message={message}>
+        <OGMessageItemBody message={message} />
+      </MessageProvider>
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should add .sendbird-og-message-item-body__og-thumbnail__image-empty classname when image is empty', () => {
-    const { container } = render(<OGMessageItemBody />);
+    const message = { message: 'example-text' };
+    const { container } = render(
+      <MessageProvider message={message}>
+        <OGMessageItemBody message={{ message: 'example-text' }} />
+      </MessageProvider>
+    );
     expect(container.getElementsByClassName('sendbird-og-message-item-body__og-thumbnail__empty').length).toBe(1);
   });
 });

--- a/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -10,7 +10,9 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
     >
       <div
         class="sendbird-og-message-item-body__text-bubble"
-      />
+      >
+        example-text
+      </div>
     </span>
     <div
       class="sendbird-og-message-item-body__og-thumbnail

--- a/src/ui/OGMessageItemBody/consts.ts
+++ b/src/ui/OGMessageItemBody/consts.ts
@@ -1,0 +1,1 @@
+export const OG_MESSAGE_BODY_CLASSNAME = 'sendbird-og-message-item-body__text-bubble';

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -7,11 +7,9 @@ import React, {
 } from 'react';
 import type { UserMessage } from '@sendbird/chat/message';
 
-import Word from '../Word';
 import ImageRenderer from '../ImageRenderer';
 import Icon, { IconTypes } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../Label';
-import uuidv4 from '../../utils/uuid';
 import { getClassName, isEditedMessage } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import TextFragment from '../../smart-components/Message/components/TextFragment';

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -16,6 +16,7 @@ import { getClassName, isEditedMessage } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import TextFragment from '../../smart-components/Message/components/TextFragment';
 import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
+import { OG_MESSAGE_BODY_CLASSNAME } from './consts';
 
 interface Props {
   className?: string | Array<string>;
@@ -63,7 +64,7 @@ export default function OGMessageItemBody({
         type={LabelTypography.BODY_1}
         color={isByMe ? LabelColors.ONCONTENT_1 : LabelColors.ONBACKGROUND_1}
       >
-        <div className="sendbird-og-message-item-body__text-bubble">
+        <div className={OG_MESSAGE_BODY_CLASSNAME}>
           <TextFragment tokens={tokens} />
           {
             isEditedMessage(message) && (

--- a/src/ui/OpenchannelOGMessage/__tests__/OpenchannelOGMessage.spec.js
+++ b/src/ui/OpenchannelOGMessage/__tests__/OpenchannelOGMessage.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import OpenchannelOGMessage from "../index";
+import { MessageProvider } from '../../../smart-components/Message/context/MessageProvider';
 
 // mock date-fns to avoid problems from snapshot timestamping
 // between testing in different locations
@@ -40,12 +41,15 @@ const getMockMessage = (callback) => {
 
 describe('ui/OpenchannelOGMessage', () => {
   it('should have default elements', function() {
+    const message = getMockMessage();
     const { container } = render(
-      <OpenchannelOGMessage
-        message={getMockMessage()}
-        userId={userId}
-        status="succeeded"
-      />
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage
+          message={getMockMessage()}
+          userId={userId}
+          status="succeeded"
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-openchannel-og-message')[0].className
@@ -95,13 +99,16 @@ describe('ui/OpenchannelOGMessage', () => {
   });
 
   it('should not have elements by chainTop', function() {
+    const message = getMockMessage();
     const { container } = render(
-      <OpenchannelOGMessage
-        message={getMockMessage()}
-        userId={userId}
-        status="succeeded"
-        chainTop
-      />
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage
+          message={message}
+          userId={userId}
+          status="succeeded"
+          chainTop
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-openchannel-og-message')[0].className
@@ -151,12 +158,15 @@ describe('ui/OpenchannelOGMessage', () => {
   });
 
   it('should not have og elements when ogMetaData does not exist', function() {
+    const message = getMockMessage((message) => ({ ...message, ogMetaData: {} }));
     const { container } = render(
-      <OpenchannelOGMessage
-        message={getMockMessage((message) => ({ ...message, ogMetaData: {} }))}
-        status="succeeded"
-        userId="hh-1234"
-      />
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage
+          message={message}
+          status="succeeded"
+          userId="hh-1234"
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-openchannel-og-message')[0].className
@@ -206,10 +216,11 @@ describe('ui/OpenchannelOGMessage', () => {
   });
 
   it('should render pending icon if status is pending', function() {
+    const message = getMockMessage((message) => ({ ...message, sendingStatus: 'pending' }));
     const { container } = render(
-      <OpenchannelOGMessage
-        message={getMockMessage((message) => ({ ...message, sendingStatus: 'pending' }))}
-      />
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage message={message} />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-openchannel-og-message__top__right__tail__pending').length
@@ -220,11 +231,14 @@ describe('ui/OpenchannelOGMessage', () => {
   });
 
   it('should render failed icon if status is failed', function() {
+    const message = getMockMessage((message) => ({ ...message, sendingStatus: 'failed' }));
     const { container } = render(
-      <OpenchannelOGMessage
-        message={getMockMessage((message) => ({ ...message, sendingStatus: 'failed' }))}
-        status="failed"
-      />
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage
+          message={message}
+          status="failed"
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName('sendbird-openchannel-og-message__top__right__tail__pending').length
@@ -235,33 +249,36 @@ describe('ui/OpenchannelOGMessage', () => {
   });
 
   it('should do a snapshot test of the OpenchannelOGMessage DOM', function() {
+    const message = {
+      messageType: 'user',
+      message: 'I am the Message',
+      createdAt: 1111,
+      updatedAt: 0,
+      ogMetaData: {
+        url: 'https://sendbird.com/',
+        title: 'This is the TITLE',
+        description: 'I am description I am who has much string in this og meta data',
+        defaultImage: {
+          url: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
+          alt: 'test',
+        },
+      },
+      sender: {
+        profileUrl: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
+        friendName: 'Hoon Baek',
+        nickname: 'Honn',
+        userId: 'hh-1234',
+      },
+      isResendable: () => false,
+    };
     const { asFragment } = render(
-      <OpenchannelOGMessage
-        message={{
-          messageType: 'user',
-          message: 'I am the Message',
-          createdAt: 1111,
-          updatedAt: 0,
-          ogMetaData: {
-            url: 'https://sendbird.com/',
-            title: 'This is the TITLE',
-            description: 'I am description I am who has much string in this og meta data',
-            defaultImage: {
-              url: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
-              alt: 'test',
-            },
-          },
-          sender: {
-            profileUrl: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
-            friendName: 'Hoon Baek',
-            nickname: 'Honn',
-            userId: 'hh-1234',
-          },
-          isResendable: () => false,
-        }}
-        status="succeeded"
-        userId="hh-1234"
-      />,
+      <MessageProvider message={message}>
+        <OpenchannelOGMessage
+          message={message}
+          status="succeeded"
+          userId="hh-1234"
+        />
+      </MessageProvider>,
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/ui/OpenchannelOGMessage/__tests__/__snapshots__/OpenchannelOGMessage.spec.js.snap
+++ b/src/ui/OpenchannelOGMessage/__tests__/__snapshots__/OpenchannelOGMessage.spec.js.snap
@@ -61,26 +61,7 @@ exports[`ui/OpenchannelOGMessage should do a snapshot test of the OpenchannelOGM
           <span
             class="sendbird-openchannel-og-message__top__right__description__message sendbird-label sendbird-label--body-1 sendbird-label--color-onbackground-1"
           >
-            <span
-              class="sendbird-word"
-            >
-              I
-            </span>
-            <span
-              class="sendbird-word"
-            >
-              am
-            </span>
-            <span
-              class="sendbird-word"
-            >
-              the
-            </span>
-            <span
-              class="sendbird-word"
-            >
-              Message
-            </span>
+            I am the Message
           </span>
         </div>
       </div>

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -33,6 +33,8 @@ import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import useLongPress from '../../hooks/useLongPress';
 import OpenChannelMobileMenu from '../OpenChannelMobileMenu';
+import TextFragment from '../../smart-components/Message/components/TextFragment';
+import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
 
 interface OpenChannelOGMessageProps {
   message: UserMessage;
@@ -93,34 +95,11 @@ export default function OpenchannelOGMessage({
   const sender = getSenderFromMessage(message);
   const { isMobile } = useMediaQueryContext();
 
-  const MemoizedMessageText = useMemo(() => () => {
-    const wordClassName = 'sendbird-openchannel-og-message--word';
-    const splitMessage = message.message.split(' ');
-    const matchedMessage = splitMessage
-      .map((word) => (
-        <Word
-          key={uuidv4()}
-          word={word}
-          message={message}
-          isByMe={message?.sender?.userId === sdk?.currentUser?.userId}
-        />
-      ));
-
-    if (message.updatedAt > 0) {
-      matchedMessage.push(
-        <Label
-          key={uuidv4()}
-          className={wordClassName}
-          type={LabelTypography.BODY_1}
-          color={LabelColors.ONBACKGROUND_2}
-        >
-          {stringSet.MESSAGE_EDITED}
-        </Label>,
-      );
-    }
-
-    return matchedMessage;
-  }, [message, message.updatedAt]);
+  const tokens = useMemo(() => {
+    return tokenizeMessage({
+      messageText: message.message,
+    });
+  }, [message?.updatedAt]);
 
   // place conxt menu top depending clientHeight of message component
   useEffect(() => {
@@ -228,7 +207,19 @@ export default function OpenchannelOGMessage({
               type={LabelTypography.BODY_1}
               color={LabelColors.ONBACKGROUND_1}
             >
-              {MemoizedMessageText()}
+              <TextFragment tokens={tokens} />
+              {
+                (message?.updatedAt > 0) && (
+                  <Label
+                    key={uuidv4()}
+                    className='sendbird-openchannel-og-message--word'
+                    type={LabelTypography.BODY_1}
+                    color={LabelColors.ONBACKGROUND_2}
+                  >
+                    {stringSet.MESSAGE_EDITED}
+                  </Label>
+                )
+              }
             </Label>
           </div>
         </div>

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -12,7 +12,6 @@ import LinkLabel from '../LinkLabel';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Loader from '../Loader';
 import UserProfile from '../UserProfile';
-import Word from '../Word';
 import { UserProfileContext } from '../../lib/UserProfileContext';
 
 import uuidv4 from '../../utils/uuid';
@@ -29,7 +28,6 @@ import {
   showMenuTrigger,
 } from '../../utils/openChannelUtils';
 import { getSenderFromMessage } from '../../utils/openChannelUtils';
-import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import useLongPress from '../../hooks/useLongPress';
 import OpenChannelMobileMenu from '../OpenChannelMobileMenu';
@@ -76,7 +74,6 @@ export default function OpenchannelOGMessage({
   const status = message?.sendingStatus;
   const { ogMetaData } = message;
   const { defaultImage } = ogMetaData;
-  const sdk = useSendbirdStateContext?.()?.stores?.sdkStore?.sdk;
   const { stringSet, dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext<UserProfileContext>(UserProfileContext);
   const [contextStyle, setContextStyle] = useState({});

--- a/src/ui/TextMessageItemBody/__tests__/TextMessageItemBody.spec.js
+++ b/src/ui/TextMessageItemBody/__tests__/TextMessageItemBody.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import TextMessageItemBody from "../index";
+import { MessageProvider } from '../../../smart-components/Message/context/MessageProvider';
 
 const createMockMessage = (process) => {
   const mockMessage = {
@@ -17,11 +18,14 @@ const createMockMessage = (process) => {
 describe('ui/TextMessageItemBody', () => {
   it('should have class names of own basic status', () => {
     const insertingClassName = 'test-class-name';
+    const message = createMockMessage();
     const { container } = render(
-      <TextMessageItemBody
-        className={insertingClassName}
-        message={createMockMessage()}
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          className={insertingClassName}
+          message={message}
+        />
+      </MessageProvider>
     );
     expect(
       container.getElementsByClassName(insertingClassName)
@@ -50,11 +54,14 @@ describe('ui/TextMessageItemBody', () => {
   });
 
   it('should have class name by isByMe is true', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <TextMessageItemBody
-        message={createMockMessage()}
-        isByMe
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          message={message}
+          isByMe
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body.outgoing')
@@ -64,11 +71,14 @@ describe('ui/TextMessageItemBody', () => {
     ).toHaveLength(0);
   });
   it('should have class name by isByMe is false', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <TextMessageItemBody
-        message={createMockMessage()}
-        isByMe={false}
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          message={message}
+          isByMe={false}
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body.outgoing')
@@ -79,11 +89,14 @@ describe('ui/TextMessageItemBody', () => {
   });
 
   it('should have class name by mouse hover prop', () => {
+    const message = createMockMessage();
     const { container } = render(
-      <TextMessageItemBody
-        message={createMockMessage()}
-        mouseHover
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          message={message}
+          mouseHover
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body.mouse-hover')
@@ -94,14 +107,17 @@ describe('ui/TextMessageItemBody', () => {
   });
 
   it('should have class name by reactions of message prop', () => {
+    const message = createMockMessage((mockMessage) => ({
+      ...mockMessage,
+      reactions: [{}, {}, {}],
+    }))
     const { container } = render(
-      <TextMessageItemBody
-        isReactionEnabled
-        message={createMockMessage((mockMessage) => ({
-          ...mockMessage,
-          reactions: [{}, {}, {}],
-        }))}
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          isReactionEnabled
+          message={message}
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body.reactions')
@@ -110,13 +126,16 @@ describe('ui/TextMessageItemBody', () => {
 
   it('should have words component by split message', () => {
     const messageText = 'First second third fourth fifth';
+    const message = createMockMessage((mockMessage) => ({
+      ...mockMessage,
+      message: messageText,
+    }))
     const { container } = render(
-      <TextMessageItemBody
-        message={createMockMessage((mockMessage) => ({
-          ...mockMessage,
-          message: messageText,
-        }))}
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          message={message}
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body__message.edited')
@@ -124,14 +143,17 @@ describe('ui/TextMessageItemBody', () => {
   });
   it('should have words component by split message when message has updatedAt', () => {
     const messageText = 'First second third fourth fifth';
+    const message = createMockMessage((mockMessage) => ({
+      ...mockMessage,
+      message: messageText,
+      updatedAt: 10101010,
+    }))
     const { container } = render(
-      <TextMessageItemBody
-        message={createMockMessage((mockMessage) => ({
-          ...mockMessage,
-          message: messageText,
-          updatedAt: 10101010,
-        }))}
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          message={message}
+        />
+      </MessageProvider>
     );
     expect(
       container.querySelectorAll('.sendbird-text-message-item-body__message.edited')
@@ -139,18 +161,21 @@ describe('ui/TextMessageItemBody', () => {
   });
 
   it('should do a snapshot test of the TextMessageItemBody DOM', function () {
+    const message = createMockMessage((mock) => ({
+      ...mock,
+      message: 'First second third fourth fifth',
+      updatedAt: 1010,
+      reactions: [{}, {}, {}],
+    }))
     const { asFragment } = render(
-      <TextMessageItemBody
-        className="class-name-for-snapshot"
-        message={createMockMessage((mock) => ({
-          ...mock,
-          message: 'First second third fourth fifth',
-          updatedAt: 1010,
-          reactions: [{}, {}, {}],
-        }))}
-        isByMe
-        mouseHover
-      />
+      <MessageProvider message={message}>
+        <TextMessageItemBody
+          className="class-name-for-snapshot"
+          message={message}
+          isByMe
+          mouseHover
+        />
+      </MessageProvider>
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
+++ b/src/ui/TextMessageItemBody/__tests__/__snapshots__/TextMessageItemBody.spec.js.snap
@@ -8,31 +8,7 @@ exports[`ui/TextMessageItemBody should do a snapshot test of the TextMessageItem
     <div
       class="class-name-for-snapshot sendbird-text-message-item-body outgoing mouse-hover "
     >
-      <span
-        class="sendbird-word"
-      >
-        First
-      </span>
-      <span
-        class="sendbird-word"
-      >
-        second
-      </span>
-      <span
-        class="sendbird-word"
-      >
-        third
-      </span>
-      <span
-        class="sendbird-word"
-      >
-        fourth
-      </span>
-      <span
-        class="sendbird-word"
-      >
-        fifth
-      </span>
+      First second third fourth fifth
       <span
         class="sendbird-text-message-item-body__message edited sendbird-label sendbird-label--body-1 sendbird-label--color-oncontent-2"
       >

--- a/src/ui/TextMessageItemBody/consts.ts
+++ b/src/ui/TextMessageItemBody/consts.ts
@@ -1,0 +1,1 @@
+export const TEXT_MESSAGE_BODY_CLASSNAME = 'sendbird-text-message-item-body';

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -5,10 +5,10 @@ import type { UserMessage } from '@sendbird/chat/message';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import { getClassName, isEditedMessage } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
-import uuidv4 from '../../utils/uuid';
-import Word from '../Word';
 import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
 import TextFragment from '../../smart-components/Message/components/TextFragment';
+import { TEXT_MESSAGE_CLASS } from '../MessageInput/hooks/usePaste/consts';
+import { TEXT_MESSAGE_BODY_CLASSNAME } from './consts';
 
 interface Props {
   className?: string | Array<string>;
@@ -49,7 +49,7 @@ export default function TextMessageItemBody({
     >
       <div className={getClassName([
         className,
-        'sendbird-text-message-item-body',
+        TEXT_MESSAGE_BODY_CLASSNAME,
         isByMe ? 'outgoing' : 'incoming',
         mouseHover ? 'mouse-hover' : '',
         (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -7,6 +7,8 @@ import { getClassName, isEditedMessage } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import uuidv4 from '../../utils/uuid';
 import Word from '../Word';
+import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
+import TextFragment from '../../smart-components/Message/components/TextFragment';
 
 interface Props {
   className?: string | Array<string>;
@@ -26,13 +28,20 @@ export default function TextMessageItemBody({
   isReactionEnabled = false,
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
-  const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
-  const sentences: Array<Array<string>> = useMemo(() => {
+  const isMessageMentioned = isMentionEnabled
+    && message?.mentionedMessageTemplate?.length > 0
+    && message?.mentionedUsers?.length > 0;
+  const tokens = useMemo(() => {
     if (isMessageMentioned) {
-      return message?.mentionedMessageTemplate?.split(/\n/).map((sentence) => sentence.split(/\s/));
+      return tokenizeMessage({
+        mentionedUsers: message?.mentionedUsers,
+        messageText: message?.mentionedMessageTemplate,
+      });
     }
-    return message?.message?.split(/\n/).map((sentence) => sentence.split(/\s/));
-  }, [message?.mentionedMessageTemplate]);
+    return tokenizeMessage({
+      messageText: message?.message,
+    });
+  }, [message?.updatedAt]);
   return (
     <Label
       type={LabelTypography.BODY_1}
@@ -45,23 +54,7 @@ export default function TextMessageItemBody({
         mouseHover ? 'mouse-hover' : '',
         (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
       ])}>
-        {
-          sentences.map((sentence, index) => {
-            return [
-              sentence.map((word) => {
-                return (
-                  <Word
-                    key={uuidv4()}
-                    word={word}
-                    message={message}
-                    isByMe={isByMe}
-                  />
-                );
-              }),
-              sentences?.[index + 1] ? <br /> : null,
-            ]
-          })
-        }
+        <TextFragment tokens={tokens} />
         {
           isEditedMessage(message) && (
             <Label

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -7,7 +7,6 @@ import { getClassName, isEditedMessage } from '../../utils';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import { tokenizeMessage } from '../../smart-components/Message/utils/tokens/tokenize';
 import TextFragment from '../../smart-components/Message/components/TextFragment';
-import { TEXT_MESSAGE_CLASS } from '../MessageInput/hooks/usePaste/consts';
 import { TEXT_MESSAGE_BODY_CLASSNAME } from './consts';
 
 interface Props {

--- a/src/ui/Word/__tests__/__snapshots__/Word.spec.js.snap
+++ b/src/ui/Word/__tests__/__snapshots__/Word.spec.js.snap
@@ -16,6 +16,7 @@ exports[`ui/Word should do a snapshot test of the Word DOM 1`] = `
             
           "
         data-nickname="Hoon Baek"
+        data-sb-mention="true"
         data-userid="hoon"
       >
         <span

--- a/src/ui/Word/index.scss
+++ b/src/ui/Word/index.scss
@@ -4,7 +4,6 @@
   display: inline;
   margin-right: 4px;
   height: fit-content;
-  white-space: nowrap;
   .sendbird-word__url,
   .sendbird-word__normal {
     display: inline-block;

--- a/src/ui/Word/index.scss
+++ b/src/ui/Word/index.scss
@@ -2,10 +2,10 @@
 
 .sendbird-word {
   display: inline;
-  margin-right: 4px;
   height: fit-content;
   .sendbird-word__url,
   .sendbird-word__normal {
+    margin-right: 4px;
     display: inline-block;
     color: inherit;
   }

--- a/src/ui/Word/index.tsx
+++ b/src/ui/Word/index.tsx
@@ -1,3 +1,7 @@
+/**
+ * @deprecated  This component is deprecated and will be removed in the next major version.
+ * Use TextFragment instead.
+ */
 import './index.scss';
 import React from 'react';
 import type { UserMessage } from '@sendbird/chat/message';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -592,6 +592,10 @@ export interface StringObj {
   userId?: string;
 }
 
+/**
+ * @deprecated
+ * use smart-components/message/utils/tokenize instead
+ */
 export const convertWordToStringObj = (word: string, _users: Array<User>, _template?: string): Array<StringObj> => {
   const users = _users || [];
   const template = _template || '@'; // Use global variable


### PR DESCRIPTION
Before:
* The words inside messages were kept in separate spans
* Which would lead to unfavourable formatting when pasted

After:
* Implement a Provider/Module to improve customization of messages
	* This is still in progress, not exported yet
	* In the future, we can add information such as ->
		* Menu render options, edit, delete callbacks etc
		* This will improve the customizability and remove some prop drilling in Messages
* Remove span between simple strings
* Urls and Mentions will still be wrapped in spans(for formatting)
* Apply new logic & components(TextFragment) to tokenize strings
* Improve keys used in rendering inside message,
	* UUIDs are not the optimal way to improve rendering
	* Create a composite key with message updated at
* Refactor usePaste hook ~
* Fix overflow of long strings
* Deprecate `Word` and `convertWordToStringObj`
* Export MessageProvider
```
export type MessageProviderProps = {
  children: React.ReactNode;
  message: BaseMessage;
  isByMe?: boolean;
}

import { MessageProvider, useMessageContext } from '@sendbird/uikit-react/Message/context'
```
Incase if you were using MessageComponents and see error message
`useMessageContext must be used within a MessageProvider `
 use: `<MessageProvider message={message}><CustomMessage /></MessageProvider>`

fixes:
https://sendbird.atlassian.net/browse/UIKIT-3400
https://sendbird.atlassian.net/browse/UIKIT-3561

