### PR TITLE
fix: Mobile layout / Navigation on DM from Thread

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -1004,7 +1004,6 @@ declare module "SendbirdUIKitGlobal" {
     onMoveToParentMessage?: (props: { message: UserMessage | FileMessage, channel: GroupChannel }) => void;
     disableUserProfile?: boolean;
     renderUserProfile?: (props: { user: User, close: () => void }) => React.ReactElement;
-    onUserProfileMessage?: (channel: GroupChannel) => void;
   }
 
   export interface ThreadContextInitialState {

--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -92,6 +92,14 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
     };
   }, [sdk]);
 
+  // if currentChannel is changed while on Thread
+  // then change panel type to CHANNEL
+  useEffect(() => {
+    if (panel === PANELS.THREAD) {
+      setPanel(PANELS.CHANNEL);
+    }
+  }, [currentChannel?.url]);
+
   return (
     <div>
       {

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -38,7 +38,6 @@ export type ThreadProviderProps = {
   // User Profile
   disableUserProfile?: boolean;
   renderUserProfile?: (props: { user: User, close: () => void }) => ReactElement;
-  onUserProfileMessage?: (channel: GroupChannel) => void;
 };
 export interface ThreadProviderInterface extends ThreadProviderProps, ThreadContextInitialState {
   // hooks for fetching threads
@@ -70,7 +69,6 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     // User Profile
     disableUserProfile,
     renderUserProfile,
-    onUserProfileMessage,
   } = props;
   const propsMessage = props?.message;
   const propsParentMessage = getParentMessageFrom(propsMessage);
@@ -89,6 +87,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     replyType,
     isMentionEnabled,
     isReactionEnabled,
+    onUserProfileMessage,
   } = config;
 
   // dux of Thread


### PR DESCRIPTION
When user sends direct message from Thread, it should open Channel Panel

Removal of `onUserProfileMessage` from `ThreadProvider` is not a breaking change
because, it was not connected from  `<Thread />` anyways

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4102