### PR TITLE
fix: display a channel only when there's a msg

### DIFF
--- a/src/modules/ChannelList/utils.js
+++ b/src/modules/ChannelList/utils.js
@@ -38,7 +38,8 @@ const createEventHandler = ({
       logger.info('ChannelList: onUserReceivedInvitation', { channel, inviter, invitees });
       const { currentUser } = sdk;
       const isInvited = invitees.find((user) => user?.userId === currentUser?.userId);
-      if (isInvited) {
+      // The newly created channel should be displayed only when there's a message
+      if (isInvited && channel?.lastMessage) {
         channelListDispatcher({
           type: channelActions.USER_INVITED,
           payload: channel,


### PR DESCRIPTION
### Description Of Changes
Resolves https://sendbird.atlassian.net/browse/UIKIT-3969 

A newly created channel should be displayed on the invitee's channel list only when there's a message not right after the channel is created.