### PR TITLE
chore: enable no-floating-decimal eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,6 @@
       }
     ],
     // TODO(Ahyoung): fix and remove one by one
-    "no-floating-decimal": "off",
     "no-shadow": "off",
     "no-useless-return": "off",
     "no-else-return": "off",

--- a/src/modules/CreateChannel/components/InviteUsers/index.tsx
+++ b/src/modules/CreateChannel/components/InviteUsers/index.tsx
@@ -29,7 +29,7 @@ export interface InviteUsersProps {
 const appHeight = () => {
   try {
     const doc = document.documentElement;
-    doc.style.setProperty('--sendbird-vh', (window.innerHeight * .01) + 'px');
+    doc.style.setProperty('--sendbird-vh', (window.innerHeight * 0.01) + 'px');
   } catch {
     //
   }


### PR DESCRIPTION
### Description Of Changes
Part of https://sendbird.atlassian.net/browse/UIKIT-3837

Enabled [no-floating-decimal](https://eslint.org/docs/latest/rules/no-floating-decimal#rule-details) rule off-ed by https://github.com/sendbird/sendbird-uikit-react/pull/490 previously.