### PR TITLE
fix: Thumbnail message longpress on mobile

### DIFF
--- a/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
+++ b/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
@@ -47,7 +47,7 @@ function useHandleChannelEvents({
 }: StaticParams): void {
   const channelStore = useChannelContext();
   const store = useSendbirdStateContext();
-  const { disableMarkAsRead } = channelStore;
+  const { disableMarkAsRead = {} } = channelStore ?? {};
   const {
     markAsReadScheduler,
     markAsDeliveredScheduler,

--- a/src/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/ui/ThumbnailMessageItemBody/index.tsx
@@ -38,9 +38,6 @@ export default function ThumbnailMessageItemBody({
         showFileViewer?.(true);
       }
     },
-  }, {
-    shouldPreventDefault: true,
-    shouldStopPropagation: true,
   });
 
   return (


### PR DESCRIPTION
### Description Of Changes

Issue
* Stopping event propagation has blocked opening long press event of MessageContent
Fix
* Do not stop event propagation on the ThumbnailMessageItem

[UIKIT-4026](https://sendbird.atlassian.net/browse/UIKIT-4026)


[UIKIT-4026]: https://sendbird.atlassian.net/browse/UIKIT-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ