### PR TITLE
fix: OpenChannel Context menu click leak

### DIFF
--- a/src/modules/OpenChannel/components/OpenChannelMessage/index.tsx
+++ b/src/modules/OpenChannel/components/OpenChannelMessage/index.tsx
@@ -218,7 +218,7 @@ export default function MessagOpenChannelMessageeHoc(props: OpenChannelMessagePr
             //   <OpenChannelUnknownMessage message={message} />
             // );
           })(),
-        }[getMessageType(message)]
+        }[getMessageType(message, { isOgMessageEnabledInOpenChannel })]
       }
       {/* Modal */}
       {

--- a/src/modules/OpenChannel/components/OpenChannelMessage/utils.ts
+++ b/src/modules/OpenChannel/components/OpenChannelMessage/utils.ts
@@ -17,9 +17,17 @@ export const SendingMessageStatus = {
   PENDING: 'pending',
 };
 
-export const getMessageType = (message: UserMessage | FileMessage | AdminMessage): string => {
+type MessageTypeOptions = {
+  isOgMessageEnabledInOpenChannel?: boolean;
+};
+
+export const getMessageType = (
+  message: UserMessage | FileMessage | AdminMessage,
+  options?: MessageTypeOptions,
+): string => {
+  const isOgMessageEnabledInOpenChannel = options?.isOgMessageEnabledInOpenChannel;
   if ((message?.isUserMessage?.()) || message?.messageType === 'user') {
-    return (message?.ogMetaData)
+    return (message?.ogMetaData && isOgMessageEnabledInOpenChannel)
       ? MessageTypes.OG
       : MessageTypes.USER;
   }

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -74,147 +74,217 @@ export default function OpenchannelFileMessage({
     onClick: openFileUrl,
   }, { delay: 300 });
   return (
-    <div
-      className={[
-        ...(Array.isArray(className) ? className : [className]),
-        'sendbird-openchannel-file-message',
-      ].join(' ')}
-      ref={mobileMenuRef}
-    >
-      <div className="sendbird-openchannel-file-message__left">
-        {
-          !chainTop && (
-            <ContextMenu
-              menuTrigger={(toggleDropdown) => (
-                <Avatar
-                  className="sendbird-openchannel-file-message__left__avatar"
-                  src={sender.profileUrl || ''}
-                  ref={avatarRef}
-                  width="28px"
-                  height="28px"
-                  onClick={() => {
-                    if (!disableUserProfile) {
-                      toggleDropdown();
-                    }
-                  }}
-                />
-              )}
-              menuItems={(closeDropdown) => (
-                <MenuItems
-                  parentRef={avatarRef}
-                  parentContainRef={avatarRef}
-                  closeDropdown={closeDropdown}
-                  style={{ paddingTop: '0px', paddingBottom: '0px' }}
-                >
-                  {
-                    renderUserProfile
-                      ? (
-                        renderUserProfile({
-                          user: sender,
-                          close: closeDropdown,
-                        })
-                      )
-                      : (
-                        <UserProfile
-                          user={sender}
-                          onSuccess={closeDropdown}
-                          disableMessaging
-                        />
-                      )
-                  }
-                </MenuItems>
-              )}
-            />
-          )
-        }
-      </div>
-      <div className="sendbird-openchannel-file-message__right">
-        {
-          !chainTop && (
-            <div className="sendbird-openchannel-file-message__right__title">
-              <Label
-                className="sendbird-openchannel-file-message__right__title__sender-name"
-                type={LabelTypography.CAPTION_2}
-                color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
-              >
-                {
-                  sender && (
-                    sender.friendName
-                    || sender.nickname
-                    || sender.userId
-                  )
-                }
-              </Label>
-              <Label
-                className="sendbird-openchannel-file-message__right__title__sent-at"
-                type={LabelTypography.CAPTION_3}
-                color={LabelColors.ONBACKGROUND_3}
-              >
-                {
-                  message?.createdAt && (
-                    format(message.createdAt, 'p', {
-                      locale: dateLocale,
-                    })
-                  )
-                }
-              </Label>
-            </div>
-          )
-        }
-        <div
-          className="sendbird-openchannel-file-message__right__body"
-          {...(isMobile ? { ...longPress } : {})}
-        >
+    <>
+      <div
+        className={[
+          ...(Array.isArray(className) ? className : [className]),
+          'sendbird-openchannel-file-message',
+        ].join(' ')}
+        ref={mobileMenuRef}
+      >
+        <div className="sendbird-openchannel-file-message__left">
           {
-            checkFileType(message.url) && (
-              <Icon
-                className="sendbird-openchannel-file-message__right__body__icon"
-                type={checkFileType(message.url)}
-                fillColor={IconColors.PRIMARY}
-                width="48px"
-                height="48px"
+            !chainTop && (
+              <ContextMenu
+                menuTrigger={(toggleDropdown) => (
+                  <Avatar
+                    className="sendbird-openchannel-file-message__left__avatar"
+                    src={sender.profileUrl || ''}
+                    ref={avatarRef}
+                    width="28px"
+                    height="28px"
+                    onClick={() => {
+                      if (!disableUserProfile) {
+                        toggleDropdown();
+                      }
+                    }}
+                  />
+                )}
+                menuItems={(closeDropdown) => (
+                  <MenuItems
+                    parentRef={avatarRef}
+                    parentContainRef={avatarRef}
+                    closeDropdown={closeDropdown}
+                    style={{ paddingTop: '0px', paddingBottom: '0px' }}
+                  >
+                    {
+                      renderUserProfile
+                        ? (
+                          renderUserProfile({
+                            user: sender,
+                            close: closeDropdown,
+                          })
+                        )
+                        : (
+                          <UserProfile
+                            user={sender}
+                            onSuccess={closeDropdown}
+                            disableMessaging
+                          />
+                        )
+                    }
+                  </MenuItems>
+                )}
               />
             )
           }
-          <TextButton
-            className="sendbird-openchannel-file-message__right__body__file-name"
-            onClick={openFileUrl}
-          >
-            <Label
-              type={LabelTypography.BODY_1}
-              color={LabelColors.ONBACKGROUND_1}
-            >
-              {truncate(message.name || message.url, 40)}
-            </Label>
-          </TextButton>
         </div>
-        {
-          (isPending || isFailed) && (
-            <div className="sendbird-openchannel-file-message__right__tail">
-              {
-                isPending && (
-                  <Loader
-                    width="16px"
-                    height="16px"
-                  >
+        <div className="sendbird-openchannel-file-message__right">
+          {
+            !chainTop && (
+              <div className="sendbird-openchannel-file-message__right__title">
+                <Label
+                  className="sendbird-openchannel-file-message__right__title__sender-name"
+                  type={LabelTypography.CAPTION_2}
+                  color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
+                >
+                  {
+                    sender && (
+                      sender.friendName
+                      || sender.nickname
+                      || sender.userId
+                    )
+                  }
+                </Label>
+                <Label
+                  className="sendbird-openchannel-file-message__right__title__sent-at"
+                  type={LabelTypography.CAPTION_3}
+                  color={LabelColors.ONBACKGROUND_3}
+                >
+                  {
+                    message?.createdAt && (
+                      format(message.createdAt, 'p', {
+                        locale: dateLocale,
+                      })
+                    )
+                  }
+                </Label>
+              </div>
+            )
+          }
+          <div
+            className="sendbird-openchannel-file-message__right__body"
+            {...(isMobile ? { ...longPress } : {})}
+          >
+            {
+              checkFileType(message.url) && (
+                <Icon
+                  className="sendbird-openchannel-file-message__right__body__icon"
+                  type={checkFileType(message.url)}
+                  fillColor={IconColors.PRIMARY}
+                  width="48px"
+                  height="48px"
+                />
+              )
+            }
+            <TextButton
+              className="sendbird-openchannel-file-message__right__body__file-name"
+              onClick={openFileUrl}
+            >
+              <Label
+                type={LabelTypography.BODY_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
+                {truncate(message.name || message.url, 40)}
+              </Label>
+            </TextButton>
+          </div>
+          {
+            (isPending || isFailed) && (
+              <div className="sendbird-openchannel-file-message__right__tail">
+                {
+                  isPending && (
+                    <Loader
+                      width="16px"
+                      height="16px"
+                    >
+                      <Icon
+                        className="sendbird-openchannel-file-message__right__tail__pending"
+                        type={IconTypes.SPINNER}
+                        fillColor={IconColors.PRIMARY}
+                        width="16px"
+                        height="16px"
+                      />
+                    </Loader>
+                  )
+                }
+                {
+                  isFailed && (
                     <Icon
-                      className="sendbird-openchannel-file-message__right__tail__pending"
-                      type={IconTypes.SPINNER}
-                      fillColor={IconColors.PRIMARY}
+                      className="sendbird-openchannel-file-message__right__tail__failed"
+                      type={IconTypes.ERROR}
+                      fillColor={IconColors.ERROR}
                       width="16px"
                       height="16px"
                     />
-                  </Loader>
-                )
-              }
+                  )
+                }
+              </div>
+            )
+          }
+        </div>
+        {
+          !isMobile && (
+            <div
+              className="sendbird-openchannel-file-message__context-menu"
+              ref={contextMenuRef}
+            >
               {
-                isFailed && (
-                  <Icon
-                    className="sendbird-openchannel-file-message__right__tail__failed"
-                    type={IconTypes.ERROR}
-                    fillColor={IconColors.ERROR}
-                    width="16px"
-                    height="16px"
+                (isFineResend({ message, userId, status }) || !isEphemeral) && (
+                  <ContextMenu
+                    menuTrigger={(toggleDropdown) => (
+                      showMenuTrigger({ message, userId, status }) && (
+                        <IconButton
+                          className="sendbird-openchannel-file-message__context-menu__icon"
+                          width="32px"
+                          height="32px"
+                          onClick={toggleDropdown}
+                        >
+                          <Icon
+                            type={IconTypes.MORE}
+                            width="24px"
+                            height="24px"
+                          />
+                        </IconButton>
+                      )
+                    )}
+                    menuItems={(closeDropdown) => (
+                      <MenuItems
+                        parentRef={contextMenuRef}
+                        parentContainRef={contextMenuRef}
+                        closeDropdown={closeDropdown}
+                        openLeft
+                      >
+                        {
+                          isFineResend({ message, userId, status }) && (
+                            <MenuItem
+                              onClick={() => {
+                                if (disabled) { return; }
+                                resendMessage(message);
+                                closeDropdown();
+                              }}
+                              dataSbId="open_channel_file_message_context_menu_resend"
+                            >
+                              {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
+                            </MenuItem>
+                          )
+                        }
+                        {
+                          (!isEphemeral && isFineDelete({ message, userId, status })) && (
+                            <MenuItem
+                              onClick={() => {
+                                if (disabled) { return; }
+                                showRemove(true);
+                                closeDropdown();
+                              }}
+                              dataSbId="open_channel_file_message_context_menu_delete"
+                            >
+                              {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
+                            </MenuItem>
+                          )
+                        }
+                      </MenuItems>
+                    )}
                   />
                 )
               }
@@ -222,74 +292,6 @@ export default function OpenchannelFileMessage({
           )
         }
       </div>
-      {
-        !isMobile && (
-          <div
-            className="sendbird-openchannel-file-message__context-menu"
-            ref={contextMenuRef}
-          >
-            {
-              (isFineResend({ message, userId, status }) || !isEphemeral) && (
-                <ContextMenu
-                  menuTrigger={(toggleDropdown) => (
-                    showMenuTrigger({ message, userId, status }) && (
-                      <IconButton
-                        className="sendbird-openchannel-file-message__context-menu__icon"
-                        width="32px"
-                        height="32px"
-                        onClick={toggleDropdown}
-                      >
-                        <Icon
-                          type={IconTypes.MORE}
-                          width="24px"
-                          height="24px"
-                        />
-                      </IconButton>
-                    )
-                  )}
-                  menuItems={(closeDropdown) => (
-                    <MenuItems
-                      parentRef={contextMenuRef}
-                      parentContainRef={contextMenuRef}
-                      closeDropdown={closeDropdown}
-                      openLeft
-                    >
-                      {
-                        isFineResend({ message, userId, status }) && (
-                          <MenuItem
-                            onClick={() => {
-                              if (disabled) { return; }
-                              resendMessage(message);
-                              closeDropdown();
-                            }}
-                            dataSbId="open_channel_file_message_context_menu_resend"
-                          >
-                            {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
-                          </MenuItem>
-                        )
-                      }
-                      {
-                        (!isEphemeral && isFineDelete({ message, userId, status })) && (
-                          <MenuItem
-                            onClick={() => {
-                              if (disabled) { return; }
-                              showRemove(true);
-                              closeDropdown();
-                            }}
-                            dataSbId="open_channel_file_message_context_menu_delete"
-                          >
-                            {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
-                          </MenuItem>
-                        )
-                      }
-                    </MenuItems>
-                  )}
-                />
-              )
-            }
-          </div>
-        )
-      }
       {
         contextMenu && (
           <OpenChannelMobileMenu
@@ -305,6 +307,6 @@ export default function OpenchannelFileMessage({
           />
         )
       }
-    </div>
+    </>
   );
 }

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -72,7 +72,7 @@ export default function OpenchannelOGMessage({
 
   const openLink = () => {
     if (checkOGIsEnalbed(message) && ogMetaData?.url) {
-      window.open(ogMetaData.url);
+      window.open(ogMetaData.url, '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -112,325 +112,327 @@ export default function OpenchannelOGMessage({
   }
 
   return (
-    <div
-      className={[
-        ...(Array.isArray(className) ? className : [className]),
-        'sendbird-openchannel-og-message',
-      ].join(' ')}
-      ref={messageComponentRef}
-      {...(isMobile ? { ...onLongPress } : {})}
-    >
+    <>
       <div
-        className="sendbird-openchannel-og-message__top"
+        className={[
+          ...(Array.isArray(className) ? className : [className]),
+          'sendbird-openchannel-og-message',
+        ].join(' ')}
+        ref={messageComponentRef}
+        {...(isMobile ? { ...onLongPress } : {})}
       >
-        <div className="sendbird-openchannel-og-message__top__left">
-          {
-            !chainTop && (
-              <ContextMenu
-                menuTrigger={(toggleDropdown) => (
-                  <Avatar
-                    className="sendbird-openchannel-og-message__top__left__avatar"
-                    src={sender.profileUrl || ''}
-                    ref={avatarRef}
-                    width="28px"
-                    height="28px"
-                    onClick={() => {
-                      if (!disableUserProfile) {
-                        toggleDropdown();
-                      }
-                    }}
-                  />
-                )}
-                menuItems={(closeDropdown) => (
-                  <MenuItems
-                    parentRef={avatarRef}
-                    parentContainRef={avatarRef}
-                    closeDropdown={closeDropdown}
-                    style={{ paddingTop: '0px', paddingBottom: '0px' }}
-                  >
-                    {
-                      renderUserProfile
-                        ? (
-                          renderUserProfile({
-                            user: sender,
-                            close: closeDropdown,
-                          })
-                        )
-                        : (
-                          <UserProfile
-                            user={sender}
-                            onSuccess={closeDropdown}
-                            disableMessaging
-                          />
-                        )
-                    }
-                  </MenuItems>
-                )}
-              />
-            )
-          }
-        </div>
-        <div className="sendbird-openchannel-og-message__top__right">
-          {
-            !chainTop && (
-              <div className="sendbird-openchannel-og-message__top__right__title">
-                <Label
-                  className="sendbird-openchannel-og-message__top__right__title__sender-name"
-                  type={LabelTypography.CAPTION_2}
-                  color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
-                >
-                  {
-                    sender && (
-                      sender.friendName
-                      || sender.nickname
-                      || sender.userId
-                    )
-                  }
-                </Label>
-                <Label
-                  className="sendbird-openchannel-og-message__top__right__title__sent-at"
-                  type={LabelTypography.CAPTION_3}
-                  color={LabelColors.ONBACKGROUND_3}
-                >
-                  {
-                    message?.createdAt && (
-                      format(message?.createdAt, 'p', {
-                        locale: dateLocale,
-                      })
-                    )
-                  }
-                </Label>
-              </div>
-            )
-          }
-          <div className="sendbird-openchannel-og-message__top__right__description">
-            <Label
-              className="sendbird-openchannel-og-message__top__right__description__message"
-              type={LabelTypography.BODY_1}
-              color={LabelColors.ONBACKGROUND_1}
-            >
-              <TextFragment tokens={tokens} />
-              {
-                ((message?.updatedAt ?? 0) > 0) && (
-                  <Label
-                    key={uuidv4()}
-                    className='sendbird-openchannel-og-message--word'
-                    type={LabelTypography.BODY_1}
-                    color={LabelColors.ONBACKGROUND_2}
-                  >
-                    {stringSet.MESSAGE_EDITED}
-                  </Label>
-                )
-              }
-            </Label>
-          </div>
-        </div>
-        {
-          !isMobile && (
-            <div
-              className="sendbird-openchannel-og-message__top__context-menu"
-              ref={contextMenuRef}
-              style={contextStyle}
-            >
-              <ContextMenu
-                menuTrigger={(toggleDropdown) => (
-                  showMenuTrigger({ message: message, userId: userId, status: status }) && (
-                    <IconButton
-                      className="sendbird-openchannel-og-message__top__context-menu--icon"
-                      width="32px"
-                      height="32px"
+        <div
+          className="sendbird-openchannel-og-message__top"
+        >
+          <div className="sendbird-openchannel-og-message__top__left">
+            {
+              !chainTop && (
+                <ContextMenu
+                  menuTrigger={(toggleDropdown) => (
+                    <Avatar
+                      className="sendbird-openchannel-og-message__top__left__avatar"
+                      src={sender.profileUrl || ''}
+                      ref={avatarRef}
+                      width="28px"
+                      height="28px"
                       onClick={() => {
-                        toggleDropdown();
+                        if (!disableUserProfile) {
+                          toggleDropdown();
+                        }
                       }}
+                    />
+                  )}
+                  menuItems={(closeDropdown) => (
+                    <MenuItems
+                      parentRef={avatarRef}
+                      parentContainRef={avatarRef}
+                      closeDropdown={closeDropdown}
+                      style={{ paddingTop: '0px', paddingBottom: '0px' }}
                     >
-                      <Icon
-                        type={IconTypes.MORE}
-                        fillColor={IconColors.CONTENT_INVERSE}
-                        width="24px"
-                        height="24px"
-                      />
-                    </IconButton>
-                  )
-                )}
-                menuItems={(closeDropdown) => (
-                  <MenuItems
-                    parentRef={contextMenuRef}
-                    parentContainRef={contextMenuRef}
-                    closeDropdown={closeDropdown}
-                    openLeft
+                      {
+                        renderUserProfile
+                          ? (
+                            renderUserProfile({
+                              user: sender,
+                              close: closeDropdown,
+                            })
+                          )
+                          : (
+                            <UserProfile
+                              user={sender}
+                              onSuccess={closeDropdown}
+                              disableMessaging
+                            />
+                          )
+                      }
+                    </MenuItems>
+                  )}
+                />
+              )
+            }
+          </div>
+          <div className="sendbird-openchannel-og-message__top__right">
+            {
+              !chainTop && (
+                <div className="sendbird-openchannel-og-message__top__right__title">
+                  <Label
+                    className="sendbird-openchannel-og-message__top__right__title__sender-name"
+                    type={LabelTypography.CAPTION_2}
+                    color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
                   >
                     {
-                      isFineCopy({ message, userId, status }) && (
-                        <MenuItem
-                          className="sendbird-openchannel-og-message__top__context-menu__copy"
-                          onClick={() => {
-                            copyToClipboard(message.message);
-                            closeDropdown();
-                          }}
-                          dataSbId="open_channel_og_message_menu_copy"
-                        >
-                          {stringSet.CONTEXT_MENU_DROPDOWN__COPY}
-                        </MenuItem>
+                      sender && (
+                        sender.friendName
+                        || sender.nickname
+                        || sender.userId
                       )
                     }
+                  </Label>
+                  <Label
+                    className="sendbird-openchannel-og-message__top__right__title__sent-at"
+                    type={LabelTypography.CAPTION_3}
+                    color={LabelColors.ONBACKGROUND_3}
+                  >
                     {
-                      (!isEphemeral && isFineEdit({ message, userId, status })) && (
-                        <MenuItem
-                          className="sendbird-openchannel-og-message__top__context-menu__edit"
-                          onClick={() => {
-                            if (disabled) {
-                              return;
-                            }
-                            showEdit(true);
-                            closeDropdown();
-                          }}
-                          dataSbId="open_channel_og_message_menu_edit"
-                        >
-                          {stringSet.CONTEXT_MENU_DROPDOWN__EDIT}
-                        </MenuItem>
+                      message?.createdAt && (
+                        format(message?.createdAt, 'p', {
+                          locale: dateLocale,
+                        })
                       )
                     }
-                    {
-                      isFineResend({ message, userId, status }) && (
-                        <MenuItem
-                          className="sendbird-openchannel-og-message__top__context-menu__resend"
-                          onClick={() => {
-                            resendMessage(message);
-                            closeDropdown();
-                          }}
-                          dataSbId="open_channel_og_message_menu_resend"
-                        >
-                          {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
-                        </MenuItem>
-                      )
-                    }
-                    {
-                      (!isEphemeral && isFineDelete({ message, userId, status })) && (
-                        <MenuItem
-                          className="sendbird-openchannel-og-message__top__context-menu__delete"
-                          onClick={() => {
-                            if (disabled) {
-                              return;
-                            }
-                            showRemove(true);
-                            closeDropdown();
-                          }}
-                          dataSbId="open_channel_og_message_menu_delete"
-                        >
-                          {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
-                        </MenuItem>
-                      )
-                    }
-                  </MenuItems>
-                )}
-              />
-            </div>
-          )
-        }
-      </div>
-      <div className="sendbird-openchannel-og-message__bottom">
-        <div className="sendbird-openchannel-og-message__bottom__og-tag" ref={mobileMenuRef}>
-          {
-            ogMetaData.url && (
+                  </Label>
+                </div>
+              )
+            }
+            <div className="sendbird-openchannel-og-message__top__right__description">
               <Label
-                className="sendbird-openchannel-og-message__bottom__og-tag__url"
-                type={LabelTypography.CAPTION_3}
-                color={LabelColors.ONBACKGROUND_2}
-              >
-                {ogMetaData.url}
-              </Label>
-            )
-          }
-          {
-            ogMetaData.title && (
-              <LinkLabel
-                className="sendbird-openchannel-og-message__bottom__og-tag__title"
-                src={ogMetaData.url}
-                type={LabelTypography.SUBTITLE_2}
-                color={LabelColors.PRIMARY}
-              >
-                {
-                  ogMetaData.title
-                }
-              </LinkLabel>
-            )
-          }
-          {
-            ogMetaData.description && (
-              <Label
-                className="sendbird-openchannel-og-message__bottom__og-tag__description"
-                type={LabelTypography.BODY_2}
+                className="sendbird-openchannel-og-message__top__right__description__message"
+                type={LabelTypography.BODY_1}
                 color={LabelColors.ONBACKGROUND_1}
               >
-                {ogMetaData.description}
-              </Label>
-            )
-          }
-          {
-            ogMetaData.url && (
-              <div
-                className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail"
-                role="button"
-                onClick={openLink}
-                onKeyDown={openLink}
-                tabIndex={0}
-              >
+                <TextFragment tokens={tokens} />
                 {
-                  defaultImage && (
-                    <ImageRenderer
-                      className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image"
-                      url={defaultImage.url || ''}
-                      alt={defaultImage.alt || ''}
-                      height="189px"
-                      defaultComponent={(
-                        <div className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image--placeholder">
-                          <Icon
-                            type={IconTypes.THUMBNAIL_NONE}
-                            width="56px"
-                            height="56px"
-                          />
-                        </div>
-                      )}
-                    />
+                  ((message?.updatedAt ?? 0) > 0) && (
+                    <Label
+                      key={uuidv4()}
+                      className='sendbird-openchannel-og-message--word'
+                      type={LabelTypography.BODY_1}
+                      color={LabelColors.ONBACKGROUND_2}
+                    >
+                      {stringSet.MESSAGE_EDITED}
+                    </Label>
                   )
                 }
+              </Label>
+            </div>
+          </div>
+          {
+            !isMobile && (
+              <div
+                className="sendbird-openchannel-og-message__top__context-menu"
+                ref={contextMenuRef}
+                style={contextStyle}
+              >
+                <ContextMenu
+                  menuTrigger={(toggleDropdown) => (
+                    showMenuTrigger({ message: message, userId: userId, status: status }) && (
+                      <IconButton
+                        className="sendbird-openchannel-og-message__top__context-menu--icon"
+                        width="32px"
+                        height="32px"
+                        onClick={() => {
+                          toggleDropdown();
+                        }}
+                      >
+                        <Icon
+                          type={IconTypes.MORE}
+                          fillColor={IconColors.CONTENT_INVERSE}
+                          width="24px"
+                          height="24px"
+                        />
+                      </IconButton>
+                    )
+                  )}
+                  menuItems={(closeDropdown) => (
+                    <MenuItems
+                      parentRef={contextMenuRef}
+                      parentContainRef={contextMenuRef}
+                      closeDropdown={closeDropdown}
+                      openLeft
+                    >
+                      {
+                        isFineCopy({ message, userId, status }) && (
+                          <MenuItem
+                            className="sendbird-openchannel-og-message__top__context-menu__copy"
+                            onClick={() => {
+                              copyToClipboard(message.message);
+                              closeDropdown();
+                            }}
+                            dataSbId="open_channel_og_message_menu_copy"
+                          >
+                            {stringSet.CONTEXT_MENU_DROPDOWN__COPY}
+                          </MenuItem>
+                        )
+                      }
+                      {
+                        (!isEphemeral && isFineEdit({ message, userId, status })) && (
+                          <MenuItem
+                            className="sendbird-openchannel-og-message__top__context-menu__edit"
+                            onClick={() => {
+                              if (disabled) {
+                                return;
+                              }
+                              showEdit(true);
+                              closeDropdown();
+                            }}
+                            dataSbId="open_channel_og_message_menu_edit"
+                          >
+                            {stringSet.CONTEXT_MENU_DROPDOWN__EDIT}
+                          </MenuItem>
+                        )
+                      }
+                      {
+                        isFineResend({ message, userId, status }) && (
+                          <MenuItem
+                            className="sendbird-openchannel-og-message__top__context-menu__resend"
+                            onClick={() => {
+                              resendMessage(message);
+                              closeDropdown();
+                            }}
+                            dataSbId="open_channel_og_message_menu_resend"
+                          >
+                            {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
+                          </MenuItem>
+                        )
+                      }
+                      {
+                        (!isEphemeral && isFineDelete({ message, userId, status })) && (
+                          <MenuItem
+                            className="sendbird-openchannel-og-message__top__context-menu__delete"
+                            onClick={() => {
+                              if (disabled) {
+                                return;
+                              }
+                              showRemove(true);
+                              closeDropdown();
+                            }}
+                            dataSbId="open_channel_og_message_menu_delete"
+                          >
+                            {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
+                          </MenuItem>
+                        )
+                      }
+                    </MenuItems>
+                  )}
+                />
               </div>
             )
           }
         </div>
-        {
-          (isPending || isFailed) && (
-            <div className="sendbird-openchannel-og-message__top__right__tail">
-              {
-                isPending && (
-                  <Loader
-                    width="16px"
-                    height="16px"
-                  >
+        <div className="sendbird-openchannel-og-message__bottom">
+          <div className="sendbird-openchannel-og-message__bottom__og-tag" ref={mobileMenuRef}>
+            {
+              ogMetaData.url && (
+                <Label
+                  className="sendbird-openchannel-og-message__bottom__og-tag__url"
+                  type={LabelTypography.CAPTION_3}
+                  color={LabelColors.ONBACKGROUND_2}
+                >
+                  {ogMetaData.url}
+                </Label>
+              )
+            }
+            {
+              ogMetaData.title && (
+                <LinkLabel
+                  className="sendbird-openchannel-og-message__bottom__og-tag__title"
+                  src={ogMetaData.url}
+                  type={LabelTypography.SUBTITLE_2}
+                  color={LabelColors.PRIMARY}
+                >
+                  {
+                    ogMetaData.title
+                  }
+                </LinkLabel>
+              )
+            }
+            {
+              ogMetaData.description && (
+                <Label
+                  className="sendbird-openchannel-og-message__bottom__og-tag__description"
+                  type={LabelTypography.BODY_2}
+                  color={LabelColors.ONBACKGROUND_1}
+                >
+                  {ogMetaData.description}
+                </Label>
+              )
+            }
+            {
+              ogMetaData.url && (
+                <div
+                  className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail"
+                  role="button"
+                  onClick={openLink}
+                  onKeyDown={openLink}
+                  tabIndex={0}
+                >
+                  {
+                    defaultImage && (
+                      <ImageRenderer
+                        className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image"
+                        url={defaultImage.url || ''}
+                        alt={defaultImage.alt || ''}
+                        height="189px"
+                        defaultComponent={(
+                          <div className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image--placeholder">
+                            <Icon
+                              type={IconTypes.THUMBNAIL_NONE}
+                              width="56px"
+                              height="56px"
+                            />
+                          </div>
+                        )}
+                      />
+                    )
+                  }
+                </div>
+              )
+            }
+          </div>
+          {
+            (isPending || isFailed) && (
+              <div className="sendbird-openchannel-og-message__top__right__tail">
+                {
+                  isPending && (
+                    <Loader
+                      width="16px"
+                      height="16px"
+                    >
+                      <Icon
+                        className="sendbird-openchannel-og-message__top__right__tail__pending"
+                        type={IconTypes.SPINNER}
+                        fillColor={IconColors.PRIMARY}
+                        width="16px"
+                        height="16px"
+                      />
+                    </Loader>
+                  )
+                }
+                {
+                  isFailed && (
                     <Icon
-                      className="sendbird-openchannel-og-message__top__right__tail__pending"
-                      type={IconTypes.SPINNER}
-                      fillColor={IconColors.PRIMARY}
+                      className="sendbird-openchannel-og-message__top__right__tail__failed"
+                      type={IconTypes.ERROR}
+                      fillColor={IconColors.ERROR}
                       width="16px"
                       height="16px"
                     />
-                  </Loader>
-                )
-              }
-              {
-                isFailed && (
-                  <Icon
-                    className="sendbird-openchannel-og-message__top__right__tail__failed"
-                    type={IconTypes.ERROR}
-                    fillColor={IconColors.ERROR}
-                    width="16px"
-                    height="16px"
-                  />
-                )
-              }
-            </div>
-          )
-        }
+                  )
+                }
+              </div>
+            )
+          }
+        </div>
       </div>
       {
         showContextMenu && (
@@ -459,6 +461,6 @@ export default function OpenchannelOGMessage({
           />
         )
       }
-    </div>
+    </>
   );
 }

--- a/src/ui/OpenchannelThumbnailMessage/index.tsx
+++ b/src/ui/OpenchannelThumbnailMessage/index.tsx
@@ -106,216 +106,288 @@ export default function OpenchannelThumbnailMessage({
   }, []);
 
   return (
-    <div
-      className={[
-        ...(Array.isArray(className) ? className : [className]),
-        'sendbird-openchannel-thumbnail-message',
-      ].join(' ')}
-      ref={messageRef}
-    >
-      <div className="sendbird-openchannel-thumbnail-message__left">
-        {
-          !chainTop && (
-            <ContextMenu
-              menuTrigger={(toggleDropdown) => (
-                <Avatar
-                  className="sendbird-openchannel-thumbnail-message__left__avatar"
-                  src={sender.profileUrl || ''}
-                  ref={avatarRef}
-                  width="28px"
-                  height="28px"
-                  onClick={() => {
-                    if (!disableUserProfile) {
-                      toggleDropdown();
+    <>
+      <div
+        className={[
+          ...(Array.isArray(className) ? className : [className]),
+          'sendbird-openchannel-thumbnail-message',
+        ].join(' ')}
+        ref={messageRef}
+      >
+        <div className="sendbird-openchannel-thumbnail-message__left">
+          {
+            !chainTop && (
+              <ContextMenu
+                menuTrigger={(toggleDropdown) => (
+                  <Avatar
+                    className="sendbird-openchannel-thumbnail-message__left__avatar"
+                    src={sender.profileUrl || ''}
+                    ref={avatarRef}
+                    width="28px"
+                    height="28px"
+                    onClick={() => {
+                      if (!disableUserProfile) {
+                        toggleDropdown();
+                      }
+                    }}
+                  />
+                )}
+                menuItems={(closeDropdown) => (
+                  <MenuItems
+                    parentRef={avatarRef}
+                    parentContainRef={avatarRef}
+                    closeDropdown={closeDropdown}
+                    style={{ paddingTop: '0px', paddingBottom: '0px' }}
+                  >
+                    {
+                      renderUserProfile
+                        ? (
+                          renderUserProfile({
+                            user: sender,
+                            close: closeDropdown,
+                          })
+                        )
+                        : (
+                          <UserProfile
+                            user={sender}
+                            onSuccess={closeDropdown}
+                            disableMessaging
+                          />
+                        )
                     }
-                  }}
-                />
-              )}
-              menuItems={(closeDropdown) => (
-                <MenuItems
-                  parentRef={avatarRef}
-                  parentContainRef={avatarRef}
-                  closeDropdown={closeDropdown}
-                  style={{ paddingTop: '0px', paddingBottom: '0px' }}
+                  </MenuItems>
+                )}
+              />
+            )
+          }
+        </div>
+        <div className="sendbird-openchannel-thumbnail-message__right">
+          {
+            !chainTop && (
+              <div className="sendbird-openchannel-thumbnail-message__right__title">
+                <Label
+                  className="sendbird-openchannel-thumbnail-message__right__title__sender-name"
+                  type={LabelTypography.CAPTION_2}
+                  color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
                 >
                   {
-                    renderUserProfile
+                    sender && (
+                      sender.friendName
+                      || sender.nickname
+                      || sender.userId
+                    )
+                  }
+                </Label>
+                <Label
+                  className="sendbird-openchannel-thumbnail-message__right__title__sent-at"
+                  type={LabelTypography.CAPTION_3}
+                  color={LabelColors.ONBACKGROUND_3}
+                >
+                  {
+                    message?.createdAt && (
+                      format(message.createdAt, 'p', {
+                        locale: dateLocale,
+                      })
+                    )
+                  }
+                </Label>
+              </div>
+            )
+          }
+          <div className="sendbird-openchannel-thumbnail-message__right__body" ref={mobileMenuRef}>
+            <div
+              className="sendbird-openchannel-thumbnail-message__right__body__wrap"
+              role="button"
+              onClick={() => {
+                if (isMessageSent) {
+                  onClick(true);
+                }
+              }}
+              onKeyDown={() => {
+                if (isMessageSent) {
+                  onClick(true);
+                }
+              }}
+              tabIndex={0}
+              {...(isMobile ? { ...onLongPress } : {})}
+            >
+              <div className="sendbird-openchannel-thumbnail-message__right__body__wrap__overlay" />
+              {
+                {
+                  [SUPPORTING_TYPES.VIDEO]: (
+                    (url || localUrl)
                       ? (
-                        renderUserProfile({
-                          user: sender,
-                          close: closeDropdown,
-                        })
+                        <div className="sendbird-openchannel-thumbnail-message__right__body__wrap__video" >
+                          {
+                            (thumbnailUrl)
+                              ? (
+                                <ImageRenderer
+                                  className="sendbird-openchannel-thumbnail-message__right__body__wrap__video"
+                                  url={thumbnailUrl}
+                                  width={messageWidth}
+                                  height="270px"
+                                  alt="image"
+                                  placeHolder={memorizedThumbnailPlaceHolder(IconTypes.PLAY)}
+                                />
+                              )
+                              : (
+                                <video className="sendbird-openchannel-thumbnail-message__right__body__wrap__video__video">
+                                  <source src={url || localUrl} type={type} />
+                                </video>
+                              )
+                          }
+                          <Icon
+                            className="sendbird-openchannel-thumbnail-message__right__body__wrap__video__icon"
+                            type={IconTypes.PLAY}
+                            fillColor={IconColors.ON_BACKGROUND_2}
+                            width="56px"
+                            height="56px"
+                          />
+                        </div>
                       )
                       : (
-                        <UserProfile
-                          user={sender}
-                          onSuccess={closeDropdown}
-                          disableMessaging
-                        />
-                      )
-                  }
-                </MenuItems>
-              )}
-            />
-          )
-        }
-      </div>
-      <div className="sendbird-openchannel-thumbnail-message__right">
-        {
-          !chainTop && (
-            <div className="sendbird-openchannel-thumbnail-message__right__title">
-              <Label
-                className="sendbird-openchannel-thumbnail-message__right__title__sender-name"
-                type={LabelTypography.CAPTION_2}
-                color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
-              >
-                {
-                  sender && (
-                    sender.friendName
-                    || sender.nickname
-                    || sender.userId
-                  )
-                }
-              </Label>
-              <Label
-                className="sendbird-openchannel-thumbnail-message__right__title__sent-at"
-                type={LabelTypography.CAPTION_3}
-                color={LabelColors.ONBACKGROUND_3}
-              >
-                {
-                  message?.createdAt && (
-                    format(message.createdAt, 'p', {
-                      locale: dateLocale,
-                    })
-                  )
-                }
-              </Label>
-            </div>
-          )
-        }
-        <div className="sendbird-openchannel-thumbnail-message__right__body" ref={mobileMenuRef}>
-          <div
-            className="sendbird-openchannel-thumbnail-message__right__body__wrap"
-            role="button"
-            onClick={() => {
-              if (isMessageSent) {
-                onClick(true);
-              }
-            }}
-            onKeyDown={() => {
-              if (isMessageSent) {
-                onClick(true);
-              }
-            }}
-            tabIndex={0}
-            {...(isMobile ? { ...onLongPress } : {})}
-          >
-            <div className="sendbird-openchannel-thumbnail-message__right__body__wrap__overlay" />
-            {
-              {
-                [SUPPORTING_TYPES.VIDEO]: (
-                  (url || localUrl)
-                    ? (
-                      <div className="sendbird-openchannel-thumbnail-message__right__body__wrap__video" >
-                        {
-                          (thumbnailUrl)
-                            ? (
-                              <ImageRenderer
-                                className="sendbird-openchannel-thumbnail-message__right__body__wrap__video"
-                                url={thumbnailUrl}
-                                width={messageWidth}
-                                height="270px"
-                                alt="image"
-                                placeHolder={memorizedThumbnailPlaceHolder(IconTypes.PLAY)}
-                              />
-                            )
-                            : (
-                              <video className="sendbird-openchannel-thumbnail-message__right__body__wrap__video__video">
-                                <source src={url || localUrl} type={type} />
-                              </video>
-                            )
-                        }
                         <Icon
-                          className="sendbird-openchannel-thumbnail-message__right__body__wrap__video__icon"
-                          type={IconTypes.PLAY}
+                          className="sendbird-openchannel-thumbnail-message__right__body__wrap__video--icon"
+                          type={IconTypes.PHOTO}
                           fillColor={IconColors.ON_BACKGROUND_2}
                           width="56px"
                           height="56px"
                         />
-                      </div>
-                    )
-                    : (
-                      <Icon
-                        className="sendbird-openchannel-thumbnail-message__right__body__wrap__video--icon"
-                        type={IconTypes.PHOTO}
-                        fillColor={IconColors.ON_BACKGROUND_2}
-                        width="56px"
-                        height="56px"
-                      />
-                    )
-                ),
-                [SUPPORTING_TYPES.IMAGE]: (
-                  (url || localUrl)
-                    ? (
-                      <ImageRenderer
-                        className="sendbird-openchannel-thumbnail-message__right__body__wrap__image"
-                        url={thumbnailUrl || url || localUrl}
-                        alt="image"
-                        width={messageWidth}
-                        height="270px"
-                        placeHolder={memorizedThumbnailPlaceHolder(IconTypes.PHOTO)}
-                      />
-                    )
-                    : (
-                      <Icon
-                        className="sendbird-openchannel-thumbnail-message__right__body__wrap__image--icon"
-                        type={IconTypes.PHOTO}
-                        fillColor={IconColors.ON_BACKGROUND_2}
-                        width="56px"
-                        height="56px"
-                      />
-                    )
-                ),
-                [SUPPORTING_TYPES.UNSUPPORTED]: (
-                  <Icon
-                    className="sendbird-openchannel-thumbnail-message__right__body__wrap__unknown"
-                    type={IconTypes.PHOTO}
-                    fillColor={IconColors.ON_BACKGROUND_2}
-                    width="56px"
-                    height="56px"
-                  />
-                ),
-              }[getSupportingFileType(type)]
-            }
-          </div>
-        </div>
-        {
-          (isPending || isFailed) && (
-            <div className="sendbird-openchannel-thumbnail-message__right__tail">
-              {
-                isPending && (
-                  <Loader
-                    width="16px"
-                    height="16px"
-                  >
+                      )
+                  ),
+                  [SUPPORTING_TYPES.IMAGE]: (
+                    (url || localUrl)
+                      ? (
+                        <ImageRenderer
+                          className="sendbird-openchannel-thumbnail-message__right__body__wrap__image"
+                          url={thumbnailUrl || url || localUrl}
+                          alt="image"
+                          width={messageWidth}
+                          height="270px"
+                          placeHolder={memorizedThumbnailPlaceHolder(IconTypes.PHOTO)}
+                        />
+                      )
+                      : (
+                        <Icon
+                          className="sendbird-openchannel-thumbnail-message__right__body__wrap__image--icon"
+                          type={IconTypes.PHOTO}
+                          fillColor={IconColors.ON_BACKGROUND_2}
+                          width="56px"
+                          height="56px"
+                        />
+                      )
+                  ),
+                  [SUPPORTING_TYPES.UNSUPPORTED]: (
                     <Icon
-                      className="sendbird-openchannel-thumbnail-message__right__tail__pending"
-                      type={IconTypes.SPINNER}
-                      fillColor={IconColors.PRIMARY}
+                      className="sendbird-openchannel-thumbnail-message__right__body__wrap__unknown"
+                      type={IconTypes.PHOTO}
+                      fillColor={IconColors.ON_BACKGROUND_2}
+                      width="56px"
+                      height="56px"
+                    />
+                  ),
+                }[getSupportingFileType(type)]
+              }
+            </div>
+          </div>
+          {
+            (isPending || isFailed) && (
+              <div className="sendbird-openchannel-thumbnail-message__right__tail">
+                {
+                  isPending && (
+                    <Loader
+                      width="16px"
+                      height="16px"
+                    >
+                      <Icon
+                        className="sendbird-openchannel-thumbnail-message__right__tail__pending"
+                        type={IconTypes.SPINNER}
+                        fillColor={IconColors.PRIMARY}
+                        width="16px"
+                        height="16px"
+                      />
+                    </Loader>
+                  )
+                }
+                {
+                  isFailed && (
+                    <Icon
+                      className="sendbird-openchannel-thumbnail-message__right__tail__failed"
+                      type={IconTypes.ERROR}
+                      fillColor={IconColors.ERROR}
                       width="16px"
                       height="16px"
                     />
-                  </Loader>
-                )
-              }
+                  )
+                }
+              </div>
+            )
+          }
+        </div>
+        {
+          !isMobile && (
+            <div
+              className="sendbird-openchannel-thumbnail-message__context-menu"
+              ref={contextMenuRef}
+            >
               {
-                isFailed && (
-                  <Icon
-                    className="sendbird-openchannel-thumbnail-message__right__tail__failed"
-                    type={IconTypes.ERROR}
-                    fillColor={IconColors.ERROR}
-                    width="16px"
-                    height="16px"
+                (isFineResend({ message, userId, status }) || !isEphemeral) && (
+                  <ContextMenu
+                    menuTrigger={(toggleDropdown) => (
+                      showMenuTrigger({ message, userId, status }) && (
+                        <IconButton
+                          className="sendbird-openchannel-thumbnail-message__context-menu--icon"
+                          width="32px"
+                          height="32px"
+                          onClick={toggleDropdown}
+                        >
+                          <Icon
+                            type={IconTypes.MORE}
+                            fillColor={IconColors.CONTENT_INVERSE}
+                            width="24px"
+                            height="24px"
+                          />
+                        </IconButton>
+                      )
+                    )}
+                    menuItems={(closeDropdown) => (
+                      <MenuItems
+                        parentRef={contextMenuRef}
+                        parentContainRef={contextMenuRef}
+                        closeDropdown={closeDropdown}
+                        openLeft
+                      >
+                        {
+                          isFineResend({ message, userId, status }) && (
+                            <MenuItem
+                              onClick={() => {
+                                resendMessage(message);
+                                closeDropdown();
+                              }}
+                              dataSbId="open_channel_thumbnail_message_menu_resend"
+                            >
+                              {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
+                            </MenuItem>
+                          )
+                        }
+                        {
+                          (!isEphemeral && isFineDelete({ message, userId, status })) && (
+                            <MenuItem
+                              onClick={() => {
+                                if (disabled) {
+                                  return;
+                                }
+                                showRemove(true);
+                                closeDropdown();
+                              }}
+                              dataSbId="open_channel_thumbnail_message_menu_delete"
+                            >
+                              {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
+                            </MenuItem>
+                          )
+                        }
+                      </MenuItems>
+                    )}
                   />
                 )
               }
@@ -323,76 +395,6 @@ export default function OpenchannelThumbnailMessage({
           )
         }
       </div>
-      {
-        !isMobile && (
-          <div
-            className="sendbird-openchannel-thumbnail-message__context-menu"
-            ref={contextMenuRef}
-          >
-            {
-              (isFineResend({ message, userId, status }) || !isEphemeral) && (
-                <ContextMenu
-                  menuTrigger={(toggleDropdown) => (
-                    showMenuTrigger({ message, userId, status }) && (
-                      <IconButton
-                        className="sendbird-openchannel-thumbnail-message__context-menu--icon"
-                        width="32px"
-                        height="32px"
-                        onClick={toggleDropdown}
-                      >
-                        <Icon
-                          type={IconTypes.MORE}
-                          fillColor={IconColors.CONTENT_INVERSE}
-                          width="24px"
-                          height="24px"
-                        />
-                      </IconButton>
-                    )
-                  )}
-                  menuItems={(closeDropdown) => (
-                    <MenuItems
-                      parentRef={contextMenuRef}
-                      parentContainRef={contextMenuRef}
-                      closeDropdown={closeDropdown}
-                      openLeft
-                    >
-                      {
-                        isFineResend({ message, userId, status }) && (
-                          <MenuItem
-                            onClick={() => {
-                              resendMessage(message);
-                              closeDropdown();
-                            }}
-                            dataSbId="open_channel_thumbnail_message_menu_resend"
-                          >
-                            {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
-                          </MenuItem>
-                        )
-                      }
-                      {
-                        (!isEphemeral && isFineDelete({ message, userId, status })) && (
-                          <MenuItem
-                            onClick={() => {
-                              if (disabled) {
-                                return;
-                              }
-                              showRemove(true);
-                              closeDropdown();
-                            }}
-                            dataSbId="open_channel_thumbnail_message_menu_delete"
-                          >
-                            {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
-                          </MenuItem>
-                        )
-                      }
-                    </MenuItems>
-                  )}
-                />
-              )
-            }
-          </div>
-        )
-      }
       {
         contextMenu && (
           <OpenChannelMobileMenu
@@ -412,6 +414,6 @@ export default function OpenchannelThumbnailMessage({
           />
         )
       }
-    </div>
+    </>
   );
 }

--- a/src/ui/OpenchannelUserMessage/index.tsx
+++ b/src/ui/OpenchannelUserMessage/index.tsx
@@ -62,10 +62,6 @@ export default function OpenchannelUserMessage({
   showRemove,
   chainTop,
 }: OpenChannelUserMessageProps): ReactElement {
-  if (!message || message.messageType !== 'user') {
-    return null;
-  }
-
   // hooks
   const { stringSet, dateLocale } = useLocalization();
   const { disableUserProfile, renderUserProfile } = useContext<UserProfileContext>(UserProfileContext);
@@ -98,252 +94,258 @@ export default function OpenchannelUserMessage({
   });
 
   const { isMobile } = useMediaQueryContext();
+  if (!message || message.messageType !== 'user') {
+    return <></>;
+  }
+
   return (
-    <div
-      className={[
-        ...(Array.isArray(className) ? className : [className]),
-        'sendbird-openchannel-user-message',
-      ].join(' ')}
-      ref={messageRef}
-    >
-      <div className="sendbird-openchannel-user-message__left">
-        {
-          !chainTop && (
-            <ContextMenu
-              menuTrigger={(toggleDropdown) => (
-                <Avatar
-                  className="sendbird-openchannel-user-message__left__avatar"
-                  src={sender.profileUrl || ''}
-                  ref={avatarRef}
-                  width="28px"
-                  height="28px"
-                  onClick={() => {
-                    if (!disableUserProfile) {
-                      toggleDropdown();
+    <>
+      <div
+        className={[
+          ...(Array.isArray(className) ? className : [className]),
+          'sendbird-openchannel-user-message',
+        ].join(' ')}
+        ref={messageRef}
+      >
+        <div className="sendbird-openchannel-user-message__left">
+          {
+            !chainTop && (
+              <ContextMenu
+                menuTrigger={(toggleDropdown) => (
+                  <Avatar
+                    className="sendbird-openchannel-user-message__left__avatar"
+                    src={sender.profileUrl || ''}
+                    ref={avatarRef}
+                    width="28px"
+                    height="28px"
+                    onClick={() => {
+                      if (!disableUserProfile) {
+                        toggleDropdown();
+                      }
+                    }}
+                  />
+                )}
+                menuItems={(closeDropdown) => (
+                  <MenuItems
+                    parentRef={avatarRef}
+                    parentContainRef={avatarRef}
+                    closeDropdown={closeDropdown}
+                    style={{ paddingTop: '0px', paddingBottom: '0px' }}
+                  >
+                    {
+                      renderUserProfile
+                        ? (
+                          renderUserProfile({
+                            user: sender,
+                            close: closeDropdown,
+                          })
+                        )
+                        : (
+                          <UserProfile
+                            user={sender}
+                            onSuccess={closeDropdown}
+                            disableMessaging
+                          />
+                        )
                     }
-                  }}
-                />
-              )}
-              menuItems={(closeDropdown) => (
-                <MenuItems
-                  parentRef={avatarRef}
-                  parentContainRef={avatarRef}
-                  closeDropdown={closeDropdown}
-                  style={{ paddingTop: '0px', paddingBottom: '0px' }}
+                  </MenuItems>
+                )}
+              />
+            )
+          }
+        </div>
+        <div className="sendbird-openchannel-user-message__right">
+          {
+            !chainTop && (
+              <div className="sendbird-openchannel-user-message__right__top">
+                <Label
+                  className="sendbird-openchannel-user-message__right__top__sender-name"
+                  type={LabelTypography.CAPTION_2}
+                  color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
                 >
                   {
-                    renderUserProfile
-                      ? (
-                        renderUserProfile({
-                          user: sender,
-                          close: closeDropdown,
-                        })
-                      )
-                      : (
-                        <UserProfile
-                          user={sender}
-                          onSuccess={closeDropdown}
-                          disableMessaging
-                        />
-                      )
+                    sender && (
+                      sender.friendName
+                      || sender.nickname
+                      || sender.userId
+                    )
                   }
-                </MenuItems>
+                </Label>
+                <Label
+                  className="sendbird-openchannel-user-message__right__top__sent-at"
+                  type={LabelTypography.CAPTION_3}
+                  color={LabelColors.ONBACKGROUND_3}
+                >
+                  {
+                    message?.createdAt && (
+                      format(message?.createdAt, 'p', {
+                        locale: dateLocale,
+                      })
+                    )
+                  }
+                </Label>
+              </div>
+            )
+          }
+          <div
+            {...(isMobile ? { ...onLongPress } : {})}
+            className="sendbird-openchannel-user-message__right__bottom" ref={mobileMenuRef}>
+            <Label
+              className="sendbird-openchannel-user-message__right__bottom__message"
+              type={LabelTypography.BODY_1}
+              color={LabelColors.ONBACKGROUND_1}
+            >
+              {message?.message}
+              {isEditedMessage(message) && (
+                <Label
+                  key={uuidv4()}
+                  type={LabelTypography.BODY_1}
+                  color={LabelColors.ONBACKGROUND_2}
+                  calssName="sendbird-openchannel-user-message-word"
+                >
+                  {` ${stringSet.MESSAGE_EDITED} `}
+                </Label>
               )}
-            />
-          )
-        }
-      </div>
-      <div className="sendbird-openchannel-user-message__right">
-        {
-          !chainTop && (
-            <div className="sendbird-openchannel-user-message__right__top">
-              <Label
-                className="sendbird-openchannel-user-message__right__top__sender-name"
-                type={LabelTypography.CAPTION_2}
-                color={isOperator ? LabelColors.SECONDARY_3 : LabelColors.ONBACKGROUND_2}
-              >
+            </Label>
+          </div>
+          {
+            (isPending || isFailed) && (
+              <div className="sendbird-openchannel-user-message__right__tail">
                 {
-                  sender && (
-                    sender.friendName
-                    || sender.nickname
-                    || sender.userId
+                  isPending && (
+                    <Loader
+                      width="16px"
+                      height="16px"
+                    >
+                      <Icon
+                        className="sendbird-openchannel-user-message__right__tail__pending"
+                        type={IconTypes.SPINNER}
+                        fillColor={IconColors.PRIMARY}
+                        width="16px"
+                        height="16px"
+                      />
+                    </Loader>
                   )
                 }
-              </Label>
-              <Label
-                className="sendbird-openchannel-user-message__right__top__sent-at"
-                type={LabelTypography.CAPTION_3}
-                color={LabelColors.ONBACKGROUND_3}
-              >
                 {
-                  message?.createdAt && (
-                    format(message?.createdAt, 'p', {
-                      locale: dateLocale,
-                    })
-                  )
-                }
-              </Label>
-            </div>
-          )
-        }
-        <div
-          {...(isMobile ? { ...onLongPress } : {})}
-          className="sendbird-openchannel-user-message__right__bottom" ref={mobileMenuRef}>
-          <Label
-            className="sendbird-openchannel-user-message__right__bottom__message"
-            type={LabelTypography.BODY_1}
-            color={LabelColors.ONBACKGROUND_1}
-          >
-            {message?.message}
-            {isEditedMessage(message) && (
-              <Label
-                key={uuidv4()}
-                type={LabelTypography.BODY_1}
-                color={LabelColors.ONBACKGROUND_2}
-                calssName="sendbird-openchannel-user-message-word"
-              >
-                {` ${stringSet.MESSAGE_EDITED} `}
-              </Label>
-            )}
-          </Label>
-        </div>
-        {
-          (isPending || isFailed) && (
-            <div className="sendbird-openchannel-user-message__right__tail">
-              {
-                isPending && (
-                  <Loader
-                    width="16px"
-                    height="16px"
-                  >
+                  isFailed && (
                     <Icon
-                      className="sendbird-openchannel-user-message__right__tail__pending"
-                      type={IconTypes.SPINNER}
-                      fillColor={IconColors.PRIMARY}
+                      className="sendbird-openchannel-user-message__right__tail__failed"
+                      type={IconTypes.ERROR}
+                      fillColor={IconColors.ERROR}
                       width="16px"
                       height="16px"
                     />
-                  </Loader>
-                )
-              }
-              {
-                isFailed && (
-                  <Icon
-                    className="sendbird-openchannel-user-message__right__tail__failed"
-                    type={IconTypes.ERROR}
-                    fillColor={IconColors.ERROR}
-                    width="16px"
-                    height="16px"
-                  />
-                )
-              }
+                  )
+                }
+              </div>
+            )
+          }
+        </div>
+        {
+          !isMobile && (
+            <div
+              className="sendbird-openchannel-user-message__context-menu"
+              ref={contextMenuRef}
+              style={contextStyle}
+            >
+              <ContextMenu
+                menuTrigger={(toggleDropdown) => (
+                  showMenuTrigger({ message: message, userId: userId, status: status }) && (
+                    <IconButton
+                      className="sendbird-openchannel-user-message__context-menu--icon"
+                      width="32px"
+                      height="32px"
+                      onClick={() => {
+                        toggleDropdown();
+                      }}
+                    >
+                      <Icon
+                        type={IconTypes.MORE}
+                        fillColor={IconColors.CONTENT_INVERSE}
+                        width="24px"
+                        height="24px"
+                      />
+                    </IconButton>
+                  )
+                )}
+                menuItems={(closeDropdown) => (
+                  <MenuItems
+                    parentRef={contextMenuRef}
+                    parentContainRef={contextMenuRef}
+                    closeDropdown={closeDropdown}
+                    openLeft
+                  >
+                    {
+                      isFineCopy({ message: message, userId: userId, status: status }) && (
+                        <MenuItem
+                          className="sendbird-openchannel-user-message__context-menu__copy"
+                          onClick={() => {
+                            copyToClipboard(message.message);
+                            closeDropdown();
+                          }}
+                          dataSbId="open_channel_user_message_menu_copy"
+                        >
+                          {stringSet.CONTEXT_MENU_DROPDOWN__COPY}
+                        </MenuItem>
+                      )
+                    }
+                    {
+                      (!isEphemeral && isFineEdit({ message: message, userId: userId, status: status })) && (
+                        <MenuItem
+                          className="sendbird-openchannel-user-message__context-menu__edit"
+                          onClick={() => {
+                            if (disabled) {
+                              return;
+                            }
+                            showEdit(true);
+                            closeDropdown();
+                          }}
+                          dataSbId="open_channel_user_message_menu_edit"
+                        >
+                          {stringSet.CONTEXT_MENU_DROPDOWN__EDIT}
+                        </MenuItem>
+                      )
+                    }
+                    {
+                      isFineResend({ message: message, userId: userId, status: status }) && (
+                        <MenuItem
+                          className="sendbird-openchannel-user-message__context-menu__resend"
+                          onClick={() => {
+                            resendMessage(message);
+                            closeDropdown();
+                          }}
+                          dataSbId="open_channel_user_message_menu_resend"
+                        >
+                          {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
+                        </MenuItem>
+                      )
+                    }
+                    {
+                      (!isEphemeral && isFineDelete({ message: message, userId: userId, status: status })) && (
+                        <MenuItem
+                          className="sendbird-openchannel-user-message__context-menu__delete"
+                          onClick={() => {
+                            if (disabled) {
+                              return;
+                            }
+                            showRemove(true);
+                            closeDropdown();
+                          }}
+                          dataSbId="open_channel_user_message_menu_delete"
+                        >
+                          {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
+                        </MenuItem>
+                      )
+                    }
+                  </MenuItems>
+                )}
+              />
             </div>
+
           )
         }
       </div>
-      {
-        !isMobile && (
-          <div
-            className="sendbird-openchannel-user-message__context-menu"
-            ref={contextMenuRef}
-            style={contextStyle}
-          >
-            <ContextMenu
-              menuTrigger={(toggleDropdown) => (
-                showMenuTrigger({ message: message, userId: userId, status: status }) && (
-                  <IconButton
-                    className="sendbird-openchannel-user-message__context-menu--icon"
-                    width="32px"
-                    height="32px"
-                    onClick={() => {
-                      toggleDropdown();
-                    }}
-                  >
-                    <Icon
-                      type={IconTypes.MORE}
-                      fillColor={IconColors.CONTENT_INVERSE}
-                      width="24px"
-                      height="24px"
-                    />
-                  </IconButton>
-                )
-              )}
-              menuItems={(closeDropdown) => (
-                <MenuItems
-                  parentRef={contextMenuRef}
-                  parentContainRef={contextMenuRef}
-                  closeDropdown={closeDropdown}
-                  openLeft
-                >
-                  {
-                    isFineCopy({ message: message, userId: userId, status: status }) && (
-                      <MenuItem
-                        className="sendbird-openchannel-user-message__context-menu__copy"
-                        onClick={() => {
-                          copyToClipboard(message.message);
-                          closeDropdown();
-                        }}
-                        dataSbId="open_channel_user_message_menu_copy"
-                      >
-                        {stringSet.CONTEXT_MENU_DROPDOWN__COPY}
-                      </MenuItem>
-                    )
-                  }
-                  {
-                    (!isEphemeral && isFineEdit({ message: message, userId: userId, status: status })) && (
-                      <MenuItem
-                        className="sendbird-openchannel-user-message__context-menu__edit"
-                        onClick={() => {
-                          if (disabled) {
-                            return;
-                          }
-                          showEdit(true);
-                          closeDropdown();
-                        }}
-                        dataSbId="open_channel_user_message_menu_edit"
-                      >
-                        {stringSet.CONTEXT_MENU_DROPDOWN__EDIT}
-                      </MenuItem>
-                    )
-                  }
-                  {
-                    isFineResend({ message: message, userId: userId, status: status }) && (
-                      <MenuItem
-                        className="sendbird-openchannel-user-message__context-menu__resend"
-                        onClick={() => {
-                          resendMessage(message);
-                          closeDropdown();
-                        }}
-                        dataSbId="open_channel_user_message_menu_resend"
-                      >
-                        {stringSet.CONTEXT_MENU_DROPDOWN__RESEND}
-                      </MenuItem>
-                    )
-                  }
-                  {
-                    (!isEphemeral && isFineDelete({ message: message, userId: userId, status: status })) && (
-                      <MenuItem
-                        className="sendbird-openchannel-user-message__context-menu__delete"
-                        onClick={() => {
-                          if (disabled) {
-                            return;
-                          }
-                          showRemove(true);
-                          closeDropdown();
-                        }}
-                        dataSbId="open_channel_user_message_menu_delete"
-                      >
-                        {stringSet.CONTEXT_MENU_DROPDOWN__DELETE}
-                      </MenuItem>
-                    )
-                  }
-                </MenuItems>
-              )}
-            />
-          </div>
-
-        )
-      }
       {
         contextMenu && (
           <OpenChannelMobileMenu
@@ -371,6 +373,6 @@ export default function OpenchannelUserMessage({
           />
         )
       }
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
In Mobile,
Touch from contextMenus were getting leaked to MessageBody
To avoid this, move context menu outside of MessageBody's JSX

```
<div longPress>
	<Message />
	<Menu/>
</div>
```

to 
```
<>
	<div longPress>
		<Message />
	</div>
	{
		<Menu/>
	}
</>
```

Bonus * OGMessage should fallback to text-messages

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4029

