### PR TITLE
fix: Use short muted message in message input of mobile mode

### DIFF
--- a/src/modules/Channel/components/MessageInput/index.tsx
+++ b/src/modules/Channel/components/MessageInput/index.tsx
@@ -12,6 +12,7 @@ import SuggestedMentionList from '../SuggestedMentionList';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
 import VoiceMessageInputWrapper from './VoiceMessageInputWrapper';
 import { useDirtyGetMentions } from '../../../Message/hooks/useDirtyGetMentions';
+import { useMediaQueryContext } from '../../../../lib/MediaQueryContext';
 
 export type MessageInputWrapperProps = {
   value?: string;
@@ -44,6 +45,7 @@ const MessageInputWrapper = (
     renderUserMentionItem,
   } = useChannelContext();
   const globalStore = useSendbirdStateContext();
+  const { isMobile } = useMediaQueryContext();
   const channel = currentGroupChannel;
 
   const {
@@ -177,7 +179,9 @@ const MessageInputWrapper = (
               placeholder={
                 (quoteMessage && stringSet.MESSAGE_INPUT__QUOTE_REPLY__PLACE_HOLDER)
                 || (utils.isDisabledBecauseFrozen(channel) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED)
-                || (utils.isDisabledBecauseMuted(channel) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED)
+                || (utils.isDisabledBecauseMuted(channel) && (
+                  isMobile ? stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED_SHORT : stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED
+                ))
               }
               ref={ref || messageInputRef}
               disabled={disabled}


### PR DESCRIPTION
### Description Of Changes

before
<img width="368" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/649b5d27-55ae-4dbb-b386-5c8a6c25c490">
after
<img width="372" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/6eafddf0-c1d1-4ae2-9630-06b3bea72d83">

[UIKIT-3911](https://sendbird.atlassian.net/browse/UIKIT-3911)


[UIKIT-3911]: https://sendbird.atlassian.net/browse/UIKIT-3911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ