### PR TITLE
hotfix: make replyType case conversion safe

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -21,6 +21,9 @@ import pubSubFactory from './pubSub/index';
 import useAppendDomNode from '../hooks/useAppendDomNode';
 
 import { UIKitConfigProvider, useUIKitConfig } from './UIKitConfigProvider';
+import initialConfig from './UIKitConfigProvider/const/initialConfig';
+import { GroupChannelConfig } from './UIKitConfigProvider/types';
+
 import { VoiceMessageProvider } from './VoiceMessageProvider';
 import { LocalizationProvider } from './LocalizationContext';
 import { MediaQueryProvider } from './MediaQueryContext';
@@ -116,7 +119,9 @@ function Sendbird(props: SendbirdProviderProps) {
              * we convert it from here.
              * i.e. 'THREAD' -> 'thread'
              */
-            replyType: replyType.toLowerCase(),
+            replyType: replyType == null
+              ? initialConfig.groupChannel.channel.replyType
+              : replyType.toLowerCase() as GroupChannelConfig['channel']['replyType'],
           },
           channelList: {
             enableTypingIndicator: isTypingIndicatorEnabledOnChannelList,


### PR DESCRIPTION
### Description Of Changes
(Reported directly by Sravan 😄)

![Screen Shot 2023-06-05 at 4 41 06 PM](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/e9ff8e33-003b-4002-b7c7-85774df41bc2)

`replyType` prop barely has null value but there's a chance to be null cause we allow it. So making it safe before it goes into `toLowerCase()`.