### PR TITLE
hotfix: Use markAsReadScheduler in MessageList

### DIFF
--- a/src/smart-components/Channel/components/MessageList/index.tsx
+++ b/src/smart-components/Channel/components/MessageList/index.tsx
@@ -56,7 +56,7 @@ const MessageList: React.FC<MessageListProps> = ({
     ? allMessages.filter((filterMessageList as (message: EveryMessage) => boolean))
     : allMessages;
   const store = useSendbirdStateContext();
-  const markAsRead = store.config.markAsRead;
+  const markAsReadScheduler = store.config.markAsReadScheduler;
 
   const onScroll = (e) => {
     const element = e.target;
@@ -109,7 +109,7 @@ const MessageList: React.FC<MessageListProps> = ({
         type: messageActionTypes.MARK_AS_READ,
         payload: { channel: currentGroupChannel },
       });
-      markAsRead?.push(currentGroupChannel);
+      markAsReadScheduler?.push(currentGroupChannel);
     }
   };
 
@@ -194,7 +194,7 @@ const MessageList: React.FC<MessageListProps> = ({
             scrollRef.current.scrollTop = scrollRef?.current?.scrollHeight - scrollRef?.current?.offsetHeight;
           }
           if (!disableMarkAsRead) {
-            markAsRead?.push(currentGroupChannel);
+            markAsReadScheduler?.push(currentGroupChannel);
             messagesDispatcher({
               type: messageActionTypes.MARK_AS_READ,
               payload: { channel: currentGroupChannel },

--- a/src/smart-components/Channel/context/ChannelProvider.tsx
+++ b/src/smart-components/Channel/context/ChannelProvider.tsx
@@ -342,6 +342,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
       logger,
       scrollRef,
       setQuoteMessage,
+      markAsReadScheduler,
     },
   );
 
@@ -383,6 +384,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     currentGroupChannel,
     messagesDispatcher,
     userFilledMessageListQuery,
+    markAsReadScheduler,
   });
 
   // callbacks for Message CURD actions

--- a/src/smart-components/Channel/context/hooks/useHandleChannelEvents.ts
+++ b/src/smart-components/Channel/context/hooks/useHandleChannelEvents.ts
@@ -8,6 +8,7 @@ import { CustomUseReducerDispatcher, Logger } from "../../../../lib/SendbirdStat
 import uuidv4 from "../../../../utils/uuid";
 import compareIds from '../../../../utils/compareIds';
 import * as messageActions from '../dux/actionTypes';
+import { MarkAsReadSchedulerType } from "../../../../lib/hooks/useMarkAsReadScheduler";
 
 /**
  * Handles ChannelEvents and send values to dispatcher using messagesDispatcher
@@ -29,6 +30,7 @@ interface StaticParams {
   scrollRef: React.RefObject<HTMLDivElement>;
   setQuoteMessage: React.Dispatch<React.SetStateAction<UserMessage | FileMessage>>;
   messagesDispatcher: CustomUseReducerDispatcher;
+  markAsReadScheduler: MarkAsReadSchedulerType;
 }
 
 function useHandleChannelEvents({
@@ -38,6 +40,7 @@ function useHandleChannelEvents({
   currentGroupChannel,
 }: DynamicParams, {
   sdk,
+  markAsReadScheduler,
   logger,
   scrollRef,
   setQuoteMessage,
@@ -70,10 +73,10 @@ function useHandleChannelEvents({
             ) {
               // and !openContextMenu
               try {
+                if (!disableMarkAsRead) {
+                  markAsReadScheduler?.push?.(currentGroupChannel);
+                }
                 setTimeout(() => {
-                  if (!disableMarkAsRead) {
-                    currentGroupChannel?.markAsRead?.();
-                  }
                   scrollIntoLast(0, scrollRef);
                 });
               } catch (error) {

--- a/src/smart-components/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/smart-components/Channel/context/hooks/useHandleReconnect.ts
@@ -7,6 +7,7 @@ import { PREV_RESULT_SIZE } from '../const';
 import * as messageActionTypes from '../dux/actionTypes';
 import { Logger } from '../../../../lib/SendbirdState';
 import { NEXT_RESULT_SIZE } from '../const';
+import { MarkAsReadSchedulerType } from '../../../../lib/hooks/useMarkAsReadScheduler';
 interface DynamicParams {
   isOnline: boolean;
   replyType?: string;
@@ -18,6 +19,7 @@ interface StaticParams {
   sdk: SendbirdGroupChat;
   currentGroupChannel: GroupChannel;
   scrollRef: React.RefObject<HTMLDivElement>;
+  markAsReadScheduler: MarkAsReadSchedulerType;
   messagesDispatcher: (props: { type: string, payload: any }) => void;
   userFilledMessageListQuery?: Record<string, any>;
 }
@@ -30,6 +32,7 @@ function useHandleReconnect(
     scrollRef,
     currentGroupChannel,
     messagesDispatcher,
+    markAsReadScheduler,
     userFilledMessageListQuery,
   }: StaticParams,
 ): void {
@@ -89,11 +92,7 @@ function useHandleReconnect(
                 });
               })
               if (!disableMarkAsRead) {
-                try {
-                  currentGroupChannel?.markAsRead?.();
-                } catch {
-                  //
-                }
+                markAsReadScheduler?.push(currentGroupChannel);
               }
           });
       }


### PR DESCRIPTION
Missed refactor markAsReadScheduler in `Channel/components/MessageList`