### PR TITLE
fix: Remove loading placeholder on image

### DIFF
--- a/src/ui/ThumbnailMessageItemBody/__tests__/ThumbnailMessageItemBody.spec.js
+++ b/src/ui/ThumbnailMessageItemBody/__tests__/ThumbnailMessageItemBody.spec.js
@@ -63,9 +63,6 @@ describe('ui/ThumbnailMessageItemBody', () => {
       container.querySelectorAll('.sendbird-thumbnail-message-item-body__icon-wrapper')
     ).toHaveLength(0);
     expect(
-      container.querySelectorAll('.sendbird-icon-photo')
-    ).toHaveLength(1);
-    expect(
       container.querySelectorAll('sendbird-icon-play')
     ).toHaveLength(0);
     expect(
@@ -137,7 +134,7 @@ describe('ui/ThumbnailMessageItemBody', () => {
     ).toHaveLength(0);
     expect(
       container.querySelectorAll('.sendbird-icon-play')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
     expect(
       container.querySelectorAll('.sendbird-icon-gif')
     ).toHaveLength(0);
@@ -162,9 +159,6 @@ describe('ui/ThumbnailMessageItemBody', () => {
       container.querySelectorAll('.sendbird-thumbnail-message-item-body__icon-wrapper')
     ).toHaveLength(1);
 
-    expect(
-      container.querySelectorAll('.sendbird-icon-photo')
-    ).toHaveLength(1); // as a default component
     expect(
       container.querySelectorAll('.sendbird-icon-play')
     ).toHaveLength(0);

--- a/src/ui/ThumbnailMessageItemBody/__tests__/__snapshots__/ThumbnailMessageItemBody.spec.js.snap
+++ b/src/ui/ThumbnailMessageItemBody/__tests__/__snapshots__/ThumbnailMessageItemBody.spec.js.snap
@@ -11,20 +11,7 @@ exports[`ui/ThumbnailMessageItemBody should do a snapshot test of the ThumbnailM
     >
       <div
         class="sendbird-thumbnail-message-item-body__placeholder"
-      >
-        <div
-          class="sendbird-thumbnail-message-item-body__placeholder__icon"
-        >
-          <div
-            class=" sendbird-icon sendbird-icon-photo sendbird-icon-color--on-background-2"
-            role="button"
-            style="width: 34px; min-width: 34px; height: 34px; min-height: 34px;"
-            tabindex="0"
-          >
-            <test-file-stub />
-          </div>
-        </div>
-      </div>
+      />
       <div
         class="sendbird-image-renderer__image"
         style="width: 100%; min-width: 360px; max-width: 400px; height: 270px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url(https://static.sendbird.com/sample/user_sdk/user_sdk_25.png);"

--- a/src/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/ui/ThumbnailMessageItemBody/index.tsx
@@ -62,16 +62,7 @@ export default function ThumbnailMessageItemBody({
           <div
             className="sendbird-thumbnail-message-item-body__placeholder"
             style={style_}
-          >
-            <div className="sendbird-thumbnail-message-item-body__placeholder__icon">
-              <Icon
-                type={isVideoMessage(message) ? IconTypes.PLAY : IconTypes.PHOTO}
-                fillColor={IconColors.ON_BACKGROUND_2}
-                width="34px"
-                height="34px"
-              />
-            </div>
-          </div>
+          />
         )}
       />
       {


### PR DESCRIPTION
Remove the old loader on thumbnail message because they look
a bit weird

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4044