### PR TITLE
fix: Race condition in disconnect/connect

### DIFF
--- a/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
+++ b/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
@@ -127,6 +127,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,
+      newInstance: true,
       modules: [
         // @ts-ignore
         new (require('@sendbird/chat/groupChannel').GroupChannelModule)(),
@@ -144,6 +145,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,
+      newInstance: true,
       modules: [
         // @ts-ignore
         new (require('@sendbird/chat/groupChannel').GroupChannelModule)(),

--- a/src/lib/hooks/useConnect/setupConnection.ts
+++ b/src/lib/hooks/useConnect/setupConnection.ts
@@ -36,6 +36,7 @@ export function setUpParams({
       new GroupChannelModule(),
       new OpenChannelModule(),
     ],
+    newInstance: true,
   };
   if (customApiHost) {
     params['customApiHost'] = customApiHost;


### PR DESCRIPTION
When there is only single instance of SDK,
and disconnect call take longer than next connect call
Solution: Set `newInstance: true` when initializing SDK instance

Fixes: https://sendbird.atlassian.net/browse/UIKIT-4193