### PR TITLE
feat: apply xxChannel.input.enableDocument dashboard config 

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -6,7 +6,7 @@
 declare module "SendbirdUIKitGlobal" {
   import type React from 'react';
   import type SendbirdChat from '@sendbird/chat';
-  import { GroupChannelModule, ModuleNamespaces, OpenChannelModule } from '@sendbird/chat/lib/__definition';
+  import { GroupChannel, GroupChannelModule, ModuleNamespaces, OpenChannel, OpenChannelModule } from '@sendbird/chat/lib/__definition';
   import type {
     SendbirdError,
     SessionHandler,
@@ -2077,6 +2077,8 @@ declare module '@sendbird/uikit-react/ui/MessageContent' {
 }
 
 declare module '@sendbird/uikit-react/ui/MessageInput' {
+  import type { GroupChannel } from '@sendbird/chat/groupChannel';
+  import type { OpenChannel } from '@sendbird/chat/openChannel';
   import type { User } from '@sendbird/chat';
 
   interface MessageInputProps {
@@ -2095,6 +2097,7 @@ declare module '@sendbird/uikit-react/ui/MessageInput' {
     onCancelEdit?: () => void,
     onStartTyping?: () => void,
     channelUrl: string,
+    channel: OpenChannel | GroupChannel | null,
     mentionSelectedUser?: Array<User>,
     onUserMentioned?: (user: User) => void,
     onMentionStringChange?: (str: string) => void,

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -2097,7 +2097,7 @@ declare module '@sendbird/uikit-react/ui/MessageInput' {
     onCancelEdit?: () => void,
     onStartTyping?: () => void,
     channelUrl: string,
-    channel: OpenChannel | GroupChannel | null,
+    channel?: OpenChannel | GroupChannel,
     mentionSelectedUser?: Array<User>,
     onUserMentioned?: (user: User) => void,
     onMentionStringChange?: (str: string) => void,

--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -6,7 +6,7 @@
 declare module "SendbirdUIKitGlobal" {
   import type React from 'react';
   import type SendbirdChat from '@sendbird/chat';
-  import { GroupChannel, GroupChannelModule, ModuleNamespaces, OpenChannel, OpenChannelModule } from '@sendbird/chat/lib/__definition';
+  import { GroupChannelModule, ModuleNamespaces, OpenChannelModule } from '@sendbird/chat/lib/__definition';
   import type {
     SendbirdError,
     SessionHandler,

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -306,10 +306,12 @@ const SendbirdSDK = ({
           groupChannel: {
             enableOgtag: configs.groupChannel.channel.enableOgtag,
             enableTypingIndicator: configs.groupChannel.channel.enableTypingIndicator,
+            enableDocument: configs.groupChannel.channel.input.enableDocument,
             threadReplySelectType: getCaseResolvedThreadReplySelectType(configs.groupChannel.channel.threadReplySelectType).upperCase,
           },
           openChannel: {
             enableOgtag: configs.openChannel.channel.enableOgtag,
+            enableDocument: configs.openChannel.channel.input.enableDocument,
           },
         },
       }}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,10 +108,12 @@ export interface SendBirdStateConfig {
   groupChannel: {
     enableOgtag: SBUConfig['groupChannel']['channel']['enableOgtag'];
     enableTypingIndicator: SBUConfig['groupChannel']['channel']['enableTypingIndicator'];
+    enableDocument: SBUConfig['groupChannel']['channel']['input']['enableDocument'];
     threadReplySelectType: SBUConfig['groupChannel']['channel']['threadReplySelectType'];
   },
   openChannel: {
     enableOgtag: SBUConfig['openChannel']['channel']['enableOgtag'];
+    enableDocument: SBUConfig['openChannel']['channel']['input']['enableDocument'];
   },
 }
 export interface SdkStore {

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -266,6 +266,7 @@ const Message = ({
         }
         <MessageInput
           isEdit
+          channel={currentGroupChannel}
           disabled={disabled}
           ref={editMessageInputRef}
           mentionSelectedUser={selectedUser}

--- a/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
+++ b/src/modules/OpenChannel/components/OpenChannelInput/index.tsx
@@ -37,6 +37,7 @@ const MessageInputWrapper = (props: MessageInputWrapperProps, ref: React.RefObje
   return (
     <div className="sendbird-openchannel-footer">
       <MessageInput
+        channel={currentOpenChannel}
         ref={ref}
         value={value}
         disabled={disabled}

--- a/src/modules/OpenChannel/components/OpenChannelMessage/index.tsx
+++ b/src/modules/OpenChannel/components/OpenChannelMessage/index.tsx
@@ -105,6 +105,7 @@ export default function MessagOpenChannelMessageeHoc(props: OpenChannelMessagePr
     return (
       <MessageInput
         isEdit
+        channel={currentOpenChannel}
         disabled={editDisabled}
         ref={editMessageInputRef}
         message={message as UserMessage}

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -157,6 +157,7 @@ export default function ParentMessageInfo({
           )
         }
         <MessageInput
+          channel={currentChannel}
           isEdit
           disabled={disabled}
           ref={editMessageInputRef}

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -159,6 +159,7 @@ export default function ThreadListItem({
         }
         <MessageInput
           isEdit
+          channel={currentChannel}
           disabled={disabled}
           ref={editMessageInputRef}
           mentionSelectedUser={selectedUser}

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -52,7 +52,7 @@ describe('ui/MessageInput', () => {
       useContext.mockReturnValue(stateContextValue);
       renderHook(() => useSendbirdStateContext());
 
-      const { container } = render(<MessageInput onSendMessage={noop} value="" />);
+      const { container } = render(<MessageInput onSendMessage={noop} value=""  channel={{channelType: 'group'}} />);
       expect(
         container.getElementsByClassName('sendbird-message-input--attach').length
       ).toBe(0);

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -28,6 +28,7 @@ import usePaste from './hooks/usePaste';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
 import { USER_MENTION_PREFIX } from '../../modules/Message/consts';
 import { TOKEN_TYPES } from '../../modules/Message/utils/tokens/types';
+import { checkIfFileUploadEnabled } from './messageInputUtils';
 
 const TEXT_FIELD_ID = 'sendbird-message-input-text-field';
 const LINE_HEIGHT = 76;
@@ -101,9 +102,10 @@ const MessageInput = React.forwardRef((props, ref) => {
   const { stringSet } = useLocalization();
   const { config } = useSendbirdStateContext();
 
-  const isFileUploadEnabled = channel?.channelType === 'open'
-    ? config.openChannel.enableDocument
-    : config.groupChannel.enableDocument;
+  const isFileUploadEnabled = checkIfFileUploadEnabled({
+    channel,
+    config,
+  });
 
   const fileInputRef = useRef(null);
   const [isInput, setIsInput] = useState(false);

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -4,12 +4,10 @@ import React, {
   useState,
   useEffect,
   useCallback,
-  useContext,
 } from 'react';
 import PropTypes from 'prop-types';
 
 import './index.scss';
-import { ChannelType } from '@sendbird/chat';
 import { MessageInputKeys, NodeNames, NodeTypes } from './const';
 
 import { USER_MENTION_TEMP_CHAR } from '../../modules/Channel/context/const';
@@ -18,7 +16,7 @@ import Button, { ButtonTypes, ButtonSizes } from '../Button';
 import renderMentionLabelToString from '../MentionUserLabel/renderToString';
 import Icon, { IconTypes, IconColors } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../Label';
-import { LocalizationContext } from '../../lib/LocalizationContext';
+import { useLocalization } from '../../lib/LocalizationContext';
 import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 
 import { nodeListToArray, sanitizeString } from './utils';
@@ -100,10 +98,10 @@ const MessageInput = React.forwardRef((props, ref) => {
     setMentionedUsers,
   } = props;
   const textFieldId = messageFieldId || TEXT_FIELD_ID;
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet } = useLocalization();
   const { config } = useSendbirdStateContext();
 
-  const isFileUploadEnabled = channel?.channelType === ChannelType.OPEN
+  const isFileUploadEnabled = channel?.channelType === 'open'
     ? config.openChannel.enableDocument
     : config.groupChannel.enableDocument;
 

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -2,13 +2,23 @@
  * Write new utils here
  * Migrate old utils as needed, and delete utils.js
  */
-import type { ChannelType } from '@sendbird/chat';
+// import { ChannelType } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
 import { match } from 'ts-pattern';
 
 import type { SendBirdStateConfig } from '../../lib/types';
 
+/**
+ * FIXME:
+ * Import this ChannelType enum from @sendbird/chat
+ * once MessageInput.spec unit tests can be run \wo jest <-> ESM issue
+ */
+enum ChannelType {
+  BASE = 'base',
+  GROUP = 'group',
+  OPEN = 'open',
+}
 /**
  * FIXME: Simplify this in UIKit@v4
  * If customer is using MessageInput inside our modules(ie: Channel, Thread, etc),
@@ -27,5 +37,6 @@ export const checkIfFileUploadEnabled = ({ channel, config }: {
     .with(ChannelType.GROUP, () => config?.groupChannel?.enableDocument)
     .with(ChannelType.OPEN, () => config?.openChannel?.enableDocument)
     .otherwise(() => true);
+
   return isEnabled;
 };

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Write new utils here
+ * Migrate old utils as needed, and delete utils.js
+ */
+import type { ChannelType } from '@sendbird/chat';
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import type { OpenChannel } from '@sendbird/chat/openChannel';
+import { match } from 'ts-pattern';
+
+import type { SendBirdStateConfig } from '../../lib/types';
+
+/**
+ * FIXME: Simplify this in UIKit@v4
+ * If customer is using MessageInput inside our modules(ie: Channel, Thread, etc),
+ * we should use the config from the module.
+ * If customer is using MessageInput outside our modules(ie: custom UI),
+ * we expect Channel to be undefined and customer gets control to show/hide file-upload.
+ * @param {*} channel GroupChannel | OpenChannel
+ * @param {*} config SendBirdStateConfig
+ * @returns boolean
+ */
+export const checkIfFileUploadEnabled = ({ channel, config }: {
+  channel?: GroupChannel | OpenChannel,
+  config?: SendBirdStateConfig,
+}) => {
+  const isEnabled = match(channel?.channelType)
+    .with(ChannelType.GROUP, () => config?.openChannel?.enableDocument)
+    .with(ChannelType.OPEN, () => config?.groupChannel?.enableDocument)
+    .otherwise(() => true);
+  return isEnabled;
+};

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -24,8 +24,8 @@ export const checkIfFileUploadEnabled = ({ channel, config }: {
   config?: SendBirdStateConfig,
 }) => {
   const isEnabled = match(channel?.channelType)
-    .with(ChannelType.GROUP, () => config?.openChannel?.enableDocument)
-    .with(ChannelType.OPEN, () => config?.groupChannel?.enableDocument)
+    .with(ChannelType.GROUP, () => config?.groupChannel?.enableDocument)
+    .with(ChannelType.OPEN, () => config?.openChannel?.enableDocument)
     .otherwise(() => true);
   return isEnabled;
 };


### PR DESCRIPTION
### Description Of Changes
https://sendbird.atlassian.net/browse/UIKIT-4085

Address `enable_document`  configs to MessageInput component. 
- [x] group_channel.channel.input.enable_document
- [x] open_channel.channel.input.enable_document