### PR TITLE
feat: add UIKitConfigStorageManager

### DIFF
--- a/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
+++ b/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
@@ -1,0 +1,120 @@
+import { UIKitConfigStorageManager } from '../.';
+import mergeConfigs from '../../utils/getConfigsByPriority';
+
+import initialConfig from '../../const/initialConfig';
+
+// Mock StorageInterface
+const mockStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+};
+
+// Mock mergeConfigs function
+jest.mock('../../utils/getConfigsByPriority', () => jest.fn());
+
+const mockAppId = 'abc123';
+
+describe('UIKitConfigStorageManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('init', () => {
+    it('should set the key and return the result of get', async () => {
+      const storageManager = new UIKitConfigStorageManager(mockStorage);
+
+      storageManager.get = jest.fn().mockResolvedValueOnce('config');
+
+      const result = await storageManager.init(mockAppId);
+
+      expect(storageManager.key).toBe(`sbu@${mockAppId}.uikitConfiguration`);
+      expect(storageManager.get).toHaveBeenCalledTimes(1);
+      expect(result).toBe('config');
+    });
+  });
+
+  describe('update', () => {
+    it('should update the stored config and return the merged config', async () => {
+      const storageManager = new UIKitConfigStorageManager(mockStorage);
+      const payload = {
+        lastUpdatedAt: 123456789,
+        uikitConfigurations: [{ name: 'config1' }, { name: 'config2' }],
+      };
+      const storedConfig = {
+        lastUpdatedAt: 987654321,
+        uikitConfigurations: [{ name: 'config3' }, { name: 'config4' }],
+      };
+      const mergedConfig = {
+        lastUpdatedAt: payload.lastUpdatedAt,
+        uikitConfigurations: [{ name: 'config3' }, { name: 'config4' }, { name: 'config1' }, { name: 'config2' }],
+      };
+
+      storageManager.get = jest.fn().mockResolvedValueOnce(storedConfig);
+      storageManager.key = `sbu@${mockAppId}.uikitConfiguration`;
+
+      mockStorage.setItem.mockResolvedValueOnce(storedConfig);
+
+      mergeConfigs.mockReturnValueOnce(mergedConfig.uikitConfigurations);
+
+      const result = await storageManager.update(payload);
+
+      expect(storageManager.get).toHaveBeenCalledTimes(1);
+      expect(mergeConfigs).toHaveBeenCalledWith(storedConfig.uikitConfigurations, payload.uikitConfigurations);
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        storageManager.key,
+        JSON.stringify(mergedConfig),
+      );
+      expect(result).toEqual(mergedConfig);
+    });
+  });
+
+  describe('get', () => {
+    it('should return the stored config if it exists', async () => {
+      const storageManager = new UIKitConfigStorageManager(mockStorage);
+      const storedConfig = {
+        lastUpdatedAt: 987654321,
+        uikitConfigurations: [{ name: 'config1' }, { name: 'config2' }],
+      };
+
+      mockStorage.getItem.mockResolvedValueOnce(JSON.stringify(storedConfig));
+      storageManager.key = `sbu@${mockAppId}.uikitConfiguration`;
+
+      const result = await storageManager.get();
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith(storageManager.key);
+      expect(result).toEqual(storedConfig);
+    });
+
+    it('should return the initial payload if the stored config does not exist', async () => {
+      const storageManager = new UIKitConfigStorageManager(mockStorage);
+      const initialPayload = {
+        lastUpdatedAt: 0,
+        uikitConfigurations: initialConfig,
+      };
+
+      storageManager.key = `sbu@${mockAppId}.uikitConfiguration`;
+      mockStorage.getItem.mockResolvedValueOnce(null);
+
+      const result = await storageManager.get();
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith(storageManager.key);
+      expect(result).toEqual(initialPayload);
+    });
+
+    it('should return the initial payload if an error occurs while retrieving the stored config', async () => {
+      const storageManager = new UIKitConfigStorageManager(mockStorage);
+      const initialPayload = {
+        lastUpdatedAt: 0,
+        uikitConfigurations: initialConfig,
+      };
+
+      storageManager.key = `sbu@${mockAppId}.uikitConfiguration`;
+      mockStorage.getItem.mockRejectedValueOnce(new Error('Failed to retrieve config'));
+
+      const result = await storageManager.get();
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith(storageManager.key);
+      expect(result).toEqual(initialPayload);
+    });
+  });
+});

--- a/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
+++ b/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
@@ -10,7 +10,7 @@ const mockStorage = {
 };
 
 // Mock mergeConfigs function
-jest.mock('../../utils/getConfigsByPriority', () => jest.fn());
+jest.mock('../../utils/mergeConfigs', () => jest.fn());
 
 const mockAppId = 'abc123';
 
@@ -38,15 +38,33 @@ describe('UIKitConfigStorageManager', () => {
       const storageManager = new UIKitConfigStorageManager(mockStorage);
       const payload = {
         lastUpdatedAt: 123456789,
-        uikitConfigurations: [{ name: 'config1' }, { name: 'config2' }],
+        uikitConfigurations: {
+          common: {
+            enableUsingDefaultUserProfile: false,
+          },
+          groupChannel: {
+            channel: {
+              enableMention: false,
+            },
+          },
+        },
       };
       const storedConfig = {
         lastUpdatedAt: 987654321,
-        uikitConfigurations: [{ name: 'config3' }, { name: 'config4' }],
+        uikitConfigurations: {
+          common: {
+            enableUsingDefaultUserProfile: true,
+          },
+          groupChannel: {
+            channel: {
+              enableMention: true,
+            },
+          },
+        },
       };
       const mergedConfig = {
         lastUpdatedAt: payload.lastUpdatedAt,
-        uikitConfigurations: [{ name: 'config3' }, { name: 'config4' }, { name: 'config1' }, { name: 'config2' }],
+        uikitConfigurations: payload.uikitConfigurations,
       };
 
       storageManager.get = jest.fn().mockResolvedValueOnce(storedConfig);
@@ -59,7 +77,7 @@ describe('UIKitConfigStorageManager', () => {
       const result = await storageManager.update(payload);
 
       expect(storageManager.get).toHaveBeenCalledTimes(1);
-      expect(mergeConfigs).toHaveBeenCalledWith(storedConfig.uikitConfigurations, payload.uikitConfigurations);
+      expect(mergeConfigs).toHaveBeenCalledWith(payload.uikitConfigurations, storedConfig.uikitConfigurations);
       expect(mockStorage.setItem).toHaveBeenCalledWith(
         storageManager.key,
         JSON.stringify(mergedConfig),

--- a/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
+++ b/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/__tests__/index.spec.ts
@@ -10,7 +10,7 @@ const mockStorage = {
 };
 
 // Mock mergeConfigs function
-jest.mock('../../utils/mergeConfigs', () => jest.fn());
+jest.mock('../../utils/getConfigsByPriority', () => jest.fn());
 
 const mockAppId = 'abc123';
 

--- a/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/index.ts
+++ b/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/index.ts
@@ -1,0 +1,51 @@
+import { UIKitConfigPayload } from '../types';
+import mergeConfigs from '../utils/getConfigsByPriority';
+import initialConfig from '../const/initialConfig';
+
+export interface StorageInterface {
+  getItem(key: string): Promise<null|string>;
+  setItem(key: string, value: string): Promise<void>;
+}
+
+export class UIKitConfigStorageManager {
+  key: string;
+
+  storage: StorageInterface;
+
+  constructor(storage: StorageInterface) {
+    this.storage = storage;
+  }
+
+  init(appId: string) {
+    this.key = `sbu@${appId}.uikitConfiguration`;
+    return this.get();
+  }
+
+  async update(payload: UIKitConfigPayload) {
+    const storedConfig = await this.get();
+    const mergedConfig = {
+      lastUpdatedAt: payload.lastUpdatedAt,
+      uikitConfigurations: mergeConfigs(storedConfig?.uikitConfigurations, payload?.uikitConfigurations),
+    };
+    await this.storage.setItem(this.key, JSON.stringify(mergedConfig));
+    return mergedConfig;
+  }
+
+  async get(): Promise<UIKitConfigPayload> {
+    const initialPayload = {
+      lastUpdatedAt: 0,
+      uikitConfigurations: initialConfig,
+    };
+    try {
+      const storedConfig = await this.storage.getItem(this.key);
+      if (storedConfig) {
+        // TODO: Validation
+        return JSON.parse(storedConfig);
+      } else {
+        return initialPayload;
+      }
+    } catch {
+      return initialPayload;
+    }
+  }
+}

--- a/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/index.ts
+++ b/src/lib/UIKitConfigProvider/UIKitConfigStorageManager/index.ts
@@ -25,7 +25,7 @@ export class UIKitConfigStorageManager {
     const storedConfig = await this.get();
     const mergedConfig = {
       lastUpdatedAt: payload.lastUpdatedAt,
-      uikitConfigurations: mergeConfigs(storedConfig?.uikitConfigurations, payload?.uikitConfigurations),
+      uikitConfigurations: mergeConfigs(payload?.uikitConfigurations, storedConfig?.uikitConfigurations),
     };
     await this.storage.setItem(this.key, JSON.stringify(mergedConfig));
     return mergedConfig;

--- a/src/lib/UIKitConfigProvider/const/initialConfig.ts
+++ b/src/lib/UIKitConfigProvider/const/initialConfig.ts
@@ -1,0 +1,55 @@
+import { UIKitConfigInfo } from '../types';
+
+// @link: https://docs.google.com/spreadsheets/d/1-AozBMHRYOXS74vZ-7x2ptQcBL6nnM-orJWRvUgmkd4/edit#gid=0
+const initialConfig: UIKitConfigInfo = {
+  common: {
+    enableUsingDefaultUserProfile: false,
+  },
+  groupChannel: {
+    channel: {
+      enableMention: false,
+      enableOgtag: true,
+      enableReactions: true,
+      enableTypingIndicator: true,
+      enableVoiceMessage: false,
+      input: {
+        camera: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+        enableDocument: true,
+        gallery: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+      },
+      replyType: 'quote_reply',
+      threadReplySelectType: 'thread',
+    },
+    channelList: {
+      enableMessageReceiptStatus: false,
+      enableTypingIndicator: false,
+    },
+    setting: {
+      enableMessageSearch: false,
+    },
+  },
+  openChannel: {
+    channel: {
+      enableOgtag: true,
+      input: {
+        camera: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+        enableDocument: true,
+        gallery: {
+          enablePhoto: true,
+          enableVideo: true,
+        },
+      },
+    },
+  },
+};
+
+export default initialConfig;


### PR DESCRIPTION
### Description Of Changes
Implemented storage manager class to store UIKitConfig response. This will be used to decide whether we call the sdk.getUIKitConfiguration() again or not by comparing `lastUpdatedAt` field value. 

UIKit React doesn't have plan to use this feature for now but probably will be used in RN. 
After this PR  is merged, we will move the whole logic under `lib/UIKitConfigProvider` to https://github.com/sendbird/sendbird-uikit-core-ts/tree/main/packages/uikit-tools. 