### PR TITLE
chore: Require for more than v3.4.0 Chat SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.2.3",
+    "@sendbird/chat": "^4.3.0",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "dompurify": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2347,15 +2347,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat@npm:^4.2.3":
-  version: 4.6.1
-  resolution: "@sendbird/chat@npm:4.6.1"
+"@sendbird/chat@npm:^4.3.0":
+  version: 4.7.2
+  resolution: "@sendbird/chat@npm:4.7.2"
   peerDependencies:
     "@react-native-async-storage/async-storage": ^1.17.6
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
-  checksum: 937aef1e0a4c403ddc88a39eed816881116ae15aa25e647962355079ed112eec4093326f1b26d8facc67ab348c5d0a3ed8cc49bf34bb2af2224a04b51f5d194b
+  checksum: 74e865395a843c7987c5a929ce78b1430e4ba2b120fd8ec16e97d7f63c50251e872c0e8a0e94e7bc3276752a7ae1d5bd435dabab34420f59c3ae0c960d047fb3
   languageName: node
   linkType: hard
 
@@ -2375,7 +2375,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^7.1.3
     "@rollup/plugin-replace": ^2.4.2
     "@rollup/plugin-typescript": ^8.2.1
-    "@sendbird/chat": ^4.2.3
+    "@sendbird/chat": ^4.3.0
     "@storybook/addon-actions": ^6.5.10
     "@storybook/addon-docs": ^6.5.10
     "@storybook/addon-links": ^6.5.10


### PR DESCRIPTION
From: https://github.com/sendbird/sendbird-uikit-react/pull/500#issuecomment-1521620718
@bang9 Thanks for catching

Description
* To support the muted participants in the participant list of OpenChannel, the Chat SDK version ^3.4.0 is required