### PR TITLE
fix: curly brace escaping in regular expression

### DIFF
--- a/src/modules/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
+++ b/src/modules/Message/utils/tokens/__tests__/tokenizeUtils.spec.ts
@@ -16,7 +16,7 @@ describe('getUserMentionRegex', () => {
     ] as User[];
     const templatePrefix = '@';
     const result = getUserMentionRegex(mentionedUsers, templatePrefix);
-    expect(result).toEqual(/(@{1}|@{2})/g);
+    expect(result).toEqual(/(@\{1\}|@\{2\})/g);
   });
 
   it('should return a correct regex pattern; userId includes some patterns need to be escaped', () => {
@@ -26,7 +26,7 @@ describe('getUserMentionRegex', () => {
     ] as User[];
     const templatePrefix = '@';
     const result = getUserMentionRegex(mentionedUsers, templatePrefix);
-    expect(result).toEqual(/(@{1\*}|@{2\+})/g);
+    expect(result).toEqual(/(@\{1\*\}|@\{2\+\})/g);
   });
 });
 

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -11,7 +11,11 @@ export function getUserMentionRegex(mentionedUsers: User[], templatePrefix_: str
       // If user.id includes these patterns, need to convert it into an escaped one
       /([.*+?^${}()|[\]\\])/g,
       '\\$1');
-    return `${templatePrefix}{${userId}}`;
+      /**
+       * //{ And //} are also for escaping
+       * because curly braces `{}` are metacharacters in regular expressions used to specify repetition
+       */
+    return `${templatePrefix}\\{${userId}\\}`;
   }).join('|')})`, 'g');
 }
 
@@ -19,7 +23,7 @@ export function identifyMentions({
   tokens,
   mentionedUsers = [],
   templatePrefix = USER_MENTION_PREFIX,
-}: IdentifyMentionsType): (MentionToken|UndeterminedToken)[] {
+}: IdentifyMentionsType): (MentionToken | UndeterminedToken)[] {
   if (!mentionedUsers?.length) {
     return tokens;
   }


### PR DESCRIPTION
### Description Of Changes

The modification in the code was to escape the curly braces ({}) by replacing them with \{ and \}.
This ensures that the curly braces are treated as literal characters in the regular expression, addressing the issue caused by their metacharacter usage.

[UIKIT-4027](https://sendbird.atlassian.net/browse/UIKIT-4027)


[UIKIT-4027]: https://sendbird.atlassian.net/browse/UIKIT-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ