### PR TITLE
hotfix: Separate exporting components and types

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -2472,7 +2472,7 @@ declare module '@sendbird/uikit-react/ui/ThumbnailMessageItemBody' {
 
 declare module '@sendbird/uikit-react/ui/Toggle' {
   export interface ToggleContextInterface {
-    checked?: boolean;
+    checked?: boolean | null;
     defaultChecked?: boolean;
     disabled?: boolean;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
@@ -2480,7 +2480,7 @@ declare module '@sendbird/uikit-react/ui/Toggle' {
     onBlur?: React.ChangeEventHandler<HTMLInputElement>;
   }
   export interface ToggleContainerProps extends ToggleContextInterface {
-    children?: React.ReactElement;
+    children?: React.ReactElement | null;
   }
   export interface ToggleUIProps {
     reversed?: boolean;

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -2480,7 +2480,7 @@ declare module '@sendbird/uikit-react/ui/Toggle' {
     onBlur?: React.ChangeEventHandler<HTMLInputElement>;
   }
   export interface ToggleContainerProps extends ToggleContextInterface {
-    children?: React.ReactElement | null;
+    children?: React.ReactElement;
   }
   export interface ToggleUIProps {
     reversed?: boolean;

--- a/src/ui/Toggle/ToggleContainer.tsx
+++ b/src/ui/Toggle/ToggleContainer.tsx
@@ -7,7 +7,7 @@ import {
 } from './ToggleContext';
 
 export interface ToggleContainerProps extends ToggleContextInterface {
-  children?: React.ReactElement;
+  children?: React.ReactElement | null;
 }
 
 // Props Explanation https://github.com/aaronshaf/react-toggle#props

--- a/src/ui/Toggle/ToggleContainer.tsx
+++ b/src/ui/Toggle/ToggleContainer.tsx
@@ -7,7 +7,7 @@ import {
 } from './ToggleContext';
 
 export interface ToggleContainerProps extends ToggleContextInterface {
-  children?: React.ReactElement | null;
+  children?: React.ReactElement;
 }
 
 // Props Explanation https://github.com/aaronshaf/react-toggle#props
@@ -18,7 +18,7 @@ export function ToggleContainer({
   onChange = Dvalue.onChange,
   onFocus = Dvalue.onFocus,
   onBlur = Dvalue.onBlur,
-  children = null,
+  children,
 }: ToggleContainerProps): React.ReactElement {
   const [isChecked, setChecked] = useState(defaultChecked || false);
   const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/Toggle/ToggleContext.ts
+++ b/src/ui/Toggle/ToggleContext.ts
@@ -16,7 +16,7 @@ export const TOGGLE_DEFAULT_VALUE = {
 };
 
 export interface ToggleContextInterface {
-  checked?: boolean;
+  checked?: boolean | null;
   defaultChecked?: boolean;
   disabled?: boolean;
   onChange?: ChangeEventHandler<HTMLInputElement>;

--- a/src/ui/Toggle/index.tsx
+++ b/src/ui/Toggle/index.tsx
@@ -54,4 +54,5 @@ function Toggle(props: ToggleProps): React.ReactElement {
   );
 }
 
-export { Toggle, ToggleContainer, ToggleContainerProps, ToggleUI, ToggleUIProps, useToggleContext };
+export type { ToggleContainerProps, ToggleUIProps };
+export { Toggle, ToggleContainer, ToggleUI, useToggleContext };


### PR DESCRIPTION
Fix the build error issue 
> [!] Error: 'ToggleContainerProps' is not exported by src/ui/Toggle/ToggleContainer.tsx, imported by src/ui/Toggle/index.tsx