### PR TITLE
fix: runtime error on accessing null parentMessage data

### DIFF
--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -220,7 +220,7 @@ export default function MessageContent({
                 if (threadReplySelectType === ThreadReplySelectType.THREAD) {
                   onReplyInThread({ message });
                 } else if (threadReplySelectType === ThreadReplySelectType.PARENT) {
-                  scrollToMessage(message.parentMessage.createdAt, message.parentMessageId);
+                  scrollToMessage(message.parentMessage?.createdAt, message.parentMessageId);
                 }
               }}
             />
@@ -423,7 +423,7 @@ export default function MessageContent({
                 if (threadReplySelectType === ThreadReplySelectType.THREAD) {
                   onReplyInThread({ message });
                 } else if (threadReplySelectType === ThreadReplySelectType.PARENT) {
-                  scrollToMessage(message.parentMessage.createdAt, message.parentMessageId);
+                  scrollToMessage(message.parentMessage?.createdAt, message.parentMessageId);
                 }
               }}
             />


### PR DESCRIPTION
### Description Of Changes
Resolves https://sendbird.atlassian.net/browse/UIKIT-4142

Fixes a runtime error caused by clicking "Reply in thread" menu from a parent message. 
![recording](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/4b67fd87-d743-4636-b710-fba1c8aa055b)

It happens only when `replyType: THREAD & threadReplySelectType: PARENT`. 