### PR TITLE
chore: Remove react-dom/server from rollup.config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,6 @@ module.exports = ({
     '@sendbird/chat/openChannel',
     '@sendbird/chat/message',
     '@sendbird/uikit-tools',
-    'react-dom/server',
     'prop-types',
     'react',
     'react-dom',


### PR DESCRIPTION
If a path is set on Rollup.config.externals, it wont be bundled
to the library during rollup build step. We have removed react-dom/server
in: https://github.com/sendbird/sendbird-uikit-react/pull/449
So, its okay to remove it

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4191

