### PR TITLE
fix: Flexible thumbnail width

### DIFF
--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -249,7 +249,7 @@ export default function ThreadListItemContent({
               isReactionEnabled={isReactionEnabledInChannel}
               showFileViewer={showFileViewer}
               style={{
-                width: '200px',
+                width: isMobile ? '100%' : '200px',
                 height: '148px',
               }}
             />

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -339,6 +339,7 @@ export default function MessageContent({
               mouseHover={mouseHover}
               isReactionEnabled={isReactionEnabledInChannel}
               showFileViewer={showFileViewer}
+              style={isMobile ? { width: '100%' } : {}}
             />
           )}
           {(getUIKitMessageType((message as FileMessage)) === messageTypes.UNKNOWN) && (


### PR DESCRIPTION
### Description Of Changes

Use 100% width to ThumbnailMessage in Mobile mode

before
<img width="333" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/dce1e798-4d55-4e37-9021-cfb4e1618340">
after
<img width="312" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/53f166dd-72be-49a1-95f5-221f1c60b991">

[UIKIT-3909](https://sendbird.atlassian.net/browse/UIKIT-3909)


[UIKIT-3909]: https://sendbird.atlassian.net/browse/UIKIT-3909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ