### PR TITLE
fix: Change the max mention count notice message

### DIFF
--- a/src/ui/Label/stringSet.js
+++ b/src/ui/Label/stringSet.js
@@ -187,7 +187,7 @@ const getStringSet = (lang = 'en') => {
       THREAD__INPUT__REPLY_IN_THREAD: 'Reply in thread',
       // Feature - Mention
       MENTION_NAME__NO_NAME: '(No name)',
-      MENTION_COUNT__OVER_LIMIT: 'You can mention up to %d times per message.',
+      MENTION_COUNT__OVER_LIMIT: 'You can mention up to %d times at a time.',
       UI__FILE_VIEWER__UNSUPPORT: 'Unsupported message',
       // Feature - Voice Message
       VOICE_MESSAGE: 'Voice Message',


### PR DESCRIPTION
### Description Of Changes

* Change the max mention count notice message
  * from: `'You can mention up to %d times per message.'`
  * to: `'You can mention up to %d times at a time.'`

[QM-1466](https://sendbird.atlassian.net/browse/QM-1466)


[QM-1466]: https://sendbird.atlassian.net/browse/QM-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ