### PR TITLE
hotfix: Keep the scrollBottom value after fetching new message list

### DIFF
--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -33,6 +33,7 @@ type MessageUIProps = {
   chainTop?: boolean;
   chainBottom?: boolean;
   handleScroll?: () => void;
+  handleMessageListHeightChange?: () => void;
   // for extending
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
@@ -47,6 +48,7 @@ const Message = ({
   chainTop,
   chainBottom,
   handleScroll,
+  handleMessageListHeightChange,
   renderCustomSeparator,
   renderEditInput,
   renderMessage,
@@ -144,6 +146,9 @@ const Message = ({
       handleScroll?.();
     }
   }, [showEdit, message?.reactions?.length]);
+  useLayoutEffect(() => {
+    handleMessageListHeightChange?.();
+  }, []);
 
   useLayoutEffect(() => {
     let animationTimeout = null;

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -104,11 +104,22 @@ const MessageList: React.FC<MessageListProps> = ({
     }
   };
 
+  // Move the messsage list scroll when the last message's height is changed by reactions
   const handleMessageHeightChange = () => {
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
       if (scrollBottom < bottom && scrollBottom <= SCROLL_BUFFER) {
+        current.scrollTop += bottom - scrollBottom;
+      }
+    }
+  };
+  // Keep the scrollBottom value after fetching new message list
+  const handleMessageListHeightChange = () => {
+    const current = scrollRef?.current;
+    if (current) {
+      const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
+      if (scrollBottom < bottom) {
         current.scrollTop += bottom - scrollBottom;
       }
     }
@@ -158,6 +169,7 @@ const MessageList: React.FC<MessageListProps> = ({
               <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
                 <Message
                   handleScroll={handleMessageHeightChange}
+                  handleMessageListHeightChange={handleMessageListHeightChange}
                   renderMessage={renderMessage}
                   message={m}
                   hasSeparator={hasSeparator}


### PR DESCRIPTION
### Description Of Changes

Keep the scrollBottom value after fetching a new message list
