### PR TITLE
fix: use global disableUserProfile if each context's one is defined

### DIFF
--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -485,7 +485,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
       toggleReaction,
     }}>
       <UserProfileProvider
-        disableUserProfile={props?.disableUserProfile}
+        disableUserProfile={props?.disableUserProfile ?? config?.disableUserProfile}
         renderUserProfile={props?.renderUserProfile}
         onUserProfileMessage={onUserProfileMessage}
       >

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -366,7 +366,7 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
       isMessageReceiptStatusEnabled: (isMessageReceiptStatusEnabled !== null) ? isMessageReceiptStatusEnabled : isMessageReceiptStatusEnabledOnChannelList,
     }}>
       <UserProfileProvider
-        disableUserProfile={userDefinedDisableUserProfile}
+        disableUserProfile={userDefinedDisableUserProfile ?? config?.disableUserProfile}
         renderUserProfile={userDefinedRenderProfile}
         onUserProfileMessage={onUserProfileMessage}
       >

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -130,7 +130,7 @@ const ChannelSettingsProvider: React.FC<ChannelSettingsContextProps> = (props: C
     }}>
       <UserProfileProvider
         renderUserProfile={props?.renderUserProfile}
-        disableUserProfile={props?.disableUserProfile}
+        disableUserProfile={props?.disableUserProfile ?? config?.disableUserProfile}
         onUserProfileMessage={onUserProfileMessage}
       >
         <div className={`sendbird-channel-settings ${className}`}>

--- a/src/modules/OpenChannel/context/OpenChannelProvider.tsx
+++ b/src/modules/OpenChannel/context/OpenChannelProvider.tsx
@@ -312,7 +312,7 @@ const OpenChannelProvider: React.FC<OpenChannelProviderProps> = (props: OpenChan
       <UserProfileProvider
         isOpenChannel
         renderUserProfile={props?.renderUserProfile}
-        disableUserProfile={props?.disableUserProfile}
+        disableUserProfile={props?.disableUserProfile ?? config?.disableUserProfile}
       >
         {children}
       </UserProfileProvider>

--- a/src/modules/OpenChannelSettings/context/OpenChannelSettingsProvider.tsx
+++ b/src/modules/OpenChannelSettings/context/OpenChannelSettingsProvider.tsx
@@ -155,7 +155,7 @@ const OpenChannelSettingsProvider: React.FC<OpenChannelSettingsContextProps> = (
       <UserProfileProvider
         isOpenChannel
         renderUserProfile={props?.renderUserProfile}
-        disableUserProfile={props?.disableUserProfile}
+        disableUserProfile={props?.disableUserProfile ?? globalStore?.config?.disableUserProfile}
       >
         {children}
       </UserProfileProvider>

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -225,7 +225,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     >
       {/* UserProfileProvider */}
       <UserProfileProvider
-        disableUserProfile={disableUserProfile}
+        disableUserProfile={disableUserProfile ?? config.disableUserProfile}
         renderUserProfile={renderUserProfile}
         onUserProfileMessage={onUserProfileMessage}
       >


### PR DESCRIPTION
## External Contributions
Resolves https://sendbird.atlassian.net/browse/UIKIT-4139

If any provider which uses `UserProfileContext` doesn't have a prop value for `disableUserProfile`  but only global config has the value, the latter is not reflected properly. 
So I put a fallback value so the global config can be used. If both are undefined, then the `disableUserProfile` will be set as undefined.
