### PR TITLE
fix: use global config's replyType if channel one is undefined

### DIFF
--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -177,7 +177,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     onChatHeaderActionClick,
     onSearchClick,
     onBackClick,
-    replyType,
+    replyType: channelReplyType,
     threadReplySelectType,
     queries,
     filterMessageList,
@@ -190,6 +190,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
 
   const globalStore = useSendbirdStateContext();
   const { config } = globalStore;
+  const replyType = channelReplyType ?? config.replyType;
   const {
     pubSub,
     logger,


### PR DESCRIPTION
### Description Of Changes
Resolves https://sendbird.atlassian.net/browse/UIKIT-4138

If ChanneContext doesn't have a prop value for`replyType` but only lib/Sendbird component has the value, the latter is not reflected correctly. So I put a fallback value so the global config can be used. If both are undefined (for some customer who only uses the ChannelContext only), then the replyType will be set as undefined.  