### PR TITLE
fix: Reactions width on mobile

### DIFF
--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.scss
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.scss
@@ -48,9 +48,6 @@
     align-items: flex-start;
 
     .sendbird-thread-list-item-content__middle__body-container {
-      .sendbird-thread-list-item-content__middle__message-item-body {
-        max-width: 198px;
-      }
       .sendbird-thread-list-item-content__middle__body-container__created-at {
         position: absolute;
         bottom: 6px;
@@ -171,11 +168,6 @@
     .sendbird-thread-list-item-content__middle__body-container {
       position: relative;
       width: fit-content;
-
-      .sendbird-thread-list-item-content__middle__message-item-body {
-        max-width: 200px;
-      }
-
       .sendbird-thread-list-item-content__middle__body-container__created-at {
         position: absolute;
         bottom: 2px;


### PR DESCRIPTION
### Description Of Changes

before
<img width="374" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/db3851bf-dd6e-47f2-881d-d24e411bc16d">
after
<img width="375" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/2567fa00-485c-4f21-a621-5e3efd1fcf76">

* Remove max-width of thread message item body

[UIKIT-3917](https://sendbird.atlassian.net/browse/UIKIT-3917)


[UIKIT-3917]: https://sendbird.atlassian.net/browse/UIKIT-3917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ