### PR TITLE
fix: Change OpenChannelInput muted state notice text

### DIFF
--- a/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
+++ b/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
@@ -17,9 +17,6 @@ const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObje
   } = useOpenChannelContext();
 
   const channel = currentOpenChannel;
-  if (!channel) {
-    return null;
-  }
 
   const { stringSet } = useContext(LocalizationContext);
   const { value } = props;
@@ -34,6 +31,9 @@ const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObje
     return '';
   }
 
+  if (!channel) {
+    return null;
+  }
   return (
     <div className="sendbird-openchannel-footer">
       <MessageInput

--- a/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
+++ b/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
@@ -7,21 +7,32 @@ export type MessageInputWrapperProps = {
   value?: string;
 };
 
-const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObject<HTMLInputElement>): JSX.Element => {
+const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObject<HTMLInputElement>): React.ReactNode => {
   const {
     currentOpenChannel,
     disabled,
     handleSendMessage,
     handleFileUpload,
+    amIMuted,
   } = useOpenChannelContext();
 
   const channel = currentOpenChannel;
   if (!channel) {
-    return;
+    return null;
   }
 
   const { stringSet } = useContext(LocalizationContext);
   const { value } = props;
+
+  function getPlaceHolderString() {
+    if (amIMuted) {
+      return stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED;
+    }
+    if (disabled) {
+      return stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED;
+    }
+    return '';
+  }
 
   return (
     <div className="sendbird-openchannel-footer">
@@ -32,11 +43,7 @@ const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObje
         isVoiceMessageEnabled={false}
         onSendMessage={handleSendMessage}
         onFileUpload={handleFileUpload}
-        placeholder={(
-          disabled
-          && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED
-          // add disabled because of muted state
-        )}
+        placeholder={getPlaceHolderString()}
       />
     </div>
   );


### PR DESCRIPTION
### Description Of Changes

* Notice disabled message input because of muted state

[UIKIT-4055](https://sendbird.atlassian.net/browse/UIKIT-4055)

before
<img width="377" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/0ecc74f5-3fb2-4bfd-9965-4c8ce33ec4e8">

after
<img width="376" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/c3eef6e8-befa-4604-9642-f1cd56af2162">


[UIKIT-4055]: https://sendbird.atlassian.net/browse/UIKIT-4055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ