### PR TITLE
feat: reset default value of duplicated configs in modules/App

### DIFF
--- a/src/modules/App/index.jsx
+++ b/src/modules/App/index.jsx
@@ -163,7 +163,6 @@ App.defaultProps = {
   allowProfileEdit: false,
   onProfileEditSuccess: null,
   disableMarkAsDelivered: false,
-  showSearchIcon: false,
   renderUserProfile: null,
   config: {},
   voiceRecord: {
@@ -175,11 +174,16 @@ App.defaultProps = {
   colorSet: null,
   imageCompression: {},
   disableAutoSelect: false,
-  isMentionEnabled: false,
-  isReactionEnabled: true,
-  replyType: 'QUOTE_REPLY',
-  disableUserProfile: false,
-  isVoiceMessageEnabled: false,
-  isTypingIndicatorEnabledOnChannelList: false,
-  isMessageReceiptStatusEnabledOnChannelList: false,
+
+  // The below configs are duplicates of the Dashboard UIKit Configs.
+  // Since their default values will be set in the Sendbird component,
+  // we don't need to set them here.
+  showSearchIcon: undefined,
+  isMentionEnabled: undefined,
+  isReactionEnabled: undefined,
+  replyType: undefined,
+  disableUserProfile: undefined,
+  isVoiceMessageEnabled: undefined,
+  isTypingIndicatorEnabledOnChannelList: undefined,
+  isMessageReceiptStatusEnabledOnChannelList: undefined,
 };


### PR DESCRIPTION
### Description Of Changes
The current default value setting via prop-types makes every configs' value have default value from the App component level. This makes Sendbird config priotization logic unnecessary. 

So I reset configs' value to `undefined` to make them set in Sendbird component instead.