### PR TITLE
fix: Allow to reduce mobile app height

### DIFF
--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -101,7 +101,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
   }, [currentChannel?.url]);
 
   return (
-    <div>
+    <div className='sb_mobile'>
       {
         panel === PANELS.CHANNEL_LIST && (
           <div className='sb_mobile__panelwrap'>

--- a/src/modules/App/mobile.scss
+++ b/src/modules/App/mobile.scss
@@ -1,5 +1,9 @@
+.sb_mobile {
+  height: 100%;
+}
+
 .sb_mobile__panelwrap {
-  height: 100vh;
+  height: 100%;
 }
 
 // storybook padding, not sendbird related

--- a/src/modules/App/stories/index.stories.js
+++ b/src/modules/App/stories/index.stories.js
@@ -268,6 +268,7 @@ export const user1 = () => fitPageSize(
     userId={array[0]}
     nickname={array[0]}
     profileUrl={addProfile}
+    breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
     showSearchIcon
     allowProfileEdit
     config={{ logLevel: 'all' }}

--- a/src/modules/App/stories/utils.jsx
+++ b/src/modules/App/stories/utils.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-export const fitPageSize = (component) => (
+export const fitPageSize = (component, style = {}) => (
   <div
     style={{
       height: '100vh',
       width: '100vw',
+      ...style,
     }}
   >
     {component}


### PR DESCRIPTION
### Description Of Changes

issue: It was not able to reduce the height of the mobile app with some wrapper component

* fix: Set the height of MobileApp to 100% & do not use 'vh'

[UIKIT-4188](https://sendbird.atlassian.net/browse/UIKIT-4188)


[UIKIT-4188]: https://sendbird.atlassian.net/browse/UIKIT-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ