### PR TITLE
fix: mentioned user Regex parsing

### DIFF
--- a/src/modules/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
+++ b/src/modules/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
@@ -18,6 +18,16 @@ describe('getUserMentionRegex', () => {
     const result = getUserMentionRegex(mentionedUsers, templatePrefix);
     expect(result).toEqual(/(@{1}|@{2})/g);
   });
+
+  it('should return a correct regex pattern; userId includes some patterns need to be escaped', () => {
+    const mentionedUsers = [
+      { userId: '1*', nickname: 'user1' },
+      { userId: '2+', nickname: 'user2' },
+    ] as User[];
+    const templatePrefix = '@';
+    const result = getUserMentionRegex(mentionedUsers, templatePrefix);
+    expect(result).toEqual(/(@{1\*}|@{2\+})/g);
+  });
 });
 
 describe('identifyMentions', () => {

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -5,7 +5,14 @@ import { isUrl } from '../../../../utils';
 
 export function getUserMentionRegex(mentionedUsers: User[], templatePrefix_: string): RegExp {
   const templatePrefix = templatePrefix_ || USER_MENTION_PREFIX;
-  return RegExp(`(${mentionedUsers.map(u => `${templatePrefix}{${u.userId}}`).join('|')})`, 'g');
+
+  return RegExp(`(${mentionedUsers.map(u => {
+    const userId = u.userId.replace(
+      // If user.id includes these patterns, need to convert it into an escaped one
+      /([.*+?^${}()|[\]\\])/g,
+      '\\$1');
+    return `${templatePrefix}{${userId}}`;
+  }).join('|')})`, 'g');
 }
 
 export function identifyMentions({
@@ -25,6 +32,7 @@ export function identifyMentions({
     }
     const { value } = token;
     const parts = value.split(userMentionRegex);
+
     const tokens = parts.map((part) => {
       if (part.match(userMentionRegex)) {
         const matchedUser = mentionedUsers.find((user) => `@{${user?.userId}}` === part);


### PR DESCRIPTION
### Description Of Changes
Fixes https://sendbird.atlassian.net/browse/UIKIT-3890

Currently, the mentioned user template is not working correctly if a userId includes some patterns need to be escaped in regex. So made a fix to make the parsed message token have escaped pattern if one of `.*+?^${}()|[\]\\` is detected. 