### PR TITLE
fix: give left-margin to the link text

### DIFF
--- a/src/ui/Word/index.scss
+++ b/src/ui/Word/index.scss
@@ -5,7 +5,7 @@
   height: fit-content;
   .sendbird-word__url,
   .sendbird-word__normal {
-    margin-right: 4px;
+    margin: 0 4px;
     display: inline-block;
     color: inherit;
   }


### PR DESCRIPTION
### Description Of Changes

Resolves [UIKIT-3722](https://sendbird.atlassian.net/browse/UIKIT-3722)

#### AS-IS
<img width="332" alt="Screenshot 2023-04-28 at 1 53 59 PM" src="https://user-images.githubusercontent.com/10060731/235057857-abdd2761-8255-4037-8ac0-3200415279e2.png">

#### TO-BE
<img width="322" alt="Screenshot 2023-04-28 at 1 53 27 PM" src="https://user-images.githubusercontent.com/10060731/235057871-a8b4dbee-57e7-4416-b3b5-42d665ed2d68.png">


[UIKIT-3722]: https://sendbird.atlassian.net/browse/UIKIT-3722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ