### PR TITLE
chore: add type.d.ts import resolver

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
           ".js",
           ".jsx",
           ".ts",
-          ".tsx"
+          ".tsx",
+          ".d.ts"
         ]
       }
     }
@@ -34,18 +35,16 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-expressions": "error",
     "react/display-name": "off",
-    "import/extensions": "off",
-    // TODO(Ahyoung): uncomment below after find a way not to get an error \w type.d.ts
-    // "import/extensions": [
-    //   "warn",
-    //   "ignorePackages",
-    //   {
-    //     "js": "never",
-    //     "jsx": "never",
-    //     "ts": "never",
-    //     "tsx": "never"
-    //   }
-    // ],
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     // TODO(Ahyoung): fix and remove one by one
     "no-floating-decimal": "off",
     "no-shadow": "off",


### PR DESCRIPTION
### Description Of Changes
It's a following task after #490 merged. \w previous config, I got these lint error since the lint config couldn't resolve the `d.ts` file extension. So I just off-ed the `import/extensions` rule at the PR and left a comment. 
<img width="766" alt="Screenshot 2023-04-14 at 2 17 14 PM" src="https://user-images.githubusercontent.com/10060731/231947754-4e0b330e-3f17-43dc-b074-7e95dbda2877.png">

So I found the workaround and enabled the rule again. 