### PR TITLE
fix: Mobile context menu does not disappear when clicking outside

### DIFF
--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -108,7 +108,6 @@ export default function ThreadListItemContent({
   return (
     <div
       className={`sendbird-thread-list-item-content ${className} ${isByMe ? 'outgoing' : 'incoming'}`}
-      {...(isMobile) ? { ...longPress } : {}}
       ref={mobileMenuRef}
     >
       <div className={`sendbird-thread-list-item-content__left ${isReactionEnabledInChannel ? 'use-reaction' : ''} ${isByMe ? 'outgoing' : 'incoming'}`}>
@@ -176,7 +175,10 @@ export default function ThreadListItemContent({
           </div>
         )}
       </div>
-      <div className="sendbird-thread-list-item-content__middle">
+      <div
+        className="sendbird-thread-list-item-content__middle"
+        {...(isMobile) ? { ...longPress } : {}}
+      >
         {(!isByMe && !chainTop && !useReplying) && (
           <Label
             className="sendbird-thread-list-item-content__middle__sender-name"


### PR DESCRIPTION
### Description Of Changes

* Move the location of `longPress` event from ThreadListItem to the middle element of it
  to prevent exposing the context menu again when clicking outside of the context menu
  in the broadcast channel (mobile)