### PR TITLE
feat: make integrated toggle config options resettable

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -20,7 +20,7 @@ import { LoggerFactory, LogLevel } from './Logger';
 import pubSubFactory from './pubSub/index';
 import useAppendDomNode from '../hooks/useAppendDomNode';
 
-import { UIKitConfigProvider, useUIKitConfig, initialConfig } from '@sendbird/uikit-tools';
+import { UIKitConfigProvider, useUIKitConfig } from '@sendbird/uikit-tools';
 
 import { VoiceMessageProvider } from './VoiceMessageProvider';
 import { LocalizationProvider } from './LocalizationContext';
@@ -118,7 +118,7 @@ function Sendbird(props: SendbirdProviderProps) {
             enableReactions: isReactionEnabled,
             enableMention: isMentionEnabled,
             enableVoiceMessage: isVoiceMessageEnabled,
-            replyType: getCaseResolvedReplyType(replyType ?? initialConfig.groupChannel.channel.replyType).lowerCase,
+            replyType: replyType != null ? getCaseResolvedReplyType(replyType).lowerCase : undefined,
           },
           channelList: {
             enableTypingIndicator: isTypingIndicatorEnabledOnChannelList,

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -109,7 +109,9 @@ function Sendbird(props: SendbirdProviderProps) {
     <UIKitConfigProvider
       localConfigs={{
         common: {
-          enableUsingDefaultUserProfile: !disableUserProfile,
+          enableUsingDefaultUserProfile: typeof disableUserProfile === 'boolean'
+            ? !disableUserProfile
+            : undefined,
         },
         groupChannel: {
           channel: {

--- a/src/modules/App/stories/integrated-app.scss
+++ b/src/modules/App/stories/integrated-app.scss
@@ -88,6 +88,11 @@
   }
   .sendbird-integrated-sample-app__moderations__option__name,
   .sendbird-integrated-sample-app__moderations__option__input {
+    display: flex;
+
+    .sendbird-checkbox {
+      margin: 2px 0 0 4px;
+    }
     @include mobile() {
       width: auto;
     }

--- a/src/modules/App/stories/integrated.stories.js
+++ b/src/modules/App/stories/integrated.stories.js
@@ -436,17 +436,42 @@ export const GroupChannel = () => {
               }}
             />
           </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Reply Type">
-            <MultipleButtons
-              options={ReplyType}
-              value={sampleOptions.replyType}
-              onClick={(selectedOption) => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  replyType: selectedOption,
-                })
+          <ModerationOptionItem
+            subTitle="Reply Type"
+            description={String(sampleOptions.replyType)}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
               }}
-            />
+            >
+              {typeof sampleOptions.replyType !== 'undefined' &&
+                <MultipleButtons
+                  options={ReplyType}
+                  value={sampleOptions.replyType}
+                  onClick={(selectedOption) => {
+                    setSampleOptions({
+                      ...sampleOptions,
+                      replyType: selectedOption,
+                    })
+                  }}
+                />
+              }
+              {/** Checkbox is for setting the replyType value to 'undefined' */}
+              <div style={{ marginLeft: 8 }}>
+                <Checkbox
+                  id="sampleOptions.replyType"
+                  checked={sampleOptions.replyType}
+                  onChange={() => {
+                    setSampleOptions(prevOptions => ({
+                      ...prevOptions,
+                      replyType: prevOptions.replyType ? undefined : true,
+                    }));
+                  }}
+                />
+              </div>
+            </div>
           </ModerationOptionItem>
           {Object.entries(toggleItems).map(([path, { title }]) => (
             <ModerationOptionItem key={path} subTitle={title} description={String(sampleOptions[path])} type={TYPES.TOGGLE}>

--- a/src/modules/App/stories/integrated.stories.js
+++ b/src/modules/App/stories/integrated.stories.js
@@ -7,6 +7,7 @@ import Streamnig from '../../OpenChannelApp/Streaming';
 
 import Label, { LabelTypography, LabelColors } from '../../../ui/Label';
 import Icon, { IconTypes, IconColors } from '../../../ui/Icon';
+import Checkbox from '../../../ui/Checkbox';
 import Button, { ButtonSizes, ButtonTypes } from '../../../ui/Button';
 import { MediaQueryProvider } from '../../../lib/MediaQueryContext';
 
@@ -84,6 +85,41 @@ const ChannelType = {
 const TYPES = {
   TOGGLE: 'TOGGLE',
 };
+
+const toggleItems = {
+  messageSearch: {
+    title: 'Message Search',
+    defaultValue: true,
+  },
+  editUserProfile: {
+    title: 'Edit User Profile',
+    defaultValue: true,
+  },
+  messageGrouping: {
+    title: 'Message Grouping',
+    defaultValue: true,
+  },
+  emojiReaction: {
+    title: 'Emoji Reaction',
+    defaultValue: true,
+  },
+  isVoiceMessageEnabled: {
+    title: 'Voice Message',
+    defaultValue: true,
+  },
+  mention: {
+    title: 'Mention',
+    defaultValue: true,
+  },
+  typingIndicator: {
+    title: 'Typing Indicator',
+    defaultValue: true,
+  },
+  messageStatus: {
+    title: 'Message Status',
+    defaultValue: true,
+  },
+}
 
 const ModerationOptionItem = ({
   subTitle,
@@ -193,20 +229,17 @@ export const GroupChannel = () => {
     userId: '',
     nickname: '',
     theme: ThemeType.light,
-    messageSearch: true,
-    editUserProfile: true,
-    messageGrouping: true,
-    emojiReaction: true,
-    mention: true,
-    typingIndicator: true,
-    messageStatus: true,
-    imageCompression: true,
-    isVoiceMessageEnabled: true,
     compressionRate: 0.7,
     resizingHeight: '',
     resizingWidth: '',
-    replyType: ReplyType.THREAD,
+    replyType: ReplyType.QUOTE_REPLY,
     channelType: ChannelType.GROUP,
+    ...Object
+      .entries(toggleItems)
+      .reduce((acc, [path, item]) => ({
+        ...acc,
+        [path]: item.defaultValue,
+      }), {})
   });
 
   useEffect(() => {
@@ -406,94 +439,29 @@ export const GroupChannel = () => {
               }}
             />
           </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Message Search" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.messageSearch}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  messageSearch: !sampleOptions.messageSearch,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Edit User Profile" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.editUserProfile}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  editUserProfile: !sampleOptions.editUserProfile,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Message Grouping" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.messageGrouping}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  messageGrouping: !sampleOptions.messageGrouping,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Emoji Reaction" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.emojiReaction}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  emojiReaction: !sampleOptions.emojiReaction,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Voice Message" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.isVoiceMessageEnabled}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  isVoiceMessageEnabled: !sampleOptions.isVoiceMessageEnabled,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Mention" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.mention}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  mention: !sampleOptions.mention,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Typing Indicator" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.typingIndicator}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  typingIndicator: !sampleOptions.typingIndicator,
-                });
-              }}
-            />
-          </ModerationOptionItem>
-          <ModerationOptionItem subTitle="Message Status" type={TYPES.TOGGLE}>
-            <ToggleButton
-              isEnabled={sampleOptions.messageStatus}
-              onClick={() => {
-                setSampleOptions({
-                  ...sampleOptions,
-                  messageStatus: !sampleOptions.messageStatus,
-                });
-              }}
-            />
-          </ModerationOptionItem>
+          {Object.entries(toggleItems).map(([path, { title }]) => (
+            <ModerationOptionItem key={path} subTitle={title} type={TYPES.TOGGLE}>
+              {typeof sampleOptions[path] === 'boolean' && <ToggleButton
+                isEnabled={sampleOptions[path]}
+                onClick={() => {
+                  setSampleOptions(prevOptions => ({
+                    ...prevOptions,
+                    [path]: !prevOptions[path],
+                  }));
+                }}
+              />}
+              <Checkbox
+                id={path}
+                checked={sampleOptions[path]}
+                onChange={() => {
+                  setSampleOptions(prevOptions => ({
+                    ...prevOptions,
+                    [path]: prevOptions[path] ? undefined : true,
+                  }));
+                }}
+              />
+            </ModerationOptionItem>
+          ))}
           <ModerationOptionItem subTitle="Image Compression" type={TYPES.TOGGLE}>
             <ToggleButton
               isEnabled={sampleOptions.imageCompression}

--- a/src/modules/App/stories/integrated.stories.js
+++ b/src/modules/App/stories/integrated.stories.js
@@ -123,6 +123,7 @@ const toggleItems = {
 
 const ModerationOptionItem = ({
   subTitle,
+  description,
   children,
   type,
 }) => {
@@ -139,6 +140,14 @@ const ModerationOptionItem = ({
           color={LabelColors.ONBACKGROUND_1}
         >
           {subTitle}
+        </Label>
+      </div>
+      <div>
+        <Label
+            type={LabelTypography.SUBTITLE_2}
+            color={LabelColors.ONBACKGROUND_3}
+          >
+          {description}
         </Label>
       </div>
       <div className='sendbird-integrated-sample-app__moderations__option__input'>
@@ -440,16 +449,20 @@ export const GroupChannel = () => {
             />
           </ModerationOptionItem>
           {Object.entries(toggleItems).map(([path, { title }]) => (
-            <ModerationOptionItem key={path} subTitle={title} type={TYPES.TOGGLE}>
-              {typeof sampleOptions[path] === 'boolean' && <ToggleButton
-                isEnabled={sampleOptions[path]}
-                onClick={() => {
-                  setSampleOptions(prevOptions => ({
-                    ...prevOptions,
-                    [path]: !prevOptions[path],
-                  }));
-                }}
-              />}
+            <ModerationOptionItem key={path} subTitle={title} description={String(sampleOptions[path])} type={TYPES.TOGGLE}>
+              {/** Toggle is for setting the value to true or false */}
+              {typeof sampleOptions[path] === 'boolean' &&
+                <ToggleButton
+                  isEnabled={sampleOptions[path]}
+                  onClick={() => {
+                    setSampleOptions(prevOptions => ({
+                      ...prevOptions,
+                      [path]: !prevOptions[path],
+                    }));
+                  }}
+                />
+              }
+              {/** Checkbox is for setting the value to 'undefined' */}
               <Checkbox
                 id={path}
                 checked={sampleOptions[path]}

--- a/src/modules/App/stories/integrated.stories.js
+++ b/src/modules/App/stories/integrated.stories.js
@@ -313,7 +313,7 @@ export const GroupChannel = () => {
                 theme={sampleOptions.theme}
                 allowProfileEdit
                 showSearchIcon={sampleOptions.messageSearch}
-                disableUserProfile={!sampleOptions.editUserProfile}
+                disableUserProfile={typeof sampleOptions.editUserProfile === 'boolean' ? !sampleOptions.editUserProfile : undefined}
                 isMessageGroupingEnabled={sampleOptions.messageGrouping}
                 isReactionEnabled={sampleOptions.emojiReaction}
                 isMentionEnabled={sampleOptions.mention}


### PR DESCRIPTION
### Description Of Changes
I was preparing a sample app environment for Feature Configuration war room but realized that there's no way to set `undefined` for the toggle items but only possible to choose `true` or `false` in this integration app.

So I added a checkbox next to the each toggle button like this (yeah couldn't come up with a better UI :smile: Any suggestion is welcome!)
![recording](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/2f144e26-9c6f-402c-80e2-a35d5e823d7f)
 
Like the above in the gif, we can make each config value to `undefined` from boolean value by uncheck the checkbox.