### PR TITLE
fix: set fallback values \w global configs in App comp

### DIFF
--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -7,20 +7,23 @@ import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import { DesktopLayout } from './DesktopLayout';
 import { MobileLayout } from './MobileLayout';
 
+import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
+
 export const AppLayout: React.FC<AppLayoutProps> = (
   props: AppLayoutProps,
 ) => {
   const {
-    isReactionEnabled,
-    replyType,
     isMessageGroupingEnabled,
     allowProfileEdit,
-    showSearchIcon,
     onProfileEditSuccess,
     disableAutoSelect,
     currentChannel,
     setCurrentChannel,
   } = props;
+
+  const globalStore = useSendbirdStateContext();
+  const globalConfigs = globalStore?.config;
+
   const [showThread, setShowThread] = useState(false);
   const [threadTargetMessage, setThreadTargetMessage] = useState<UserMessage | FileMessage | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -28,6 +31,15 @@ export const AppLayout: React.FC<AppLayoutProps> = (
   const [highlightedMessage, setHighlightedMessage] = useState<number | null>(null);
   const [startingPoint, setStartingPoint] = useState<number | null>(null);
   const { isMobile } = useMediaQueryContext();
+
+  /**
+   * Below configs can be set via Dashboard UIKit config setting but as a lower priority than App props.
+   * So need to be have fallback value \w global configs even though each prop values are undefined
+   */
+  const replyType = props.replyType ?? globalConfigs?.replyType;
+  const isReactionEnabled = props.isReactionEnabled ?? globalConfigs?.isReactionEnabled;
+  const showSearchIcon = props.showSearchIcon ?? globalConfigs?.showSearchIcon;
+
   return (
     <>
       {
@@ -35,10 +47,10 @@ export const AppLayout: React.FC<AppLayoutProps> = (
           ? (
             <MobileLayout
               replyType={replyType}
+              showSearchIcon={showSearchIcon}
+              isReactionEnabled={isReactionEnabled}
               isMessageGroupingEnabled={isMessageGroupingEnabled}
               allowProfileEdit={allowProfileEdit}
-              isReactionEnabled={isReactionEnabled}
-              showSearchIcon={showSearchIcon}
               onProfileEditSuccess={onProfileEditSuccess}
               currentChannel={currentChannel}
               setCurrentChannel={setCurrentChannel}
@@ -52,11 +64,11 @@ export const AppLayout: React.FC<AppLayoutProps> = (
           )
           : (
             <DesktopLayout
-              isReactionEnabled={isReactionEnabled}
               replyType={replyType}
+              isReactionEnabled={isReactionEnabled}
+              showSearchIcon={showSearchIcon}
               isMessageGroupingEnabled={isMessageGroupingEnabled}
               allowProfileEdit={allowProfileEdit}
-              showSearchIcon={showSearchIcon}
               onProfileEditSuccess={onProfileEditSuccess}
               disableAutoSelect={disableAutoSelect}
               currentChannel={currentChannel}


### PR DESCRIPTION
### Description Of Changes
Fixes https://sendbird.atlassian.net/browse/UIKIT-4140

Since the component level in `modules/App` is like below 
```
const { replyType, isReactionEnabled, showSearchIcon } = props;

<Sendbird <-- lib/Sendbird
  replyType={replyType}
  isReactionEnabled={isReactionEnabled}
  showSearchIcon={showSearchIcon}
 >
    <AppLayout
       replyType={replyType}
       isReactionEnabled={isReactionEnabled}
       showSearchIcon={showSearchIcon}
    >
```
there's a chance that any of replyType / isReactionEnabled / showSearchIcon can be undefined even thought their values are set from Dashboard since the Dashboard values are set inside of `lib/Sendbird`. So AppLayout props still can have undefined values for these three configs. 

So I put fallback value setting logic \w global configs in `AppLayout`. 
