### PR TITLE
fix: Un-expose reactions menu in special channels

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -29,6 +29,7 @@ import { VOICE_RECORDER_DEFAULT_MAX, VOICE_RECORDER_DEFAULT_MIN } from '../utils
 import { useMarkAsReadScheduler } from './hooks/useMarkAsReadScheduler';
 import { useMarkAsDeliveredScheduler } from './hooks/useMarkAsDeliveredScheduler';
 import { ConfigureSessionTypes } from './hooks/useConnect/types';
+import { getIsReactionEnabled } from '../utils/getIsReactionEnabled';
 
 export type UserListQueryType = {
   hasNext?: boolean;
@@ -213,7 +214,10 @@ const Sendbird = ({
     // common.enable_using_default_user_profile
     disableUserProfile,
     // group_channel.enable_reactions
-    isReactionEnabled,
+    isReactionEnabled: getIsReactionEnabled({
+      appLevel: sdkStore?.sdk?.appInfo?.useReaction,
+      globalLevel: isReactionEnabled,
+    }),
     // group_channel.enable_mention
     isMentionEnabled: isMentionEnabled || false,
     // group_channel.enable_voice_message

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -29,7 +29,6 @@ import { VOICE_RECORDER_DEFAULT_MAX, VOICE_RECORDER_DEFAULT_MIN } from '../utils
 import { useMarkAsReadScheduler } from './hooks/useMarkAsReadScheduler';
 import { useMarkAsDeliveredScheduler } from './hooks/useMarkAsDeliveredScheduler';
 import { ConfigureSessionTypes } from './hooks/useConnect/types';
-import { getIsReactionEnabled } from '../utils/getIsReactionEnabled';
 
 export type UserListQueryType = {
   hasNext?: boolean;
@@ -214,10 +213,7 @@ const Sendbird = ({
     // common.enable_using_default_user_profile
     disableUserProfile,
     // group_channel.enable_reactions
-    isReactionEnabled: getIsReactionEnabled({
-      appLevel: sdkStore?.sdk?.appInfo?.useReaction,
-      globalLevel: isReactionEnabled,
-    }),
+    isReactionEnabled: isReactionEnabled,
     // group_channel.enable_mention
     isMentionEnabled: isMentionEnabled || false,
     // group_channel.enable_voice_message

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -23,6 +23,7 @@ import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { CoreMessageType } from '../../../utils';
 
 import * as utils from './utils';
+import { getIsReactionEnabled } from '../../../utils/getIsReactionEnabled';
 
 import messagesInitialState from './dux/initialState';
 import messagesReducer from './dux/reducers';
@@ -242,7 +243,13 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   const isSuper = currentGroupChannel?.isSuper || false;
   const isBroadcast = currentGroupChannel?.isBroadcast || false;
   const { appInfo } = sdk;
-  const usingReaction = appInfo?.useReaction && !isBroadcast && !isSuper && (config?.isReactionEnabled || isReactionEnabled);
+  const usingReaction = getIsReactionEnabled({
+    appLevel: appInfo?.useReaction,
+    isBroadcast,
+    isSuper,
+    globalLevel: config?.isReactionEnabled,
+    moduleLevel: isReactionEnabled,
+  });
 
   const emojiAllMap = useMemo(() => (
     usingReaction

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -242,9 +242,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
 
   const isSuper = currentGroupChannel?.isSuper || false;
   const isBroadcast = currentGroupChannel?.isBroadcast || false;
-  const { appInfo } = sdk;
   const usingReaction = getIsReactionEnabled({
-    appLevel: appInfo?.useReaction,
     isBroadcast,
     isSuper,
     globalLevel: config?.isReactionEnabled,

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -6,9 +6,8 @@ import './index.scss';
 import RemoveMessage from '../RemoveMessageModal';
 import ParentMessageInfoItem from './ParentMessageInfoItem';
 
-import {
-  getSenderName,
-} from '../../../../utils';
+import { getSenderName } from '../../../../utils';
+import { getIsReactionEnabled } from '../../../../utils/getIsReactionEnabled';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useThreadContext } from '../../context/ThreadProvider';
@@ -67,7 +66,11 @@ export default function ParentMessageInfo({
   const [showRemove, setShowRemove] = useState(false);
   const [supposedHover, setSupposedHover] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
-  const usingReaction = isReactionEnabled && !currentChannel?.isSuper && !currentChannel?.isBroadcast;
+  const usingReaction = getIsReactionEnabled({
+    globalLevel: isReactionEnabled,
+    isSuper: currentChannel.isSuper,
+    isBroadcast: currentChannel.isBroadcast,
+  });
   const isByMe = userId === parentMessage.sender.userId;
 
   // Mobile
@@ -335,7 +338,7 @@ export default function ParentMessageInfo({
           hideMenu={() => {
             setShowMobileMenu(false);
           }}
-          isReactionEnabled={isReactionEnabled}
+          isReactionEnabled={usingReaction}
           isByMe={isByMe}
           emojiContainer={emojiContainer}
           showEdit={setShowEditInput}

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -16,6 +16,7 @@ import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 import ThreadListItemContent from './ThreadListItemContent';
 import { Role } from '../../../../lib/types';
 import { useDirtyGetMentions } from '../../../Message/hooks/useDirtyGetMentions';
+import { getIsReactionEnabled } from '../../../../utils/getIsReactionEnabled';
 
 export interface ThreadListItemProps {
   className?: string;
@@ -65,7 +66,11 @@ export default function ThreadListItem({
   const [showEdit, setShowEdit] = useState(false);
   const [showRemove, setShowRemove] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
-  const usingReaction = isReactionEnabled && !currentChannel?.isSuper && !currentChannel?.isBroadcast;
+  const usingReaction = getIsReactionEnabled({
+    globalLevel: isReactionEnabled,
+    isSuper: currentChannel.isSuper,
+    isBroadcast: currentChannel.isBroadcast,
+  });
 
   // Move to message
   const messageScrollRef = useRef(null);

--- a/src/utils/__tests__/getIsReactionEnabled.spec.ts
+++ b/src/utils/__tests__/getIsReactionEnabled.spec.ts
@@ -5,9 +5,6 @@ describe('Global-utils/getIsReactionEnabled', () => {
     expect(getIsReactionEnabled({})).toBeTrue();
 
     expect(getIsReactionEnabled({
-      appLevel: true,
-    })).toBeTrue();
-    expect(getIsReactionEnabled({
       globalLevel: true,
     })).toBeTrue();
     expect(getIsReactionEnabled({
@@ -15,64 +12,62 @@ describe('Global-utils/getIsReactionEnabled', () => {
     })).toBeTrue();
 
     expect(getIsReactionEnabled({
-      appLevel: true,
-      globalLevel: true,
-    })).toBeTrue();
-    expect(getIsReactionEnabled({
-      appLevel: true,
-      moduleLevel: true,
-    })).toBeTrue();
-    expect(getIsReactionEnabled({
       globalLevel: true,
       moduleLevel: true,
     })).toBeTrue();
-
-    expect(getIsReactionEnabled({
-      appLevel: true,
-      globalLevel: true,
-      moduleLevel: true,
-    })).toBeTrue();
-  });
-
-  it('should disable if one level does not allow', () => {
-    expect(getIsReactionEnabled({
-      appLevel: false,
-      globalLevel: true,
-    })).toBeFalse();
-    expect(getIsReactionEnabled({
-      appLevel: true,
-      globalLevel: false,
-    })).toBeFalse();
   });
 
   it('should have higher priority to the moduleLevel', () => {
     expect(getIsReactionEnabled({
-      appLevel: true,
       globalLevel: true,
       moduleLevel: false,
     })).toBeFalse();
     expect(getIsReactionEnabled({
-      appLevel: false,
       globalLevel: false,
       moduleLevel: true,
     })).toBeTrue();
   });
 
-  it('should be disabled in the special channels', () => {
+  it('should be disabled by the special channels', () => {
     expect(getIsReactionEnabled({
-      appLevel: true,
+      globalLevel: true,
+      isBroadcast: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      globalLevel: true,
+      isSuper: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      globalLevel: true,
+      isBroadcast: true,
+      isSuper: true,
+    })).toBeFalse();
+
+    expect(getIsReactionEnabled({
+      moduleLevel: true,
+      isBroadcast: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      moduleLevel: true,
+      isSuper: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      moduleLevel: true,
+      isBroadcast: true,
+      isSuper: true,
+    })).toBeFalse();
+
+    expect(getIsReactionEnabled({
       globalLevel: true,
       moduleLevel: true,
       isBroadcast: true,
     })).toBeFalse();
     expect(getIsReactionEnabled({
-      appLevel: true,
       globalLevel: true,
       moduleLevel: true,
       isSuper: true,
     })).toBeFalse();
     expect(getIsReactionEnabled({
-      appLevel: true,
       globalLevel: true,
       moduleLevel: true,
       isBroadcast: true,

--- a/src/utils/__tests__/getIsReactionEnabled.spec.ts
+++ b/src/utils/__tests__/getIsReactionEnabled.spec.ts
@@ -1,0 +1,76 @@
+import { getIsReactionEnabled } from '../getIsReactionEnabled';
+
+describe('Global-utils/getIsReactionEnabled', () => {
+  it('should enable as a default', () => {
+    expect(getIsReactionEnabled({})).toBeTrue();
+
+    expect(getIsReactionEnabled({
+      appLevel: true,
+    })).toBeTrue();
+    expect(getIsReactionEnabled({
+      globalLevel: true,
+    })).toBeTrue();
+    expect(getIsReactionEnabled({
+      moduleLevel: true,
+    })).toBeTrue();
+
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+    })).toBeTrue();
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      moduleLevel: true,
+    })).toBeTrue();
+    expect(getIsReactionEnabled({
+      globalLevel: true,
+      moduleLevel: true,
+    })).toBeTrue();
+
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+      moduleLevel: true,
+    })).toBeTrue();
+  });
+
+  it('should disable if it is turned off from one level', () => {
+    expect(getIsReactionEnabled({
+      appLevel: false,
+      globalLevel: true,
+      moduleLevel: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: false,
+      moduleLevel: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+      moduleLevel: false,
+    })).toBeFalse();
+  });
+
+  it('should be disabled in the special channels', () => {
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+      moduleLevel: true,
+      isBroadcast: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+      moduleLevel: true,
+      isSuper: true,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      appLevel: true,
+      globalLevel: true,
+      moduleLevel: true,
+      isBroadcast: true,
+      isSuper: true,
+    })).toBeFalse();
+  });
+});

--- a/src/utils/__tests__/getIsReactionEnabled.spec.ts
+++ b/src/utils/__tests__/getIsReactionEnabled.spec.ts
@@ -17,7 +17,21 @@ describe('Global-utils/getIsReactionEnabled', () => {
     })).toBeTrue();
   });
 
-  it('should have higher priority to the moduleLevel', () => {
+  it('should disable if set values are false', () => {
+    expect(getIsReactionEnabled({
+      globalLevel: false,
+    })).toBeFalse();
+    expect(getIsReactionEnabled({
+      moduleLevel: false,
+    })).toBeFalse();
+
+    expect(getIsReactionEnabled({
+      globalLevel: false,
+      moduleLevel: false,
+    })).toBeFalse();
+  });
+
+  it('should have higher priority to the moduleLevel than globalLevel', () => {
     expect(getIsReactionEnabled({
       globalLevel: true,
       moduleLevel: false,
@@ -28,7 +42,7 @@ describe('Global-utils/getIsReactionEnabled', () => {
     })).toBeTrue();
   });
 
-  it('should be disabled by the special channels', () => {
+  it('should disable in the special type channels', () => {
     expect(getIsReactionEnabled({
       globalLevel: true,
       isBroadcast: true,

--- a/src/utils/__tests__/getIsReactionEnabled.spec.ts
+++ b/src/utils/__tests__/getIsReactionEnabled.spec.ts
@@ -34,22 +34,28 @@ describe('Global-utils/getIsReactionEnabled', () => {
     })).toBeTrue();
   });
 
-  it('should disable if it is turned off from one level', () => {
+  it('should disable if one level does not allow', () => {
     expect(getIsReactionEnabled({
       appLevel: false,
       globalLevel: true,
-      moduleLevel: true,
     })).toBeFalse();
     expect(getIsReactionEnabled({
       appLevel: true,
       globalLevel: false,
-      moduleLevel: true,
     })).toBeFalse();
+  });
+
+  it('should have higher priority to the moduleLevel', () => {
     expect(getIsReactionEnabled({
       appLevel: true,
       globalLevel: true,
       moduleLevel: false,
     })).toBeFalse();
+    expect(getIsReactionEnabled({
+      appLevel: false,
+      globalLevel: false,
+      moduleLevel: true,
+    })).toBeTrue();
   });
 
   it('should be disabled in the special channels', () => {

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -16,13 +16,5 @@ export function getIsReactionEnabled({
   globalLevel = true,
   moduleLevel,
 }: IsReactionEnabledProps): boolean {
-  if (moduleLevel) {
-    return !isBroadcast && !isSuper;
-  }
-  return (
-    globalLevel
-    && (moduleLevel ?? true)
-    && !isBroadcast
-    && !isSuper
-  );
+  return (isBroadcast || isSuper) ? false : (moduleLevel ?? globalLevel);
 }

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -16,5 +16,5 @@ export function getIsReactionEnabled({
   globalLevel = true,
   moduleLevel,
 }: IsReactionEnabledProps): boolean {
-  return (isBroadcast || isSuper) ? false : (moduleLevel ?? globalLevel);
+  return !(isBroadcast || isSuper) && (moduleLevel ?? globalLevel);
 }

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -4,7 +4,6 @@
  */
 
 export interface IsReactionEnabledProps {
-  appLevel?: boolean;
   isBroadcast?: boolean;
   isSuper?: boolean;
   globalLevel?: boolean;
@@ -12,7 +11,6 @@ export interface IsReactionEnabledProps {
 }
 
 export function getIsReactionEnabled({
-  appLevel = true,
   isBroadcast = false,
   isSuper = false,
   globalLevel = true,
@@ -22,8 +20,7 @@ export function getIsReactionEnabled({
     return !isBroadcast && !isSuper;
   }
   return (
-    appLevel
-    && globalLevel
+    globalLevel
     && (moduleLevel ?? true)
     && !isBroadcast
     && !isSuper

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -8,7 +8,7 @@ export interface IsReactionEnabledProps {
   isBroadcast?: boolean;
   isSuper?: boolean;
   globalLevel?: boolean;
-  moduleLevel?: boolean;
+  moduleLevel?: boolean | null;
 }
 
 export function getIsReactionEnabled({
@@ -16,7 +16,16 @@ export function getIsReactionEnabled({
   isBroadcast = false,
   isSuper = false,
   globalLevel = true,
-  moduleLevel = true,
+  moduleLevel = null,
 }: IsReactionEnabledProps): boolean {
-  return appLevel && !isBroadcast && !isSuper && globalLevel && moduleLevel;
+  if (moduleLevel) {
+    return !isBroadcast && !isSuper;
+  }
+  return (
+    appLevel
+    && globalLevel
+    && (moduleLevel ?? true)
+    && !isBroadcast
+    && !isSuper
+  );
 }

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -1,0 +1,22 @@
+/**
+ * This function helps consider the every condition
+ * related to enabling emoji reaction feature.
+ */
+
+export interface IsReactionEnabledProps {
+  appLevel?: boolean;
+  isBroadcast?: boolean;
+  isSuper?: boolean;
+  globalLevel?: boolean;
+  moduleLevel?: boolean;
+}
+
+export function getIsReactionEnabled({
+  appLevel = true,
+  isBroadcast = false,
+  isSuper = false,
+  globalLevel = true,
+  moduleLevel = true,
+}: IsReactionEnabledProps): boolean {
+  return appLevel && !isBroadcast && !isSuper && globalLevel && moduleLevel;
+}

--- a/src/utils/getIsReactionEnabled.ts
+++ b/src/utils/getIsReactionEnabled.ts
@@ -7,14 +7,14 @@ export interface IsReactionEnabledProps {
   isBroadcast?: boolean;
   isSuper?: boolean;
   globalLevel?: boolean;
-  moduleLevel?: boolean | null;
+  moduleLevel?: boolean;
 }
 
 export function getIsReactionEnabled({
   isBroadcast = false,
   isSuper = false,
   globalLevel = true,
-  moduleLevel = null,
+  moduleLevel,
 }: IsReactionEnabledProps): boolean {
   if (moduleLevel) {
     return !isBroadcast && !isSuper;


### PR DESCRIPTION
### Description Of Changes

* Do not show emoji reactions in the Supergroup channel & Broadcast group channel
  * Create a util func: getIsReactionEnabled
  * Use the function to everywhere calculate the condition of isReactionEnabled

[UIKIT-4008](https://sendbird.atlassian.net/browse/UIKIT-4008)

[UIKIT-4008]: https://sendbird.atlassian.net/browse/UIKIT-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ