### PR TITLE
feat: run yarn install only when pkg.json has changes

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-# Install dependencies
-yarn install
+# Run yarn install only when package.json has been changed
+if git diff-tree --name-only --no-commit-id ORIG_HEAD HEAD | grep 'package.json'; then
+  echo "package.json has been changed, running yarn install..."
+  yarn install
+fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Run yarn install only when package.json has been changed
-if git diff-tree --name-only --no-commit-id ORIG_HEAD HEAD | grep 'package.json'; then
-  echo "package.json has been changed, running yarn install..."
+declare -a FILES=("package.json" "yarn.lock" ".yarn/")
+
+# Run yarn install only when there's any change in the above listed files
+if git diff-tree --name-only --no-commit-id ORIG_HEAD HEAD | grep -E $(IFS="|" ; echo "${FILES[*]}"); then
+  echo "package.json or yarn config has been changed, running yarn install..."
   yarn install
 fi


### PR DESCRIPTION
### Description Of Changes
Running yarn install on every git pull would be unnecessary. So I added a condition in post-merge hook to check if package.json has been changed. 

https://sendbird.slack.com/archives/C050Z6DA70A/p1683788237121899?thread_ts=1683787988.006319&cid=C050Z6DA70A 