### PR TITLE
fix: remove lookbehind pattern in getWhiteSpacePreservedText

### DIFF
--- a/src/smart-components/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
+++ b/src/smart-components/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
@@ -107,11 +107,11 @@ describe('getWhiteSpacePreservedText', () => {
   it('should keep the leading and trailing white spaces', () => {
     const text = ' aaa ';
     const result = getWhiteSpacePreservedText(text);
-    expect(result).toEqual(' aaa\u00A0');
+    expect(result).toEqual('\u00A0aaa\u00A0');
   });
   it('should keep the new lines', () => {
     const text = ' aaa\naa';
     const result = getWhiteSpacePreservedText(text);
-    expect(result).toEqual(' aaa\naa');
+    expect(result).toEqual('\u00A0aaa\naa');
   });
 });

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -108,7 +108,5 @@ export function getWhiteSpacePreservedText(text: string): string {
   return text
     // convert any space or tab into the non-breaking space
     // to preserve the leading & trailing white spaces
-    .replace(/(?<!^)[ \t]+/g, '\u00A0')
-    // and keep the new line as well
-    .replace(/\n/g, '\n');
+    .replace(/([ \t]+)/g, (_, spaces) => '\u00A0'.repeat(spaces.length))
 }

--- a/src/smart-components/Message/utils/tokens/tokenize.ts
+++ b/src/smart-components/Message/utils/tokens/tokenize.ts
@@ -100,8 +100,8 @@ export function tokenizeMessage({
 }
 
 /**
- * To preserve the original text which has
- * leading & trailing white spaces & new-lines in the middle
+ * Don't need to use this util in DOM element since the white spaces will be kept as is,
+ * but will need if the text is wrapped \w React.Fragement or </>
  * @link https://sendbird.slack.com/archives/GPGHESTL3/p1681180484341369
  */
 export function getWhiteSpacePreservedText(text: string): string {


### PR DESCRIPTION
### Description Of Changes
Resolves [UIKIT-3792](https://sendbird.atlassian.net/browse/UIKIT-3792)

Regex lookbehind pattern doesnt work on safari
See: https://caniuse.com/js-regexp-lookbehind
https://stackoverflow.com/a/51568859

After this patch uikit works on safari

[UIKIT-3792]: https://sendbird.atlassian.net/browse/UIKIT-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ