### PR TITLE
feat: Use channel optionally inside MessageInput

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -2095,7 +2095,7 @@ declare module '@sendbird/uikit-react/ui/MessageInput' {
     onCancelEdit?: () => void,
     onStartTyping?: () => void,
     channelUrl: string,
-    channel: OpenChannel | GroupChannel | null,
+    channel?: OpenChannel | GroupChannel,
     mentionSelectedUser?: Array<User>,
     onUserMentioned?: (user: User) => void,
     onMentionStringChange?: (str: string) => void,

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -52,7 +52,7 @@ describe('ui/MessageInput', () => {
       useContext.mockReturnValue(stateContextValue);
       renderHook(() => useSendbirdStateContext());
 
-      const { container } = render(<MessageInput onSendMessage={noop} value="" />);
+      const { container } = render(<MessageInput onSendMessage={noop} value=""  channel={{channelType: 'group'}} />);
       expect(
         container.getElementsByClassName('sendbird-message-input--attach').length
       ).toBe(0);

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -28,6 +28,7 @@ import usePaste from './hooks/usePaste';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
 import { USER_MENTION_PREFIX } from '../../modules/Message/consts';
 import { TOKEN_TYPES } from '../../modules/Message/utils/tokens/types';
+import { checkIfFileUploadEnabled } from './messageInputUtils';
 
 const TEXT_FIELD_ID = 'sendbird-message-input-text-field';
 const LINE_HEIGHT = 76;
@@ -101,9 +102,10 @@ const MessageInput = React.forwardRef((props, ref) => {
   const { stringSet } = useLocalization();
   const { config } = useSendbirdStateContext();
 
-  const isFileUploadEnabled = channel?.channelType === 'open'
-    ? config.openChannel.enableDocument
-    : config.groupChannel.enableDocument;
+  const isFileUploadEnabled = checkIfFileUploadEnabled({
+    channel,
+    config,
+  });
 
   const fileInputRef = useRef(null);
   const [isInput, setIsInput] = useState(false);

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -2,13 +2,23 @@
  * Write new utils here
  * Migrate old utils as needed, and delete utils.js
  */
-import type { ChannelType } from '@sendbird/chat';
+// import { ChannelType } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
 import { match } from 'ts-pattern';
 
 import type { SendBirdStateConfig } from '../../lib/types';
 
+/**
+ * FIXME:
+ * Import this ChannelType enum from @sendbird/chat
+ * once MessageInput.spec unit tests can be run \wo jest <-> ESM issue
+ */
+enum ChannelType {
+  BASE = 'base',
+  GROUP = 'group',
+  OPEN = 'open',
+}
 /**
  * FIXME: Simplify this in UIKit@v4
  * If customer is using MessageInput inside our modules(ie: Channel, Thread, etc),
@@ -27,5 +37,6 @@ export const checkIfFileUploadEnabled = ({ channel, config }: {
     .with(ChannelType.GROUP, () => config?.groupChannel?.enableDocument)
     .with(ChannelType.OPEN, () => config?.openChannel?.enableDocument)
     .otherwise(() => true);
+
   return isEnabled;
 };

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Write new utils here
+ * Migrate old utils as needed, and delete utils.js
+ */
+import type { ChannelType } from '@sendbird/chat';
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import type { OpenChannel } from '@sendbird/chat/openChannel';
+import { match } from 'ts-pattern';
+
+import type { SendBirdStateConfig } from '../../lib/types';
+
+/**
+ * FIXME: Simplify this in UIKit@v4
+ * If customer is using MessageInput inside our modules(ie: Channel, Thread, etc),
+ * we should use the config from the module.
+ * If customer is using MessageInput outside our modules(ie: custom UI),
+ * we expect Channel to be undefined and customer gets control to show/hide file-upload.
+ * @param {*} channel GroupChannel | OpenChannel
+ * @param {*} config SendBirdStateConfig
+ * @returns boolean
+ */
+export const checkIfFileUploadEnabled = ({ channel, config }: {
+  channel?: GroupChannel | OpenChannel,
+  config?: SendBirdStateConfig,
+}) => {
+  const isEnabled = match(channel?.channelType)
+    .with(ChannelType.GROUP, () => config?.openChannel?.enableDocument)
+    .with(ChannelType.OPEN, () => config?.groupChannel?.enableDocument)
+    .otherwise(() => true);
+  return isEnabled;
+};

--- a/src/ui/MessageInput/messageInputUtils.ts
+++ b/src/ui/MessageInput/messageInputUtils.ts
@@ -24,8 +24,8 @@ export const checkIfFileUploadEnabled = ({ channel, config }: {
   config?: SendBirdStateConfig,
 }) => {
   const isEnabled = match(channel?.channelType)
-    .with(ChannelType.GROUP, () => config?.openChannel?.enableDocument)
-    .with(ChannelType.OPEN, () => config?.groupChannel?.enableDocument)
+    .with(ChannelType.GROUP, () => config?.groupChannel?.enableDocument)
+    .with(ChannelType.OPEN, () => config?.openChannel?.enableDocument)
     .otherwise(() => true);
   return isEnabled;
 };


### PR DESCRIPTION
If customer is using MessageInput inside our modules(ie: Channel, Thread, etc),
we should use the config from the module.
If customer is using MessageInput outside our modules(ie: custom UI),
we expect Channel to be undefined and customer gets control to show/hide file-upload.

