### PR TITLE
fix: Center align & remove ellipsis from admin message

### DIFF
--- a/src/ui/AdminMessage/index.scss
+++ b/src/ui/AdminMessage/index.scss
@@ -7,5 +7,6 @@
 
   .sendbird-admin-message__text {
     display: flex;
+    text-align: center;
   }
 }

--- a/src/ui/AdminMessage/index.scss
+++ b/src/ui/AdminMessage/index.scss
@@ -7,7 +7,5 @@
 
   .sendbird-admin-message__text {
     display: flex;
-    width: 100%;
-    word-break: break-word;
   }
 }


### PR DESCRIPTION
We added ellipsis and left align Admin Message in #584

But, admin messages should be center aligned and shouldn't
have ellipsis

Fixes: https://sendbird.atlassian.net/browse/QM-2155 