### PR TITLE
fix: modify url regex to filter

### DIFF
--- a/src/utils/__tests__/utils.spec.js
+++ b/src/utils/__tests__/utils.spec.js
@@ -1,4 +1,4 @@
-import { binarySearch } from '../index';
+import { binarySearch, isUrl } from '../index';
 
 describe('Global-utils', () => {
   it('should find right index with binarySearch', () => {
@@ -14,6 +14,48 @@ describe('Global-utils', () => {
       expect(targetIndex).toEqual(index);
       const targetIndexPlusOne = binarySearch(criterionArray, value + 1);
       expect(targetIndexPlusOne).toEqual(index);
+    });
+  });
+});
+
+describe('isURL', () => {
+  it('should return true for valid URLs', () => {
+    const validURLs = [
+      // with protocol
+      'http://www.example.com',
+      'https://www.example.com',
+      'http://example.com',
+      'https://example.com',
+      // without protocol
+      'www.example.com',
+      'example.com',
+      // with sub paths
+      'http://www.example.com/path/to/page.html',
+      'https://www.example.com/path/to/page.html',
+      'http://example.com/path/to/page.html',
+      'https://example.com/path/to/page.html',
+      'www.example.com/path/to/page.html',
+      'example.com/path/to/page.html',
+      // with query strings
+      'http://www.example.com/path/to/page.html?query=string',
+      'https://www.example.com/path/to/page.html?query=string',
+      'http://example.com/path/to/page.html?query=string',
+      'https://example.com/path/to/page.html?query=string',
+      'www.example.com/path/to/page.html?query=string',
+      'example.com/path/to/page.html?query=string',
+    ]
+    validURLs.forEach((url) => {
+      expect(isUrl(url)).toBe(true);
+    });
+  });
+  it('should return false for invalid URLs', () => {
+    const invalidURLs = [
+      'aaa',
+      '$123.123',
+      'aaa@sendbird.com',
+    ]
+    invalidURLs.forEach((url) => {
+      expect(isUrl(url)).toBe(false);
     });
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -258,8 +258,9 @@ export const isMessageSentByMe = (userId: string, message: UserMessage | FileMes
   (userId && message?.sender?.userId) && userId === message.sender.userId
 );
 
-const URL_REG = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+const URL_REG = /^((http|https):\/\/)?([a-z\d]+\.)+[a-z]{2,6}(\:[0-9]{1,5})?(\/[-a-zA-Z\d%_.~+]*)*(\?[;&a-zA-Z\d%_.~+=-]*)?(\#[-a-zA-Z\d_]*)?$/;
 export const isUrl = (text: string): boolean => URL_REG.test(text);
+
 const MENTION_TAG_REG = /\@\{.*?\}/i;
 export const isMentionedText = (text: string): boolean => MENTION_TAG_REG.test(text);
 


### PR DESCRIPTION
### Description Of Changes
Resolves [UIKIT-3707](https://sendbird.atlassian.net/browse/UIKIT-3707)

**AS-IS**
A string \w $ sign(e.g. `$123.12`) or @ sign(e.g.`team_engineering@inkle.io`) created unnecessary underline with link
![before](https://user-images.githubusercontent.com/10060731/234905778-af84da0f-0ae7-4ed0-a6b3-89adb0264bf4.gif)

**TO-BE**

![after](https://user-images.githubusercontent.com/10060731/234905878-c012fa1d-8424-4a27-ad43-2137b68b7f02.gif)




[UIKIT-3707]: https://sendbird.atlassian.net/browse/UIKIT-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ