### PR TITLE
fix: prevent white space only text sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@svgr/webpack": "^5.1.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "autoprefixer": "^9.7.4",

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -59,7 +59,7 @@ describe('ui/MessageInput', () => {
     expect(input.textContent).toBe(mockText);
 
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onSendMessage).toHaveBeenCalled();
+    expect(onSendMessage).toHaveBeenCalledWith({ mentionTemplate: mockText, message: mockText });
   });
 
   it('should call sendMessage with valid string; new lines included', async () => {
@@ -74,7 +74,7 @@ describe('ui/MessageInput', () => {
     expect(input.textContent).toBe(mockText);
 
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onSendMessage).toHaveBeenCalled();
+    expect(onSendMessage).toHaveBeenCalledWith({ mentionTemplate: mockText, message: mockText });
   });
 
   it('should not call sendMessage with invalid string; only white spaces', async() => {
@@ -89,7 +89,7 @@ describe('ui/MessageInput', () => {
     expect(input.textContent).toBe(mockText);
 
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(onSendMessage).not.toHaveBeenCalledWith({ mentionTemplate: mockText, message: mockText });
   });
   
   it('should render send icon if text is present', async() => {

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen,fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import MessageInput from "../index";
 
@@ -45,28 +46,75 @@ describe('ui/MessageInput', () => {
     ).toBe(0);
   });
 
-  it.skip('should render send icon if text is present', () => {
-    const component = shallow(
-      <MessageInput
-        onSendMessage={noop}
-        message={{
-          message: 'hello',
-          mentionedMessageTempalte: 'hello'
-        }}
-      />
-    );
+  it('should call sendMessage with valid string', async () => {
+    const onSendMessage = jest.fn();
+    const textRef = { current: { innerText: null } };
+    const mockText = 'Test Value';
+
+    render(<MessageInput onSendMessage={onSendMessage} ref={textRef} />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, mockText);
+    expect(input.textContent).toBe(mockText);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSendMessage).toHaveBeenCalled();
+  });
+
+  it('should call sendMessage with valid string; new lines included', async () => {
+    const onSendMessage = jest.fn();
+    const textRef = { current: { innerText: null } };
+    const mockText = '        \nTest Value     \n';
+
+    render(<MessageInput onSendMessage={onSendMessage} ref={textRef} />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, mockText);
+    expect(input.textContent).toBe(mockText);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSendMessage).toHaveBeenCalled();
+  });
+
+  it('should not call sendMessage with invalid string; only white spaces', async() => {
+    const onSendMessage = jest.fn();
+    const textRef = { current: { innerText: null } };
+    const mockText = '    ';
+
+    render(<MessageInput onSendMessage={onSendMessage} ref={textRef} />);
+    
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, mockText);
+    expect(input.textContent).toBe(mockText);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+  
+  it('should render send icon if text is present', async() => {
+    const onSendMessage = jest.fn();
+    const textRef = { current: { innerText: null } };
+    const mockText = 'hello';
+
+    const { container } = render(<MessageInput onSendMessage={onSendMessage} ref={textRef} />);
+    
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, mockText);
+    expect(input.textContent).toBe(mockText);
+
     expect(
-      component.find('#sendbird-message-input-text-field').exists()
-    ).toBe(true);
+      container.getElementsByClassName('sendbird-message-input-text-field').length
+    ).toBe(1);
     expect(
-      component.find('.sendbird-message-input--send').exists()
-    ).toBe(true);
+      container.getElementsByClassName('sendbird-message-input--send').length
+    ).toBe(1);
     expect(
-      component.find('.sendbird-message-input--attach').exists()
-    ).toBe(false);
+      container.getElementsByClassName('sendbird-message-input--attach').length
+    ).toBe(0);
     expect(
-      component.find('.sendbird-message-input--edit-action').exists()
-    ).toBe(false);
+      container.getElementsByClassName('sendbird-message-input--edit-action').length
+    ).toBe(0);
   });
 
   it('should display save/cancel button on edit mode', () => {

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -137,7 +137,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       //
     }
     setMentionedUserIds([]);
-    setIsInput(textField?.innerText?.trim().length > 0);
+    setIsInput(textField?.textContent?.trim().length > 0);
     setHeight();
   }, [initialValue]);
 
@@ -184,7 +184,7 @@ const MessageInput = React.forwardRef((props, ref) => {
         }
         setMentionedUserIds([]);
       }
-      setIsInput(textField?.innerText?.trim().length > 0);
+      setIsInput(textField?.textContent?.trim().length > 0);
       setHeight();
     }
   }, [isEdit, message]);
@@ -199,7 +199,7 @@ const MessageInput = React.forwardRef((props, ref) => {
         setMentionedUserIds(newMentionedUserIds);
       }
     }
-    setIsInput(textField.innerText.trim().length > 0);
+    setIsInput(textField.textContent?.trim().length > 0);
   }, [targetStringInfo, isMentionEnabled]);
 
   // #Mention | Replace selected user nickname to the MentionedUserLabel
@@ -325,7 +325,7 @@ const MessageInput = React.forwardRef((props, ref) => {
 
   const sendMessage = () => {
     const textField = ref?.current;
-    if (!isEdit && textField?.innerText) {
+    if (!isEdit && textField?.textContent) {
       let messageText = '';
       let mentionTemplate = '';
       textField.childNodes.forEach((node) => {
@@ -355,7 +355,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       setHeight();
     }
   };
-  const isEditDisabled = !(ref?.current?.innerText?.trim());
+  const isEditDisabled = !(ref?.current?.textContent?.trim());
   const editMessage = () => {
     const textField = ref?.current;
     const messageId = message?.messageId;
@@ -420,6 +420,7 @@ const MessageInput = React.forwardRef((props, ref) => {
               e.preventDefault();
             } else {
               if (!e.shiftKey && e.key === MessageInputKeys.Enter
+                && textField?.textContent?.trim().length > 0
                 && e?.nativeEvent?.isComposing !== true
               ) {
                 e.preventDefault();
@@ -448,7 +449,7 @@ const MessageInput = React.forwardRef((props, ref) => {
           onInput={() => {
             setHeight();
             onStartTyping();
-            setIsInput(textField.innerText?.trim().length > 0);
+            setIsInput(textField?.textContent?.trim().length > 0);
             useMentionedLabelDetection();
           }}
           onPaste={onPaste}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,6 +2471,7 @@ __metadata:
     "@svgr/webpack": ^5.1.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^13.4.0
+    "@testing-library/user-event": ^14.4.3
     "@typescript-eslint/eslint-plugin": ^5.59.2
     "@typescript-eslint/parser": ^5.59.2
     autoprefixer: ^9.7.4
@@ -3730,6 +3731,15 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: 51ec548c1fdb1271089a5c63e0908f0166f2c7fcd9cacd3108ebbe0ce64cb4351812d885892020dc37608418cfb15698514856502b3cab0e5cc58d6cc1bd4a3e
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.4.3":
+  version: 14.4.3
+  resolution: "@testing-library/user-event@npm:14.4.3"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 852c48ea6db1c9471b18276617c84fec4320771e466cd58339a732ca3fd73ad35e5a43ae14f51af51a8d0a150dcf60fcaab049ef367871207bea8f92c4b8195e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description Of Changes
Resolves https://sendbird.atlassian.net/browse/UIKIT-3869

Previously, even I made the send btn invisible when there's only empty spaces(+ new lines) in the input field, but still the empty white spaces could be sent by hitting an enter button 😅

So I made a fix to block sending like below (see what I'm pressing)
![recording](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/3fa7b3ce-ba94-44db-82f7-7562ac6a3a71)



Plus I added more unit tests to prevent any further mistakes. 


