### PR TITLE
feat: make sdk disconnected on Sendbird component umount

### DIFF
--- a/src/hooks/useUnmount.ts
+++ b/src/hooks/useUnmount.ts
@@ -1,10 +1,10 @@
-import { useLayoutEffect } from 'react';
+import { DependencyList, useLayoutEffect } from 'react';
 
 // this hook accepts a callback to run component is unmounted
-export function useUnmount(callback: () => void) {
+export function useUnmount(callback: () => void, deps: DependencyList = []) {
   useLayoutEffect(() => {
     return () => {
       callback();
     };
-  }, []);
+  }, deps);
 }

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -31,6 +31,8 @@ import { useMarkAsReadScheduler } from './hooks/useMarkAsReadScheduler';
 import { ConfigureSessionTypes } from './hooks/useConnect/types';
 import { useMarkAsDeliveredScheduler } from './hooks/useMarkAsDeliveredScheduler';
 import { getCaseResolvedReplyType, getCaseResolvedThreadReplySelectType } from './utils/resolvedReplyType';
+import { useUnmount } from '../hooks/useUnmount';
+import { disconnectSdk } from './hooks/useConnect/disconnectSdk';
 
 export type UserListQueryType = {
   hasNext?: boolean;
@@ -191,6 +193,17 @@ const SendbirdSDK = ({
     userDispatcher,
     initDashboardConfigs,
   });
+
+  useUnmount(() => {
+    if (typeof sdk.disconnect === 'function') {
+      disconnectSdk({
+        logger,
+        sdkDispatcher,
+        userDispatcher,
+        sdk,
+      });
+    }
+  }, [sdk.disconnect]);
 
   // to create a pubsub to communicate between parent and child
   useEffect(() => {


### PR DESCRIPTION
### Description Of Changes
Address https://sendbird.atlassian.net/browse/UIKIT-4132

I found that the sdk is not disconnected on Sendbird component unmount which makes the connection is being kept even though we want it to be destroyed. 
So I made sdk.disconnect() is called when it's unmount.

p.s. I made a separate RC to test in Dashboard project and confirmed that their issue is gone with this patch. 