### PR TITLE
[Message]: Make the message component selectable

### DIFF
--- a/src/ui/Label/index.scss
+++ b/src/ui/Label/index.scss
@@ -1,10 +1,5 @@
 @import '../../styles/variables';
 
-.sendbird-label {
-  -webkit-user-select: none;
-  -webkit-touch-callout: none;
-}
-
 [class*=sendbird-label] {
   font-family: var(--sendbird-font-family-default);
 }
@@ -46,12 +41,12 @@
 }
 
 .sendbird-label--body-1 {
- font-size: 14px;
- font-weight: normal;
- font-stretch: normal;
- font-style: normal;
- line-height: 1.43;
- letter-spacing: normal;
+  font-size: 14px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.43;
+  letter-spacing: normal;
 }
 
 .sendbird-label--body-2 {
@@ -82,20 +77,20 @@
 }
 
 .sendbird-label--caption-1 {
- font-size: 14px;
- font-weight: 600;
- font-stretch: normal;
- font-style: normal;
- line-height: 1.43;
- letter-spacing: normal;
+  font-size: 14px;
+  font-weight: 600;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.43;
+  letter-spacing: normal;
 }
 
 .sendbird-label--caption-2 {
- font-size: 12px;
- font-weight: bold;
- font-style: normal;
- line-height: 1;
- letter-spacing: normal;
+  font-size: 12px;
+  font-weight: bold;
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: normal;
 }
 
 .sendbird-label--caption-3 {


### PR DESCRIPTION
I know I'm not supposed to open PR as I'm not a contributer, but please take a look and let me know. I recently upgraded and found this. If I'm removing something that's essential, let me know I can try to help. I found this code is added from #550, so if the code I'm removing is supposed to work only on mobile, I'll try to add a media-query. Won't be offended if you close the PR also :)

## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

### Description Of Changes

- Not able to select messages even email addresses from the message.

https://github.com/sendbird/sendbird-uikit-react/assets/31589372/b4346f7e-445d-4e6c-b455-0e921356492d


