### PR TITLE
feat: add nodeLinker to yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@ plugins:
     spec: "@yarnpkg/plugin-version"
 
 yarnPath: .yarn/releases/yarn-3.5.0.cjs
+nodeLinker: node-modules

--- a/src/lib/dux/sdk/reducers.ts
+++ b/src/lib/dux/sdk/reducers.ts
@@ -32,5 +32,5 @@ export default function reducer(state: SdkStoreStateType, action: SdkActionTypes
     })
     .otherwise(() => {
       return state;
-    }) as SdkStoreStateType;
+    });
 }

--- a/src/lib/dux/user/reducers.ts
+++ b/src/lib/dux/user/reducers.ts
@@ -22,5 +22,5 @@ export default function reducer(state: UserStoreStateType, action: UserActionTyp
     })
     .otherwise(() => {
       return state;
-    }) as UserStoreStateType;
+    });
 }


### PR DESCRIPTION
### Description Of Changes
Applies a comment in https://sendbird.slack.com/archives/C050Z6DA70A/p1681698139040799?thread_ts=1681693613.459129&cid=C050Z6DA70A. 

I introduced yarn 3 but there's an issue \w ts-pattern that it throws an weird TS error even though we used it correctly. 
But realized that it's gone \w `nodeLinker: node-modules` setting 🤷 
This won't be a permanent fix but will find another workaround including the pkg manager replacement yarn -> pnpm maybe.
