### PR TITLE
fix: Add types of GroupChat and OpenChat for SendbirdChat

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -5,7 +5,6 @@
  */
 declare module "SendbirdUIKitGlobal" {
   import type React from 'react';
-  import type Locale from 'date-fns';
   import type SendbirdChat from '@sendbird/chat';
   import type {
     SendbirdError,
@@ -148,7 +147,7 @@ declare module "SendbirdUIKitGlobal" {
   export type EveryMessage = ClientUserMessage | ClientFileMessage | ClientAdminMessage;
   export type ClientSentMessages = ClientUserMessage | ClientFileMessage;
 
-  export type GetSdk = SendbirdChat | undefined;
+  export type GetSdk = SendbirdChat | SendbirdGroupChat | SendbirdOpenChat | undefined;
   export type GetConnect = (
     userId: string,
     accessToken?: string
@@ -229,7 +228,7 @@ declare module "SendbirdUIKitGlobal" {
     userId: string;
     appId: string;
     accessToken?: string;
-    configureSession?: (sdk: SendbirdChat) => SessionHandler;
+    configureSession?: (sdk: SendbirdChat | SendbirdGroupChat | SendbirdOpenChat) => SessionHandler;
     customApiHost?: string,
     customWebSocketHost?: string,
     children?: React.ReactElement;

--- a/src/lib/hooks/useConnect/types.ts
+++ b/src/lib/hooks/useConnect/types.ts
@@ -1,4 +1,6 @@
 import SendbirdChat, { SessionHandler } from '@sendbird/chat';
+import { SendbirdGroupChat } from '@sendbird/chat/groupChannel';
+import { SendbirdOpenChat } from '@sendbird/chat/openChannel';
 
 import { SdkActionTypes } from '../../dux/sdk/actionTypes';
 import { UserActionTypes } from '../../dux/user/actionTypes';
@@ -14,7 +16,7 @@ export type TriggerTypes = {
   accessToken?: string;
 }
 
-export type ConfigureSessionTypes = (sdk: SendbirdChat) => SessionHandler;
+export type ConfigureSessionTypes = (sdk: SendbirdChat | SendbirdGroupChat | SendbirdOpenChat) => SessionHandler;
 
 export type StaticTypes = {
   nickname: string;


### PR DESCRIPTION
### Description Of Changes

Issue
* Customer had to use the type assertion for removing type error
```javascript
const globalState = useSendbirdStateContext()
const getSdk = sendbirdSelectors.getSdk(globalState) as SendbirdGroupChat;
getSdk.groupChannel.getTotalUnreadMessageCount();
```

Fix
* Specify the `getSdk` returns SendbirdGroupChat or SendbirdOpenChat