### PR TITLE
fix: move scroll every time when message height changes

### DIFF
--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -136,11 +136,12 @@ const Message = ({
     }));
   }, [mentionedUserIds]);
 
-  // Move the messsage list scroll when the last message's height is changed by reactions
+  /**
+   * Move the messsage list scroll
+   * when the message's height is changed by `showEdit` OR `message.reactions`
+   */
   useDidMountEffect(() => {
-    if (currentGroupChannel?.lastMessage?.messageId === message?.messageId) {
-      handleScroll?.();
-    }
+    handleScroll?.();
   }, [showEdit, message?.reactions?.length]);
   useLayoutEffect(() => {
     handleMessageListHeightChange?.();

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -119,12 +119,16 @@ const MessageList: React.FC<MessageListProps> = ({
     }
   };
 
-  // Move the messsage list scroll when the last message's height is changed by reactions
+  /**
+   * Move the messsage list scroll
+   * when each message's height is changed by `reactions` OR `showEdit`
+   */
   const handleMessageHeightChange = () => {
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
       if (scrollBottom < bottom) {
+        // Move the scroll as much as the height of the message has changed
         current.scrollTop += bottom - scrollBottom;
       }
     }

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -124,7 +124,7 @@ const MessageList: React.FC<MessageListProps> = ({
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
-      if (scrollBottom < bottom && scrollBottom <= SCROLL_BUFFER) {
+      if (scrollBottom < bottom) {
         current.scrollTop += bottom - scrollBottom;
       }
     }


### PR DESCRIPTION
### Description Of Changes

* fix: move scroll every time when message height changes
  * prev: moving scroll only when the last message height changes

[UIKIT-4042](https://sendbird.atlassian.net/browse/UIKIT-4042)


[UIKIT-4042]: https://sendbird.atlassian.net/browse/UIKIT-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ