### PR TITLE
fix: incorrect prop passing in ChannelSetting component

### DIFF
--- a/src/modules/ChannelSettings/index.tsx
+++ b/src/modules/ChannelSettings/index.tsx
@@ -23,7 +23,7 @@ const ChannelSettings: React.FC<ChannelSettingsProps> = (props: ChannelSettingsP
       queries={props?.queries}
       className={props?.className}
       disableUserProfile={props?.disableUserProfile}
-      renderUserProfile={props?.renderChannelProfile}
+      renderUserProfile={props?.renderUserProfile}
     >
       <ChannelSettingsUI
         renderPlaceholderError={props?.renderPlaceholderError}


### PR DESCRIPTION
### Description Of Changes

Resolves https://sendbird.atlassian.net/browse/UIKIT-3832
Just replaced a incorrect prop passing `renderChannelProfile` -> `renderUserProfile` 