### PR TITLE
feat: Setup CircleCI for lint and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - uikit-yarn-dependencies-{{ checksum "yarn.lock" }}{{ checksum "package.json" }}
+            - uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn install --immutable
       - command-lint
       - command-test
       - save_cache:
-          key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}{{ checksum "package.json" }}
+          key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - ./.yarn/cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+commands:
+  command-build_and_test:
+    steps:
+      - run:
+          name: UIKit for React build and test
+          command: |
+            npm install
+            npm run build
+            npm test
+          no_output_timeout: 30m
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  job-build_and_test:
+    docker:
+      - image: cimg/python:3.11.2-node
+    steps:
+      - checkout
+      - run: node --version
+      - add_ssh_keys:
+          fingerprints:
+            - "1a:44:ff:cc:11:16:9c:28:f3:9b:c2:ec:47:85:d0:46"
+      - command-build_and_test
+      
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  built-and-test:
+    jobs:
+      - job-build_and_test:
+          filters:
+            branches:
+              ignore:
+                - main
+                - develop-v3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,17 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@stable --activate
       - run: yarn --version
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn install --immutable
       - command-lint
       - command-test
       - save_cache:
           key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
+            - ./.yarn/cache
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,18 +20,15 @@ jobs:
   job-lint_and_test:
     docker:
       - image: cimg/node:16.19.1
+    parallelism: 4
+    resource_class: large
     steps:
       - checkout
       - run: node --version
       - run: corepack enable
       - run: corepack prepare yarn@stable --activate
       - run: yarn --version
-      - run: yarn install
-      # todo: cache node_modules
-      # - save_cache:
-      #   paths:
-      #       - node_modules
-      #   key: yarn-deps-{{ checksum "yarn.lock" }}-{{ epoch }}
+      - run: yarn install --immutable
       - command-lint_and_test
 
 # Invoke jobs via workflows
@@ -39,9 +36,4 @@ jobs:
 workflows:
   built-and-test:
     jobs:
-      - job-lint_and_test:
-          filters:
-            branches:
-              ignore:
-                - main
-                - develop-v3
+      - job-lint_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,36 +3,43 @@
 version: 2.1
 
 commands:
-  command-build_and_test:
+  command-lint_and_test:
     steps:
       - run:
           name: UIKit for React build and test
           command: |
-            npm install
-            npm run build
-            npm test
+            yarn run eslint
+            yarn run eslint-ts
+            yarn run test
+
           no_output_timeout: 30m
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  job-build_and_test:
+  job-lint_and_test:
     docker:
-      - image: cimg/python:3.11.2-node
+      - image: cimg/node:16.19.1
     steps:
       - checkout
       - run: node --version
-      - add_ssh_keys:
-          fingerprints:
-            - "1a:44:ff:cc:11:16:9c:28:f3:9b:c2:ec:47:85:d0:46"
-      - command-build_and_test
-      
+      - run: corepack enable
+      - run: corepack prepare yarn@stable --activate
+      - run: yarn --version
+      - run: yarn install
+      # todo: cache node_modules
+      # - save_cache:
+      #   paths:
+      #       - node_modules
+      #   key: yarn-deps-{{ checksum "yarn.lock" }}-{{ epoch }}
+      - command-lint_and_test
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   built-and-test:
     jobs:
-      - job-build_and_test:
+      - job-lint_and_test:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ jobs:
       - run: yarn install --immutable
       - command-lint
       - command-test
+      - save_cache:
+          key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
+            - uikit-yarn-dependencies-{{ checksum "yarn.lock" }}{{ checksum "package.json" }}
       - run: yarn install --immutable
       - command-lint
       - command-test
       - save_cache:
-          key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
+          key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}{{ checksum "package.json" }}
           paths:
             - ./.yarn/cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,20 @@
 version: 2.1
 
 commands:
-  command-lint_and_test:
+  command-lint:
     steps:
       - run:
-          name: UIKit for React build and test
+          name: UIKit for React lint
           command: |
             yarn run eslint
             yarn run eslint-ts
-            yarn run test
-
-          no_output_timeout: 30m
+          no_output_timeout: 5m
+  command-test:
+    steps:
+      - run:
+          name: UIKit for React test
+          command: yarn run test
+          no_output_timeout: 15m
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -29,7 +33,8 @@ jobs:
       - run: corepack prepare yarn@stable --activate
       - run: yarn --version
       - run: yarn install --immutable
-      - command-lint_and_test
+      - command-lint
+      - command-test
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "global-jsdom": "^8.5.0",
     "husky": "^8.0.0",
-    "jest": "^29.0.1",
+    "jest": "29.5.0",
     "jest-environment-jsdom": "^29.0.1",
     "jest-extended": "^3.2.4",
     "jsdom": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "global-jsdom": "^8.5.0",
     "husky": "^8.0.0",
     "jest": "29.5.0",
-    "jest-environment-jsdom": "^29.0.1",
+    "jest-environment-jsdom": "29.5.0",
     "jest-extended": "^3.2.4",
     "jsdom": "^20.0.0",
     "np": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,7 @@ __metadata:
     global-jsdom: ^8.5.0
     husky: ^8.0.0
     jest: 29.5.0
-    jest-environment-jsdom: ^29.0.1
+    jest-environment-jsdom: 29.5.0
     jest-extended: ^3.2.4
     jsdom: ^20.0.0
     np: ^7.5.0
@@ -12052,7 +12052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-jsdom@npm:^29.0.1":
+"jest-environment-jsdom@npm:29.5.0":
   version: 29.5.0
   resolution: "jest-environment-jsdom@npm:29.5.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,7 +2494,7 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     global-jsdom: ^8.5.0
     husky: ^8.0.0
-    jest: ^29.0.1
+    jest: 29.5.0
     jest-environment-jsdom: ^29.0.1
     jest-extended: ^3.2.4
     jsdom: ^20.0.0
@@ -12452,7 +12452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.0.1":
+"jest@npm:29.5.0":
   version: 29.5.0
   resolution: "jest@npm:29.5.0"
   dependencies:


### PR DESCRIPTION
We have decided to use Circle CI as the main CI tool 
- Reduce cost from github
- Parity with other JS projects in the company

##### Changes

* Add circle CI
* Setup Lint, Test
* Update Jest minor version

#####  Todo/Seperate PR: 
* Remove GH-Action
* Setup coverage

[CORE-5381](https://sendbird.atlassian.net/browse/CORE-5381)


[CORE-5381]: https://sendbird.atlassian.net/browse/CORE-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ