### PR TITLE
fix: MessageInput - detect new lines in safari

### DIFF
--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -329,6 +329,11 @@ const MessageInput = React.forwardRef((props, ref) => {
         } else if (node.nodeType === NodeTypes.ElementNode && node.nodeName === NodeNames.Br) {
           messageText += '\n';
           mentionTemplate += '\n';
+        } else if (node?.nodeType === NodeTypes.ElementNode && node?.nodeName === NodeNames.Div) {
+          // handles newline in safari
+          const { textContent = '' } = node;
+          messageText += `\n${textContent}`;
+          mentionTemplate += `\n${textContent}`;
         } else { // other nodes including text node
           const { textContent = '' } = node;
           messageText += textContent;


### PR DESCRIPTION
safari puts `<div>text</div>` for new lines inside content editable div(input)
Other browsers put newline or `br`

fixes: https://sendbird.atlassian.net/browse/UIKIT-3577


