### PR TITLE
fix: Improve MobileContextMenu

### DIFF
--- a/src/ui/MobileMenu/MobileContextMenu.tsx
+++ b/src/ui/MobileMenu/MobileContextMenu.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../utils';
 import { useLocalization } from '../../lib/LocalizationContext';
 import Icon, { IconTypes, IconColors } from '../Icon';
-import Label, { LabelTypography } from '../Label';
+import Label, { LabelColors, LabelTypography } from '../Label';
 
 const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMenuProps): React.ReactElement => {
   const {
@@ -43,7 +43,7 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
   const showMenuItemReply: boolean = (replyType === 'QUOTE_REPLY')
     && !isFailedMessage(message)
     && !isPendingMessage(message)
-    && (channel?.isGroupChannel() && !(channel as GroupChannel)?.isBroadcast);
+    && channel?.isGroupChannel();
   const showMenuItemThread: boolean = (replyType === 'THREAD') && !isOpenedFromThread
     && !isFailedMessage(message)
     && !isPendingMessage(message)
@@ -70,7 +70,10 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               }}
               dataSbId="ui_mobile_message_item_menu_copy"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
                 {stringSet?.MESSAGE_MENU__COPY}
               </Label>
               <Icon
@@ -88,15 +91,26 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
                 hideMenu();
                 setQuoteMessage(message);
               }}
-              disable={message?.parentMessageId > 0}
+              disable={(message?.parentMessageId ?? 0) > 0}
               dataSbId="ui_mobile_message_item_menu_reply"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={
+                  (message?.parentMessageId ?? 0) > 0
+                    ? LabelColors.ONBACKGROUND_4
+                    : LabelColors.ONBACKGROUND_1
+                }
+              >
                 {stringSet.MESSAGE_MENU__REPLY}
               </Label>
               <Icon
                 type={IconTypes.REPLY}
-                fillColor={IconColors.PRIMARY}
+                fillColor={
+                  (message?.parentMessageId ?? 0) > 0
+                    ? IconColors.ON_BACKGROUND_4
+                    : IconColors.PRIMARY
+                }
                 width="24px"
                 height="24px"
               />
@@ -111,7 +125,10 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               }}
               dataSbId="ui_mobile_message_item_menu_thread"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
                 {stringSet.MESSAGE_MENU__THREAD}
               </Label>
               <Icon
@@ -131,7 +148,10 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               }}
               dataSbId="ui_mobile_message_item_menu_edit"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
                 {stringSet.MESSAGE_MENU__EDIT}
               </Label>
               <Icon
@@ -151,7 +171,10 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               }}
               dataSbId="ui_mobile_message_item_menu_resend"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
                 {stringSet.MESSAGE_MENU__RESEND}
               </Label>
               <Icon
@@ -169,15 +192,26 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
                 hideMenu();
                 showRemove(true);
               }}
-              disable={message?.threadInfo?.replyCount > 0}
+              disable={(message?.threadInfo?.replyCount ?? 0) > 0}
               dataSbId="ui_mobile_message_item_menu_delete"
             >
-              <Label type={LabelTypography.SUBTITLE_1}>
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={
+                  (message?.threadInfo?.replyCount ?? 0) > 0
+                    ? LabelColors.ONBACKGROUND_4
+                    : LabelColors.ONBACKGROUND_1
+                }
+              >
                 {stringSet.MESSAGE_MENU__DELETE}
               </Label>
               <Icon
                 type={IconTypes.DELETE}
-                fillColor={IconColors.PRIMARY}
+                fillColor={
+                  (message?.threadInfo?.replyCount ?? 0) > 0
+                    ? IconColors.ON_BACKGROUND_4
+                    : IconColors.PRIMARY
+                }
                 width="24px"
                 height="24px"
               />
@@ -197,7 +231,10 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
                 href={fileMessage?.url}
                 target="_blank"
               >
-                <Label type={LabelTypography.SUBTITLE_1}>
+                <Label
+                  type={LabelTypography.SUBTITLE_1}
+                  color={LabelColors.ONBACKGROUND_1}
+                >
                   {stringSet.MESSAGE_MENU__SAVE}
                 </Label>
                 <Icon

--- a/src/ui/MobileMenu/MobileContextMenu.tsx
+++ b/src/ui/MobileMenu/MobileContextMenu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { BaseMenuProps } from './types';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
-import type { GroupChannel } from '@sendbird/chat/groupChannel';
 
 import ContextMenu, { MenuItems, MenuItem } from '../ContextMenu';
 


### PR DESCRIPTION
In the mode: `replyType="QUOTE_REPLY"`
* show a reply menu item in the broadcast channel
* apply disabled text color
* apply disabled icon color

[UIKIT-4016](https://sendbird.atlassian.net/browse/UIKIT-4016)

#### before
<img width="373" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/51d68ff3-707b-4f40-8bf3-e024c39fffee">
<img width="378" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/95303f24-5d9d-4b5c-a197-a0bd928957a6">
<img width="374" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/51d600a2-2912-47f7-b659-77e4de7b7063">
<img width="372" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/269aa9a7-1e12-4936-b9d6-65bfd2bed74a">

#### after
<img width="375" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/99ff3612-ee16-45d8-84ee-64c4565a569d">
<img width="377" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/4e691a27-91ad-49a7-88e4-ff5023143ce4">
<img width="373" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/1ea73f28-2b25-431e-b4ec-4cee30c91fd0">
<img width="371" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/1cc6dcd8-d169-47cf-9657-1c792c8cca23">


[UIKIT-4016]: https://sendbird.atlassian.net/browse/UIKIT-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ