### PR TITLE
fix: Set minimum height of UserListItem of ReactedMembersBottomSheet

### DIFF
--- a/src/ui/MobileMenu/mobile-menu-reacted-members.scss
+++ b/src/ui/MobileMenu/mobile-menu-reacted-members.scss
@@ -34,4 +34,5 @@
 }
 .sendbird-message__bottomsheet__reactor-list__item.sendbird-user-list-item {
   border-bottom: 0px;
+  min-height: 48px;
 }


### PR DESCRIPTION
### Description Of Changes

Set the minimum height of UserListItem on the ReactedMembersBottomSheet
![image](https://github.com/sendbird/sendbird-uikit-react/assets/46333979/2e56f7f8-184c-497a-9122-d4c4c181bd7b)

[UIKIT-3995](https://sendbird.atlassian.net/browse/UIKIT-3995)


[UIKIT-3995]: https://sendbird.atlassian.net/browse/UIKIT-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ