### PR TITLE
fix: apply ellipsis to quote and admin msg

### DIFF
--- a/src/ui/AdminMessage/index.scss
+++ b/src/ui/AdminMessage/index.scss
@@ -7,5 +7,7 @@
 
   .sendbird-admin-message__text {
     display: flex;
+    width: 100%;
+    word-break: break-word;
   }
 }

--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -27,6 +27,10 @@
   }
 }
 
+.sendbird-message-content__middle__quote-message__quote {
+  width: 100%;
+}
+
 // incoming
 .sendbird-message-content.incoming {
   .sendbird-message-content__left {
@@ -69,6 +73,9 @@
       position: relative;
       margin-left: 12px;
       margin-bottom: 4px;
+      width: 100%;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
     }
 
     .sendbird-message-content__middle__quote-message {

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -260,6 +260,7 @@ export default function MessageContent({
         {(useReplying) ? (
           <div className={getClassName(['sendbird-message-content__middle__quote-message', isByMe ? 'outgoing' : 'incoming', useReplyingClassName])}>
             <QuoteMessage
+              className="sendbird-message-content__middle__quote-message__quote"
               message={message as UserMessage | FileMessage}
               userId={userId}
               isByMe={isByMe}

--- a/src/ui/QuoteMessage/index.scss
+++ b/src/ui/QuoteMessage/index.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   &.incoming { align-items: flex-start; }
   &.outgoing { align-items: flex-end; }
+  width: 100%;
   max-width: 400px;
 
   .sendbird-quote-message__replied-to {
@@ -16,6 +17,7 @@
     align-items: center;
     height: 16px;
     padding: 0px 12px;
+    width: 100%;
     .sendbird-quote-message__replied-to__icon {
       position: relative;
       margin-bottom: 4px;


### PR DESCRIPTION
### Description Of Changes

#### before
<img width="376" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/bb6f8500-80e1-4a62-acef-d680a75e7c8e">
<img width="379" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/1b6b57c5-144e-4029-8380-77bb5c9d54ca">

#### after
<img width="375" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/2ca6f359-339a-4680-b321-020aee8fa0bc">
<img width="376" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/dc11cd11-fb5e-480a-b1ab-c3424c2bbfae">

* fix: apply ellipsis to the QuoteMessage
* fix: break-word of AdminMessage

[UIKIT-3986](https://sendbird.atlassian.net/browse/UIKIT-3986)


[UIKIT-3986]: https://sendbird.atlassian.net/browse/UIKIT-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ