### PR TITLE
fix: Thread / Add extra state to show/hide delete menu

### DIFF
--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -339,6 +339,11 @@ export default function ParentMessageInfo({
           hideMenu={() => {
             setShowMobileMenu(false);
           }}
+          deleteMenuState={
+            allThreadMessages?.length === 0
+              ? 'ACTIVE'
+              : 'HIDE'
+          }
           isReactionEnabled={usingReaction}
           isByMe={isByMe}
           emojiContainer={emojiContainer}

--- a/src/ui/MobileMenu/MobileContextMenu.tsx
+++ b/src/ui/MobileMenu/MobileContextMenu.tsx
@@ -29,6 +29,7 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
     resendMessage,
     showEdit,
     showRemove,
+    deleteMenuState,
     setQuoteMessage,
     parentRef,
     onReplyInThread,
@@ -39,7 +40,16 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
   const showMenuItemCopy: boolean = isUserMessage(message as UserMessage);
   const showMenuItemEdit: boolean = (isUserMessage(message as UserMessage) && isSentMessage(message) && isByMe);
   const showMenuItemResend: boolean = (isFailedMessage(message) && message?.isResendable && isByMe);
+
   const showMenuItemDelete: boolean = !isPendingMessage(message) && isByMe;
+  const showMenuItemDeleteByState = isByMe && (deleteMenuState === undefined || deleteMenuState !== 'HIDE');
+  const showMenuItemDeleteFinal = showMenuItemDeleteByState && showMenuItemDelete;
+
+  const disableDelete = (
+    (deleteMenuState !== undefined && deleteMenuState === 'DISABLE')
+    || (message?.threadInfo?.replyCount ?? 0) > 0
+  );
+
   const showMenuItemDownload: boolean = !isPendingMessage(message) && isFileMessage(message)
     && !(isVoiceMessage(message) && ((channel as GroupChannel)?.isSuper || (channel as GroupChannel)?.isBroadcast));
   const showMenuItemReply: boolean = (replyType === 'QUOTE_REPLY')
@@ -187,20 +197,22 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               />
             </MenuItem>
           )}
-          {showMenuItemDelete && (
+          {showMenuItemDeleteFinal && (
             <MenuItem
               className="sendbird-message__mobile-context-menu-item menu-item-delete"
               onClick={() => {
-                hideMenu();
-                showRemove(true);
+                if (!disableDelete) {
+                  hideMenu();
+                  showRemove(true);
+                }
               }}
-              disable={(message?.threadInfo?.replyCount ?? 0) > 0}
+              disable={disableDelete}
               dataSbId="ui_mobile_message_item_menu_delete"
             >
               <Label
                 type={LabelTypography.SUBTITLE_1}
                 color={
-                  (message?.threadInfo?.replyCount ?? 0) > 0
+                  disableDelete
                     ? LabelColors.ONBACKGROUND_4
                     : LabelColors.ONBACKGROUND_1
                 }
@@ -210,7 +222,7 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
               <Icon
                 type={IconTypes.DELETE}
                 fillColor={
-                  (message?.threadInfo?.replyCount ?? 0) > 0
+                  disableDelete
                     ? IconColors.ON_BACKGROUND_4
                     : IconColors.PRIMARY
                 }

--- a/src/ui/MobileMenu/index.tsx
+++ b/src/ui/MobileMenu/index.tsx
@@ -15,6 +15,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
     isByMe,
     replyType,
     disabled,
+    deleteMenuState,
     showRemove,
     showEdit,
     resendMessage,
@@ -40,6 +41,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
               disabled={disabled}
               showRemove={showRemove}
               showEdit={showEdit}
+              deleteMenuState={deleteMenuState}
               resendMessage={resendMessage}
               setQuoteMessage={setQuoteMessage}
               emojiContainer={emojiContainer}
@@ -58,6 +60,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
               showEdit={showEdit}
               replyType={replyType}
               disabled={disabled}
+              deleteMenuState={deleteMenuState}
               showRemove={showRemove}
               resendMessage={resendMessage}
               setQuoteMessage={setQuoteMessage}

--- a/src/ui/MobileMenu/types.ts
+++ b/src/ui/MobileMenu/types.ts
@@ -8,6 +8,9 @@ import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
 import React from 'react';
 
+// Fixme@v4 - deleteMessageOption type, rethink options
+export type DeleteMenuStates = 'DISABLE' | 'HIDE' | 'ACTIVE';
+
 export interface BaseMenuProps {
   channel: GroupChannel | OpenChannel;
   message: UserMessage | FileMessage;
@@ -16,6 +19,8 @@ export interface BaseMenuProps {
   isByMe?: boolean;
   replyType?: ReplyType;
   disabled?: boolean;
+  // This should take precedence over logic inside the component
+  deleteMenuState?: DeleteMenuStates;
   showEdit?: (bool: boolean) => void;
   showRemove?: (bool: boolean) => void;
   resendMessage?: (message: UserMessage | FileMessage) => Promise<UserMessage | FileMessage>;


### PR DESCRIPTION
message?.threadInfo?.replyCount is not getting updated dynamically

This is a temporary prop that we wont open to public, if this is SDK issue,
then we can remove later 

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4098