### PR TITLE
feat: handle configuration priorities

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -264,7 +264,7 @@ const Sendbird = ({
       }}
     >
     <UIKitConfigProvider
-      appConfigurations={{
+      localConfigs={{
         common: {
           enableUsingDefaultUserProfile: !uikitConfigurations.disableUserProfile,
         },

--- a/src/lib/UIKitConfigProvider/index.tsx
+++ b/src/lib/UIKitConfigProvider/index.tsx
@@ -4,6 +4,8 @@ import React, { useCallback, useState, createContext, useContext } from 'react';
 import { snakeToCamel } from './utils/snakeToCamel';
 import { DeepPartial } from './utils/types';
 
+import getConfigsByPriority from './utils/getConfigsByPriority';
+
 import { UIKitConfigInfo } from './types';
 
 // @link: https://docs.google.com/spreadsheets/d/1-AozBMHRYOXS74vZ-7x2ptQcBL6nnM-orJWRvUgmkd4/edit#gid=0
@@ -68,16 +70,16 @@ const UIKitConfigContext = createContext<UIKitConfigContextInterface>({
 });
 
 interface UIKitConfigProviderProps {
-  appConfigurations: DeepPartial<UIKitConfigInfo>;
+  // Configurations set by code level
+  localConfigs: DeepPartial<UIKitConfigInfo>;
   children: React.ReactElement;
   // If the storage value is not provided,
   // it'll fetch the new configs set by dashboard everytime
   storage?: any;
 }
 
-const UIKitConfigProvider = ({ storage, children /* appConfigurations */ }: UIKitConfigProviderProps) => {
-  // TODO: Implement
-  // const localConfigs = mergeConfigs(initialConfig, mapToUIKItConfig(configurations));
+const UIKitConfigProvider = ({ storage, children, localConfigs }: UIKitConfigProviderProps) => {
+  // Set by Feature Config setting in Dashboard
   const [remoteConfigs, setRemoteConfigs] = useState(initialConfig);
 
   const initDashboardConfigs = useCallback(async (sdk: SendbirdChat) => {
@@ -105,10 +107,7 @@ const UIKitConfigProvider = ({ storage, children /* appConfigurations */ }: UIKi
     }
   }, []);
 
-  // TODO: Implement
-  // const configs = getByPriority(localConfigs, remoteConfigs);
-  const configs = remoteConfigs;
-
+  const configs = getConfigsByPriority(localConfigs, remoteConfigs);
   return <UIKitConfigContext.Provider value={{ initDashboardConfigs, configs }}>{children}</UIKitConfigContext.Provider>;
 };
 

--- a/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
+++ b/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
@@ -1,6 +1,7 @@
 import getConfigsByPriority from '../getConfigsByPriority';
+import { UIKitConfigInfo } from '../../types';
 
-const mockRemoteConfigs = {
+const mockRemoteConfigs: UIKitConfigInfo = {
   common: {
     enableUsingDefaultUserProfile: false,
   },
@@ -58,7 +59,7 @@ describe('getConfigsByPriority', () => {
         enableUsingDefaultUserProfile: true,
       },
     };
-    const remoteConfigs = {
+    const remoteConfigs: UIKitConfigInfo = {
       // Non-existing configs in localConfigs should be merged too
       ...mockRemoteConfigs,
       common: {

--- a/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
+++ b/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
@@ -1,5 +1,56 @@
 import getConfigsByPriority from '../getConfigsByPriority';
 
+const mockRemoteConfigs = {
+  common: {
+    enableUsingDefaultUserProfile: false,
+  },
+  groupChannel: {
+    channel: {
+      enableMention: false,
+      enableOgtag: true,
+      enableReactions: true,
+      enableTypingIndicator: true,
+      enableVoiceMessage: false,
+      input: {
+        camera: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+        enableDocument: true,
+        gallery: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+      },
+      replyType: 'quote_reply',
+      threadReplySelectType: 'thread',
+    },
+    channelList: {
+      enableMessageReceiptStatus: false,
+      enableTypingIndicator: false,
+    },
+    setting: {
+      enableMessageSearch: false,
+    },
+  },
+  openChannel: {
+    channel: {
+      enableOgtag: true,
+      input: {
+        camera: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+        enableDocument: true,
+        gallery: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+      },
+    },
+  },
+};
+
 describe('getConfigsByPriority', () => {
   it('should override remoteConfigs value \w localConfigs which has higher priority', () => {
     const localConfigs = {
@@ -8,54 +59,10 @@ describe('getConfigsByPriority', () => {
       },
     };
     const remoteConfigs = {
+      // Non-existing configs in localConfigs should be merged too
+      ...mockRemoteConfigs,
       common: {
         enableUsingDefaultUserProfile: false, // Only this value should be replaced
-      },
-      // These below non-existing configs in localConfigs should be merged too
-      groupChannel: {
-        channel: {
-          enableMention: false,
-          enableOgtag: true,
-          enableReactions: true,
-          enableTypingIndicator: true,
-          enableVoiceMessage: false,
-          input: {
-            camera: {
-              enablePhoto: true,
-              enableVideo: true,
-            },
-            enableDocument: true,
-            gallery: {
-              enablePhoto: true,
-              enableVideo: true,
-            },
-          },
-          replyType: 'quote_reply',
-          threadReplySelectType: 'thread',
-        },
-        channelList: {
-          enableMessageReceiptStatus: false,
-          enableTypingIndicator: false,
-        },
-        setting: {
-          enableMessageSearch: false,
-        },
-      },
-      openChannel: {
-        channel: {
-          enableOgtag: true,
-          input: {
-            camera: {
-              enablePhoto: true,
-              enableVideo: true,
-            },
-            enableDocument: true,
-            gallery: {
-              enablePhoto: true,
-              enableVideo: true,
-            },
-          },
-        },
       },
     };
 
@@ -63,5 +70,11 @@ describe('getConfigsByPriority', () => {
       ...remoteConfigs,
       ...localConfigs,
     });
+  });
+
+  it('should merge correctly even localConfigs has empty object or nullable fields', () => {
+    const localConfigs = {};
+    const remoteConfigs = mockRemoteConfigs;
+    expect(getConfigsByPriority(localConfigs, remoteConfigs)).toEqual(remoteConfigs);
   });
 });

--- a/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
+++ b/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
@@ -1,0 +1,67 @@
+import getConfigsByPriority from '../getConfigsByPriority';
+
+describe('getConfigsByPriority', () => {
+  it('should override remoteConfigs value \w localConfigs which has higher priority', () => {
+    const localConfigs = {
+      common: {
+        enableUsingDefaultUserProfile: true,
+      },
+    };
+    const remoteConfigs = {
+      common: {
+        enableUsingDefaultUserProfile: false, // Only this value should be replaced
+      },
+      // These below non-existing configs in localConfigs should be merged too
+      groupChannel: {
+        channel: {
+          enableMention: false,
+          enableOgtag: true,
+          enableReactions: true,
+          enableTypingIndicator: true,
+          enableVoiceMessage: false,
+          input: {
+            camera: {
+              enablePhoto: true,
+              enableVideo: true,
+            },
+            enableDocument: true,
+            gallery: {
+              enablePhoto: true,
+              enableVideo: true,
+            },
+          },
+          replyType: 'quote_reply',
+          threadReplySelectType: 'thread',
+        },
+        channelList: {
+          enableMessageReceiptStatus: false,
+          enableTypingIndicator: false,
+        },
+        setting: {
+          enableMessageSearch: false,
+        },
+      },
+      openChannel: {
+        channel: {
+          enableOgtag: true,
+          input: {
+            camera: {
+              enablePhoto: true,
+              enableVideo: true,
+            },
+            enableDocument: true,
+            gallery: {
+              enablePhoto: true,
+              enableVideo: true,
+            },
+          },
+        },
+      },
+    };
+
+    expect(getConfigsByPriority(localConfigs, remoteConfigs)).toEqual({
+      ...remoteConfigs,
+      ...localConfigs,
+    });
+  });
+});

--- a/src/lib/UIKitConfigProvider/utils/__tests__/type.spec.ts
+++ b/src/lib/UIKitConfigProvider/utils/__tests__/type.spec.ts
@@ -1,0 +1,30 @@
+import { isSameType } from '../types';
+
+describe('isSameType', () => {
+  it('should return true if both values have the same type', () => {
+    expect(isSameType(10, 20)).toBe(true);
+    expect(isSameType('hello', 'world')).toBe(true);
+    expect(isSameType(true, false)).toBe(true);
+    expect(isSameType({}, {})).toBe(true);
+    expect(isSameType([], [])).toBe(true);
+  });
+
+  it('should return false if the values have different types', () => {
+    expect(isSameType(10, 'hello')).toBe(false);
+    expect(isSameType(true, 0)).toBe(false);
+    expect(isSameType({}, [])).toBe(false);
+    expect(isSameType(null, undefined)).toBe(false);
+  });
+
+  it('should handle null values correctly', () => {
+    expect(isSameType(null, null)).toBe(true);
+    expect(isSameType(null, 10)).toBe(false);
+    expect(isSameType(20, null)).toBe(false);
+  });
+
+  it('should handle arrays correctly', () => {
+    expect(isSameType([], [])).toBe(true);
+    expect(isSameType([1, 2, 3], [4, 5, 6])).toBe(true);
+    expect(isSameType([], {})).toBe(false);
+  });
+});

--- a/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
+++ b/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
@@ -1,9 +1,5 @@
-import { DeepPartial } from './types';
+import { DeepPartial, isSameType } from './types';
 import { UIKitConfigInfo } from '../types';
-
-function isSameType<T, U>(a: T, b: U): boolean {
-  return typeof a === typeof b;
-}
 
 /**
  * @param localConfigs Set directly in code level. It has higher priority than remote ones

--- a/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
+++ b/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
@@ -1,6 +1,10 @@
 import { DeepPartial } from './types';
 import { UIKitConfigInfo } from '../types';
 
+function isSameType<T, U>(a: T, b: U): boolean {
+  return typeof a === typeof b;
+}
+
 /**
  * @param localConfigs Set directly in code level. It has higher priority than remote ones
  * @param remoteConfigs Set by Feature Config setting in Dashboard
@@ -10,15 +14,11 @@ export default function getConfigsByPriority(localConfigs: DeepPartial<UIKitConf
   const prioritizedConfigs = { ...remoteConfigs }; // copy remoteConfigs to prevent mutation
 
   Object.keys(localConfigs).forEach(key => {
-    if (
-      prioritizedConfigs.hasOwnProperty(key)
-      && localConfigs[key] !== null
-      // Recursively call getConfigsByPriority only when the value of the key is Object
-      && typeof localConfigs[key] === 'object'
-    ) {
-      prioritizedConfigs[key] = getConfigsByPriority(localConfigs[key], prioritizedConfigs[key]);
-    } else {
-      prioritizedConfigs[key] = localConfigs[key];
+    if (prioritizedConfigs.hasOwnProperty(key) && isSameType(localConfigs[key], prioritizedConfigs[key])) {
+      prioritizedConfigs[key] = typeof localConfigs[key] === 'object'
+        // Recursively call getConfigsByPriority only when the value of the key is Object
+        ? getConfigsByPriority(localConfigs[key], prioritizedConfigs[key])
+        : localConfigs[key];
     }
   });
 

--- a/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
+++ b/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
@@ -1,0 +1,26 @@
+import { DeepPartial } from './types';
+import { UIKitConfigInfo } from '../types';
+
+/**
+ * @param localConfigs Set directly in code level. It has higher priority than remote ones
+ * @param remoteConfigs Set by Feature Config setting in Dashboard
+ * @returns
+ */
+export default function getConfigsByPriority(localConfigs: DeepPartial<UIKitConfigInfo>, remoteConfigs: UIKitConfigInfo): UIKitConfigInfo {
+  const prioritizedConfigs = { ...remoteConfigs }; // copy remoteConfigs to prevent mutation
+
+  Object.keys(localConfigs).forEach(key => {
+    if (
+      prioritizedConfigs.hasOwnProperty(key)
+      && localConfigs[key] !== null
+      // Recursively call getConfigsByPriority only when the value of the key is Object
+      && typeof localConfigs[key] === 'object'
+    ) {
+      prioritizedConfigs[key] = getConfigsByPriority(localConfigs[key], prioritizedConfigs[key]);
+    } else {
+      prioritizedConfigs[key] = localConfigs[key];
+    }
+  });
+
+  return prioritizedConfigs;
+}

--- a/src/lib/UIKitConfigProvider/utils/types.ts
+++ b/src/lib/UIKitConfigProvider/utils/types.ts
@@ -3,3 +3,8 @@
 export type DeepPartial<T> = T extends Function
   ? T
   : (T extends object ? { [P in keyof T]?: DeepPartial<T[P]>; } : T);
+
+export function isSameType<T, U>(a: T, b: U): boolean {
+  // we do this cause typeof can't differenciate object/ array/ null
+  return Object.prototype.toString.call(a) === Object.prototype.toString.call(b);
+}


### PR DESCRIPTION
### Description Of Changes
Addresses https://sendbird.atlassian.net/browse/UIKIT-4014 

`UIKitConfigProvider` which handles Uikit Configuration in context has been added by my prev PR #561 and I commented two parts 
1. return valid configs depends on their each priorities 
i.e. local configs set in code level should have higher priority than the configs set by Dashboard feature configuration setting
2. save the Dashboard feature configurations in storage(React won't use this feature for now) 

So, this PR is for 1. 