### PR TITLE
hotfix: merge non-existing config fields in localConfigs to remote ones

### DIFF
--- a/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
+++ b/src/lib/UIKitConfigProvider/utils/__tests__/getConfigsByPriority.spec.ts
@@ -78,4 +78,38 @@ describe('getConfigsByPriority', () => {
     const remoteConfigs = mockRemoteConfigs;
     expect(getConfigsByPriority(localConfigs, remoteConfigs)).toEqual(remoteConfigs);
   });
+
+  it('should merge correctly even localConfigs has empty object or nullable fields', () => {
+    const localConfigs = {
+      common: {
+        enableUsingDefaultUserProfile: true,
+      },
+      groupChannel: {
+        channel: {
+          enableMention: false,
+          enableOgtag: true,
+          enableReactions: true,
+          enableTypingIndicator: true,
+          enableVoiceMessage: false,
+        } },
+    };
+    const remoteConfigs = {
+      common: {
+        enableUsingDefaultUserProfile: false,
+      },
+    };
+    expect(getConfigsByPriority(localConfigs, remoteConfigs)).toEqual({
+      common: {
+        enableUsingDefaultUserProfile: true,
+      },
+      groupChannel: {
+        channel: {
+          enableMention: false,
+          enableOgtag: true,
+          enableReactions: true,
+          enableTypingIndicator: true,
+          enableVoiceMessage: false,
+        } },
+    });
+  });
 });

--- a/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
+++ b/src/lib/UIKitConfigProvider/utils/getConfigsByPriority.ts
@@ -15,6 +15,8 @@ export default function getConfigsByPriority(localConfigs: DeepPartial<UIKitConf
         // Recursively call getConfigsByPriority only when the value of the key is Object
         ? getConfigsByPriority(localConfigs[key], prioritizedConfigs[key])
         : localConfigs[key];
+    } else {
+      prioritizedConfigs[key] = localConfigs[key];
     }
   });
 


### PR DESCRIPTION
### Description Of Changes
Resolves https://sendbird.slack.com/archives/C050Z6DA70A/p1685588878155939 

Please refer to the newly added unit test in [here](https://github.com/sendbird/sendbird-uikit-react/compare/hotfix/non-existing-configs-in-remote-config?expand=1#diff-2c24fdca2158f33d1308774314a045afd9e81ab657ed3ca5f1378be95649838a). That's the case that I missed previously 😅
 -> When localConfigs has more fields that don't exist in remoteConfigs, it occurs the error. 