### PR TITLE
fix: Prevent hover style of ParentMessageInfo comp

### DIFF
--- a/src/modules/Thread/components/ParentMessageInfo/index.scss
+++ b/src/modules/Thread/components/ParentMessageInfo/index.scss
@@ -131,6 +131,12 @@
     background-color: t(bg-1);
   }
 }
+// mobile should have higher priority than themed
+.sendbird-parent-message-info.sendbird-thread-ui__parent-message-info:hover {
+  @include mobile() {
+    background-color: transparent;
+  }
+}
 .sendbird-parent-message-info:hover .sendbird-emoji-reactions {
   @include themed() {
     border: 1px solid t(bg-1);


### PR DESCRIPTION
### Description Of Changes

before
<img width="382" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/1ddec21d-45ce-444d-adb5-e714272f6840">
after
<img width="379" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/fb507c06-0040-480d-9f94-ddbf26ad06d8">

[UIKIT-3915](https://sendbird.atlassian.net/browse/UIKIT-3915)


[UIKIT-3915]: https://sendbird.atlassian.net/browse/UIKIT-3915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ