### PR TITLE
fix: Remove edited message from ChannelPreview

### DIFF
--- a/src/modules/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/modules/ChannelList/components/ChannelPreview/index.tsx
@@ -19,7 +19,7 @@ import TextButton from '../../../../ui/TextButton';
 import { useChannelListContext } from '../../context/ChannelListProvider';
 import { TypingIndicatorText } from '../../../Channel/components/TypingIndicator';
 import MessageStatus from '../../../../ui/MessageStatus';
-import { isEditedMessage, isVoiceMessage } from '../../../../utils';
+import { isVoiceMessage } from '../../../../utils';
 import { useMediaQueryContext } from '../../../../lib/MediaQueryContext';
 import useLongPress from '../../../../hooks/useLongPress';
 
@@ -176,7 +176,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
               }
               {
                 !isChannelTyping && !isVoiceMessage(channel?.lastMessage as FileMessage) && (
-                  utils.getLastMessage(channel) + (isEditedMessage(channel?.lastMessage as UserMessage | FileMessage) ? ` ${stringSet.MESSAGE_EDITED}` : '')
+                  utils.getLastMessage(channel)
                 )
               }
               {


### PR DESCRIPTION
### Description Of Changes

* remove the (edited) text from ChannelPreview component

before
<img width="378" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/cd5fcb25-6e1e-4ed5-bb97-b49dc192cc05">

after
<img width="387" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/6ec91c81-08e0-497f-9d9d-8d0196bcebe5">

[UIKIT-3992](https://sendbird.atlassian.net/browse/UIKIT-3992)

[UIKIT-3992]: https://sendbird.atlassian.net/browse/UIKIT-3992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ