### PR TITLE
fix: Add border bottom to the ParentMessageInfo component

### DIFF
--- a/src/modules/Thread/components/ThreadUI/index.scss
+++ b/src/modules/Thread/components/ThreadUI/index.scss
@@ -35,6 +35,7 @@
 .sendbird-thread-ui__parent-message-info {
   @include themed() {
     border-top: 1px solid t(on-bg-4);
+    border-bottom: 1px solid t(on-bg-4);
   }
   .sendbird-word__mention {
     .sendbird-label {


### PR DESCRIPTION
### Description Of Changes

The design request has been changed

#### before
Desktop
<img width="424" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/781dcd6f-c0de-4537-824c-b96951335eab">
Mobile
<img width="381" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/42f00447-8ac9-4800-9b0b-cf37680c42a5">

#### after
Desktop
<img width="436" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/82c67d59-8e4b-4ae2-b803-b9c0671f0ef2">
mobile
<img width="382" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/652c4def-cb98-463e-af21-16aa54d686e7">

[UIKIT-3914](https://sendbird.atlassian.net/browse/UIKIT-3914)

[UIKIT-3914]: https://sendbird.atlassian.net/browse/UIKIT-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ