### PR TITLE
feat: apply groupchannel enableMessageSearch config flag

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -241,6 +241,7 @@ declare module "SendbirdUIKitGlobal" {
     markAsReadScheduler?: MarkAsReadSchedulerType;
     disableUserProfile?: boolean;
     disableMarkAsDelivered?: boolean;
+    showSearchIcon?: boolean;
     renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
     allowProfileEdit?: boolean;
     userListQuery?(): UserListQuery;

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -87,6 +87,7 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps {
   imageCompression?: ImageCompressionOptions;
   allowProfileEdit?: boolean;
   disableMarkAsDelivered?: boolean;
+  showSearchIcon?: boolean;
   renderUserProfile?: () => React.ReactElement;
   onUserProfileMessage?: () => void;
 }
@@ -100,6 +101,7 @@ function Sendbird(props: SendbirdProviderProps) {
     isVoiceMessageEnabled,
     isTypingIndicatorEnabledOnChannelList,
     isMessageReceiptStatusEnabledOnChannelList,
+    showSearchIcon,
   } = props;
 
   return (
@@ -123,6 +125,9 @@ function Sendbird(props: SendbirdProviderProps) {
           channelList: {
             enableTypingIndicator: isTypingIndicatorEnabledOnChannelList,
             enableMessageReceiptStatus: isMessageReceiptStatusEnabledOnChannelList,
+          },
+          setting: {
+            enableMessageSearch: showSearchIcon,
           },
         },
       }}
@@ -307,6 +312,7 @@ const SendbirdSDK = ({
             configs.groupChannel.channelList.enableTypingIndicator,
           isMessageReceiptStatusEnabledOnChannelList:
             configs.groupChannel.channelList.enableMessageReceiptStatus,
+          showSearchIcon: configs.groupChannel.setting.enableMessageSearch,
           // Remote configs set from dashboard by UIKit feature configuration
           groupChannel: {
             enableOgtag: configs.groupChannel.channel.enableOgtag,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,6 +103,7 @@ export interface SendBirdStateConfig {
   isTypingIndicatorEnabledOnChannelList?: boolean;
   isMessageReceiptStatusEnabledOnChannelList?: boolean;
   replyType: ReplyType;
+  showSearchIcon?: boolean;
   // Remote configs set from dashboard by UIKit feature configuration
   groupChannel: {
     enableOgtag: SBUConfig['groupChannel']['channel']['enableOgtag'];

--- a/src/modules/App/index.jsx
+++ b/src/modules/App/index.jsx
@@ -77,6 +77,7 @@ export default function App(props) {
       isTypingIndicatorEnabledOnChannelList={isTypingIndicatorEnabledOnChannelList}
       isMessageReceiptStatusEnabledOnChannelList={isMessageReceiptStatusEnabledOnChannelList}
       replyType={replyType}
+      showSearchIcon={showSearchIcon}
     >
       <AppLayout
         isReactionEnabled={isReactionEnabled}

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -206,6 +206,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   } = config;
   const sdk = globalStore?.stores?.sdkStore?.sdk as SendbirdGroupChat;
   const sdkInit = globalStore?.stores?.sdkStore?.initialized;
+  const globalConfigs = globalStore?.config;
 
   const [initialTimeStamp, setInitialTimeStamp] = useState(startingPoint);
   useEffect(() => {
@@ -424,7 +425,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
       channelUrl,
       isReactionEnabled: usingReaction,
       isMessageGroupingEnabled,
-      showSearchIcon,
+      showSearchIcon: showSearchIcon ?? globalConfigs.showSearchIcon,
       highlightedMessage,
       startingPoint,
       onBeforeSendUserMessage,


### PR DESCRIPTION
### Description Of Changes
https://sendbird.atlassian.net/browse/UIKIT-4085

Applied enable_message_search config flag by adding `showSearchIcon` to lib/Sendbird component prop which is not a completely new one but it can be passed from `App` component which already has `showSearchIcon` prop. 

 - [x] group_channel.setting.input.enable_message_search