### PR TITLE
chore: modify jest config to get exact coverage value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist
 .rpt2_cache
 release
 
+# test
+/coverage
+
 # misc
 .vscode
 .DS_Store

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,15 +21,17 @@ module.exports = {
   // collectCoverage: false,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  collectCoverageFrom: ['src/**/*.[jt]s?(x)'],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: undefined,
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "/_externals/",
+    "/stories/"
+  ],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -40,7 +42,7 @@ module.exports = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: undefined,
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "test": "jest",
     "test-update-snapshot": "jest -u",
+    "test:coverage": "yarn run test --coverage",
     "afterbuild": "node ./scripts/post_build.js;",
     "cp-css": "./scripts/copy-css.sh",
     "clean-release": "rm -rf ./release; rm -rf ./dist",


### PR DESCRIPTION
### Description Of Changes
[UIKIT-3775](https://sendbird.atlassian.net/browse/UIKIT-3775)

Probably we will get more exact coverage value \w https://github.com/sendbird/sendbird-uikit-react/pull/461 once it's merged I guess. Until then, I just wanna have another way to get this \w one line command. 



[UIKIT-3775]: https://sendbird.atlassian.net/browse/UIKIT-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ