### PR TITLE
fix: Active channel url causes flicker of current channel on the channel list

### DIFF
--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
 
 import type { AppLayoutProps } from './types';
@@ -18,9 +19,8 @@ export const AppLayout: React.FC<AppLayoutProps> = (
     showSearchIcon,
     onProfileEditSuccess,
     disableAutoSelect,
-    currentChannel,
-    setCurrentChannel,
   } = props;
+  const [currentChannel, setCurrentChannel] = useState<GroupChannel | null>(null);
   const [showThread, setShowThread] = useState(false);
   const [threadTargetMessage, setThreadTargetMessage] = useState<UserMessage | FileMessage>(null);
   const [showSettings, setShowSettings] = useState(false);

--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
 
 import type { AppLayoutProps } from './types';
@@ -19,8 +18,9 @@ export const AppLayout: React.FC<AppLayoutProps> = (
     showSearchIcon,
     onProfileEditSuccess,
     disableAutoSelect,
+    currentChannel,
+    setCurrentChannel,
   } = props;
-  const [currentChannel, setCurrentChannel] = useState<GroupChannel | null>(null);
   const [showThread, setShowThread] = useState(false);
   const [threadTargetMessage, setThreadTargetMessage] = useState<UserMessage | FileMessage>(null);
   const [showSettings, setShowSettings] = useState(false);

--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -107,7 +107,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
           <div className='sb_mobile__panelwrap'>
             <Channel
               replyType={replyType}
-              channelUrl={currentChannel?.url}
+              channelUrl={currentChannel?.url || ''}
               onSearchClick={() => {
                 setPanel(PANELS.MESSAGE_SEARCH);
               }}
@@ -130,7 +130,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
         panel === PANELS?.CHANNEL_SETTINGS && (
           <div className='sb_mobile__panelwrap'>
             <ChannelSettings
-              channelUrl={currentChannel?.url}
+              channelUrl={currentChannel?.url || ''}
               onCloseClick={() => {
                 setPanel(PANELS.CHANNEL);
               }}
@@ -145,7 +145,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
         panel === PANELS?.MESSAGE_SEARCH && (
           <div className='sb_mobile__panelwrap'>
             <MessageSearch
-              channelUrl={currentChannel?.url}
+              channelUrl={currentChannel?.url || ''}
               onCloseClick={() => {
                 setPanel(PANELS.CHANNEL);
               }}

--- a/src/modules/App/index.jsx
+++ b/src/modules/App/index.jsx
@@ -3,7 +3,7 @@
  * Can also be used as an example for creating
  * default chat apps
  */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Sendbird from '../../lib/Sendbird';
@@ -46,6 +46,7 @@ export default function App(props) {
     isTypingIndicatorEnabledOnChannelList,
     isMessageReceiptStatusEnabledOnChannelList,
   } = props;
+  const [currentChannel, setCurrentChannel] = useState(null);
   return (
     <Sendbird
       stringSet={stringSet}
@@ -85,6 +86,8 @@ export default function App(props) {
         showSearchIcon={showSearchIcon}
         onProfileEditSuccess={onProfileEditSuccess}
         disableAutoSelect={disableAutoSelect}
+        currentChannel={currentChannel}
+        setCurrentChannel={setCurrentChannel}
       />
     </Sendbird>
   );

--- a/src/modules/App/index.jsx
+++ b/src/modules/App/index.jsx
@@ -3,7 +3,7 @@
  * Can also be used as an example for creating
  * default chat apps
  */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import Sendbird from '../../lib/Sendbird';
@@ -46,7 +46,6 @@ export default function App(props) {
     isTypingIndicatorEnabledOnChannelList,
     isMessageReceiptStatusEnabledOnChannelList,
   } = props;
-  const [currentChannel, setCurrentChannel] = useState(null);
   return (
     <Sendbird
       stringSet={stringSet}
@@ -79,8 +78,6 @@ export default function App(props) {
       replyType={replyType}
     >
       <AppLayout
-        currentChannel={currentChannel}
-        setCurrentChannel={setCurrentChannel}
         isReactionEnabled={isReactionEnabled}
         replyType={replyType}
         isMessageGroupingEnabled={isMessageGroupingEnabled}

--- a/src/modules/App/types.ts
+++ b/src/modules/App/types.ts
@@ -19,21 +19,18 @@ export interface AppLayoutProps {
   showSearchIcon?: boolean;
   onProfileEditSuccess?(user: User): void;
   disableAutoSelect?: boolean;
+  currentChannel?: GroupChannel;
+  setCurrentChannel: React.Dispatch<GroupChannel>;
 }
 
-interface CommontLayoutProps {
-  currentChannel?: GroupChannel | null;
-  setCurrentChannel?: React.Dispatch<GroupChannel>;
-}
-
-export interface MobileLayoutProps extends AppLayoutProps, CommontLayoutProps {
+export interface MobileLayoutProps extends AppLayoutProps {
   highlightedMessage?: number;
   setHighlightedMessage?: React.Dispatch<number>;
   startingPoint?: number;
   setStartingPoint?: React.Dispatch<number>;
 }
 
-export interface DesktopLayoutProps extends AppLayoutProps, CommontLayoutProps {
+export interface DesktopLayoutProps extends AppLayoutProps {
   showSettings: boolean;
   setShowSettings: React.Dispatch<boolean>;
   showSearch: boolean;

--- a/src/modules/App/types.ts
+++ b/src/modules/App/types.ts
@@ -1,5 +1,5 @@
 import type { User } from '@sendbird/chat';
-import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
 
 import type { Locale } from 'date-fns';
@@ -19,18 +19,21 @@ export interface AppLayoutProps {
   showSearchIcon?: boolean;
   onProfileEditSuccess?(user: User): void;
   disableAutoSelect?: boolean;
-  currentChannel?: GroupChannel;
+}
+
+interface CommontLayoutProps {
+  currentChannel?: GroupChannel | null;
   setCurrentChannel?: React.Dispatch<GroupChannel>;
 }
 
-export interface MobileLayoutProps extends AppLayoutProps {
+export interface MobileLayoutProps extends AppLayoutProps, CommontLayoutProps {
   highlightedMessage?: number;
   setHighlightedMessage?: React.Dispatch<number>;
   startingPoint?: number;
   setStartingPoint?: React.Dispatch<number>;
 }
 
-export interface DesktopLayoutProps extends AppLayoutProps {
+export interface DesktopLayoutProps extends AppLayoutProps, CommontLayoutProps {
   showSettings: boolean;
   setShowSettings: React.Dispatch<boolean>;
   showSearch: boolean;

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -81,7 +81,7 @@ export interface ChannelListProviderProps {
   overrideInviteUser?(params: OverrideInviteUserType): void;
   onThemeChange?(theme: string): void;
   onProfileEditSuccess?(user: User): void;
-  onChannelSelect?(channel: GroupChannel): void;
+  onChannelSelect?(channel: GroupChannel | null): void;
   sortChannelList?: (channels: GroupChannel[]) => GroupChannel[];
   queries?: ChannelListQueries;
   children?: React.ReactElement;
@@ -104,7 +104,7 @@ export interface ChannelListProviderInterface extends ChannelListProviderProps {
   channelListQuery: GroupChannelListQuery;
   currentUserId: string;
   channelListDispatcher: CustomUseReducerDispatcher;
-  channelSource: GroupChannelListQuerySb;
+  channelSource: GroupChannelListQuerySb | null;
 }
 
 interface ChannelListStoreInterface {
@@ -188,12 +188,12 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
     channelListReducers,
     channelListInitialState,
   ) as [ChannelListStoreInterface, CustomUseReducerDispatcher];
-  const { loading, currentChannel } = channelListStore;
+  const { currentChannel } = channelListStore;
 
-  const [channelSource, setChannelSource] = useState<GroupChannelListQuerySb>();
+  const [channelSource, setChannelSource] = useState<GroupChannelListQuerySb | null>(null);
   const [typingChannels, setTypingChannels] = useState<Array<GroupChannel>>([]);
 
-  const [channelsTomarkAsRead, setChannelsToMarkAsRead] = useState([]);
+  const [channelsTomarkAsRead, setChannelsToMarkAsRead] = useState<Array<GroupChannel>>([]);
   useEffect(() => {
     // https://stackoverflow.com/a/60907638
     let isMounted = true;
@@ -378,7 +378,6 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
       overrideInviteUser,
       onChannelSelect,
       sortChannelList,
-      loading,
       allowProfileEdit: enableEditProfile,
       channelListDispatcher,
       channelSource,

--- a/src/modules/ChannelList/context/hooks/useActiveChannelUrl.ts
+++ b/src/modules/ChannelList/context/hooks/useActiveChannelUrl.ts
@@ -25,7 +25,7 @@ function useActiveChannelUrl({
   return useEffect(() => {
     if (activeChannelUrl) {
       logger.info('ChannelListProvider: looking for active channel', { activeChannelUrl });
-      const activeChannel = channels.find(channel => channel.url === activeChannelUrl);
+      const activeChannel = channels?.find(channel => channel.url === activeChannelUrl);
       if (activeChannel) {
         channelListDispatcher({
           type: messageActionTypes.SET_CURRENT_CHANNEL,
@@ -49,7 +49,7 @@ function useActiveChannelUrl({
           });
       }
     }
-  }, [activeChannelUrl, channels, sdk]);
+  }, [activeChannelUrl]);
 }
 
 export default useActiveChannelUrl;


### PR DESCRIPTION
### Description Of Changes

Issue 
* The activated channel flickers between the previous current channel and a new channel after creating the new group channel
* Infinite loop
  * (1) `Creating a channel` causes the change of the channel list
  * (2) `useActiveChannelUrl` is triggered by the channel list change
  * (3) `useActiveChannelUrl` set the current channel to the previous channel

Fix
* Remove the channel list dependency from the `useEffect` of useActiveChannelUrl to fix the current channel flickers on the channel list