### PR TITLE
fix: Handle undefined message type in is voice message

### DIFF
--- a/src/utils/__tests__/isVoiceMessage.spec.ts
+++ b/src/utils/__tests__/isVoiceMessage.spec.ts
@@ -1,5 +1,5 @@
-import { FileMessage, UserMessage } from "@sendbird/chat/message";
-import { isVoiceMessage } from "..";
+import { FileMessage, UserMessage } from '@sendbird/chat/message';
+import { isVoiceMessage } from '..';
 
 const mockVoiceMessage = {
   message: null,

--- a/src/utils/__tests__/isVoiceMessage.spec.ts
+++ b/src/utils/__tests__/isVoiceMessage.spec.ts
@@ -1,0 +1,132 @@
+import { FileMessage, UserMessage } from "@sendbird/chat/message";
+import { isVoiceMessage } from "..";
+
+const mockVoiceMessage = {
+  message: null,
+  messageType: 'file',
+  createdAt: 1,
+  type: 'audio/mp3;sbu_type=voice',
+  name: 'Voice_message.mp3',
+  file: new File([], 'Voice_message.mp3'),
+  metaArrays: [
+    { key: 'KEY_INTERNAL_MESSAGE_TYPE', value: ['voice/mp3'] },
+  ],
+} as unknown as FileMessage;
+const mockUserMessage = {
+  message: 'I am user message',
+  messageType: 'user',
+  createdAt: 1,
+  type: null,
+  name: null,
+  file: null,
+} as unknown as UserMessage;
+
+describe('Global-utils/isVoiceMessage', () => {
+  it('should verify voice message', () => {
+    expect(
+      isVoiceMessage(mockVoiceMessage),
+    ).toBeTrue();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'audio/mp3',
+        // referring correct metaArrays
+      } as unknown as FileMessage),
+    ).toBeTrue();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        // referring correct type
+        metaArrays: [],
+      } as unknown as FileMessage),
+    ).toBeTrue();
+  });
+  it('should filter invalid parameters', () => {
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'voice/mp3;sbu_type=voice',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: '',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: null,
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: undefined,
+      } as unknown as FileMessage),
+    ).toBeFalse();
+  });
+  it('should filter user messages', () => {
+    expect(
+      isVoiceMessage(mockUserMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockUserMessage,
+        type: undefined,
+        name: undefined,
+        file: undefined,
+      } as unknown as UserMessage),
+    ).toBeFalse();
+  });
+  it('should filter the other file messages', () => {
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'audio/mp3',
+        metaArrays: [],
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'audio/ogg',
+        metaArrays: [],
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'audio/webm',
+        metaArrays: [],
+      } as unknown as FileMessage),
+    ).toBeFalse();
+
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'video/mp4',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'video/ogg',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'video/webm',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+
+    expect(
+      isVoiceMessage({
+        ...mockVoiceMessage,
+        type: 'application/ogg',
+      } as unknown as FileMessage),
+    ).toBeFalse();
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -165,10 +165,10 @@ export const isAudioMessage = (message: FileMessage): boolean => message && isFi
 export const isAudioMessageMimeType = (type: string): boolean => (/^audio\//.test(type));
 export const isVoiceMessage = (message: Nullable<FileMessage | UserMessage>): boolean => {
   // ex) audio/m4a OR audio/m4a;sbu_type=voice
-  if (!(message && isFileMessage(message))) {
+  if (!(message && isFileMessage(message)) || !(message as FileMessage).type) {
     return false;
   }
-  const [mimeType, typeParameter] = message.type.split(';');
+  const [mimeType, typeParameter] = (message as FileMessage).type.split(';');
   if (!isAudioMessageMimeType(mimeType) || !typeParameter) {
     return false;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -163,23 +163,25 @@ export const isGifMessage = (message: UserMessage | FileMessage): boolean => (
 );
 export const isAudioMessage = (message: FileMessage): boolean => message && isFileMessage(message) && isAudio(message.type);
 export const isAudioMessageMimeType = (type: string): boolean => (/^audio\//.test(type));
+export const isVoiceMessageMimeType = (type: string): boolean => (/^voice\//.test(type));
 export const isVoiceMessage = (message: Nullable<FileMessage | UserMessage>): boolean => {
   // ex) audio/m4a OR audio/m4a;sbu_type=voice
   if (!(message && isFileMessage(message)) || !(message as FileMessage).type) {
     return false;
   }
   const [mimeType, typeParameter] = (message as FileMessage).type.split(';');
-  if (!isAudioMessageMimeType(mimeType) || !typeParameter) {
+
+  if (!isAudioMessageMimeType(mimeType)) {
     return false;
   }
-  const [key, value] = typeParameter.split('=');
-  if (key === 'sbu_type' && value === 'voice') {
-    return true;
+
+  if (typeParameter) {
+    const [key, value] = typeParameter.split('=');
+    return key === 'sbu_type' && value === 'voice';
   }
   // ex) message.metaArrays = [{ key: 'KEY_INTERNAL_MESSAGE_TYPE', value: ['voice/m4a'] }]
   return isVoiceMessageMimeType(message?.metaArrays?.find((metaArray) => metaArray.key === 'KEY_INTERNAL_MESSAGE_TYPE')?.value?.[0] ?? '');
 };
-export const isVoiceMessageMimeType = (type: string): boolean => (/^voice\//.test(type));
 
 export const isEditedMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => isUserMessage(message) && (message?.updatedAt > 0);
 export const isEnabledOGMessage = (message: UserMessage): boolean => (


### PR DESCRIPTION
### Description Of Changes

issue: Screen error shows up intermittently and says that the `message.type` property is undefined
fix: Check if the type property is empty and return false when it is