### PR TITLE
feat: add gh workflow for auto release ticket creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
           paths:
             - ./.yarn/cache
   create-ticket:
-    macos:
-      xcode: "14.1"
+    docker:
+      - image: cimg/node:16.19.1
     steps:
       - checkout
       - clone_deployment_script
@@ -80,8 +80,8 @@ jobs:
               --jira_auth_user $JIRA_AUTH_USER\
               --jira_auth_api_token $JIRA_AUTH_API_TOKEN\
               --project SDKRLSD\
-              --name ios_core@$RELEASE_VERSION\
-              --description 'Created by automation'
+              --name js_uikit@$RELEASE_VERSION\
+              --description 'Created by automation @ $CIRCLE_PROJECT_REPONAME'
       - run:
           name: Jira - Create release ticket
           command: |
@@ -89,13 +89,13 @@ jobs:
               --jira_auth_user $JIRA_AUTH_USER\
               --jira_auth_api_token $JIRA_AUTH_API_TOKEN\
               --project SDKRLSD\
-              --version ios_core@$RELEASE_VERSION\
-              --title "[Chat] iOS@$RELEASE_VERSION"\
-              --description 'Created by automation'\
+              --version js_uikit@$RELEASE_VERSION\
+              --title "[UIKit] js_uikit@$RELEASE_VERSION"\
+              --description 'Created by automation @ $CIRCLE_PROJECT_REPONAME'\
               --source_repo $CIRCLE_PROJECT_REPONAME\
               --source_branch $CIRCLE_BRANCH\
               --source_jira_project CORE\
-              --source_jira_version ios@$RELEASE_VERSION)
+              --source_jira_version js_uikit@$RELEASE_VERSION)
             echo "export RELEASE_TICKET_KEY=$release_ticket_key" >> $BASH_ENV
             source $BASH_ENV
       - slack/notify:
@@ -108,7 +108,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@chat-approver <https://sendbird.atlassian.net/browse/$RELEASE_TICKET_KEY|🔖 Chat iOS $RELEASE_VERSION release ticket> has been created!"
+                    "text": "@chat-approver <https://sendbird.atlassian.net/browse/$RELEASE_TICKET_KEY|🔖 UIKit JS $RELEASE_VERSION release ticket> has been created!"
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,10 @@ commands:
       - run:
           name: Git - Clone deployment scripts
           when: always
+          environment:
+            SDK_DEPLOYMENT_BOT_EMAIL: ${{ secrets.SDK_DEPLOYMENT_BOT_EMAIL }}
           command: |
-            git config --global user.email "sha.sdk_deployment@sendbird.com"
+            git config --global user.email $SDK_DEPLOYMENT_BOT_EMAIL
             git clone --depth 1 --branch 1.0.1 git@github.com:sendbird/sdk-deployment.git ~/sdk-deployment
 
 # Define a job to be invoked later in a workflow.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ version: 2.1
 orbs:
   slack: circleci/slack@4.10.1
 
+executors:
+  node-executor:
+    docker:
+      - image: cimg/node:16.19.1
+
 # MARK: Worflow parameters
 parameters:
   run_workflow_create_ticket:
@@ -40,8 +45,7 @@ commands:
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   job-lint_and_test:
-    docker:
-      - image: cimg/node:16.19.1
+    executor: node-executor
     parallelism: 4
     resource_class: large
     steps:
@@ -62,8 +66,7 @@ jobs:
           paths:
             - ./.yarn/cache
   create-ticket:
-    docker:
-      - image: cimg/node:16.19.1
+    executor: node-executor
     steps:
       - checkout
       - clone_deployment_script

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,16 @@
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
+# MARK: Orbs
+orbs:
+  slack: circleci/slack@4.10.1
+
+# MARK: Worflow parameters
+parameters:
+  run_workflow_create_ticket:
+    type: boolean
+    default: false
+
 commands:
   command-lint:
     steps:
@@ -17,6 +27,14 @@ commands:
           name: UIKit for React test
           command: yarn run test
           no_output_timeout: 15m
+  clone_deployment_script:
+    steps:
+      - run:
+          name: Git - Clone deployment scripts
+          when: always
+          command: |
+            git config --global user.email "sha.sdk_deployment@sendbird.com"
+            git clone --depth 1 --branch 1.0.1 git@github.com:sendbird/sdk-deployment.git ~/sdk-deployment
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -43,6 +61,59 @@ jobs:
           key: uikit-yarn-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - ./.yarn/cache
+  create-ticket:
+    macos:
+      xcode: "14.1"
+    steps:
+      - checkout
+      - clone_deployment_script
+      - run:
+          name: Extract release version
+          command: |
+            release_version=$(python3 ~/sdk-deployment/scripts/v1.2/extract_version.py --branch_name $CIRCLE_BRANCH)
+            echo "export RELEASE_VERSION=$release_version" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Jira - Create release version
+          command: |
+            python3 ~/sdk-deployment/scripts/v1.2/create_version.py\
+              --jira_auth_user $JIRA_AUTH_USER\
+              --jira_auth_api_token $JIRA_AUTH_API_TOKEN\
+              --project SDKRLSD\
+              --name ios_core@$RELEASE_VERSION\
+              --description 'Created by automation'
+      - run:
+          name: Jira - Create release ticket
+          command: |
+            release_ticket_key=$(python3 ~/sdk-deployment/scripts/v1.2/create_ticket.py\
+              --jira_auth_user $JIRA_AUTH_USER\
+              --jira_auth_api_token $JIRA_AUTH_API_TOKEN\
+              --project SDKRLSD\
+              --version ios_core@$RELEASE_VERSION\
+              --title "[Chat] iOS@$RELEASE_VERSION"\
+              --description 'Created by automation'\
+              --source_repo $CIRCLE_PROJECT_REPONAME\
+              --source_branch $CIRCLE_BRANCH\
+              --source_jira_project CORE\
+              --source_jira_version ios@$RELEASE_VERSION)
+            echo "export RELEASE_TICKET_KEY=$release_ticket_key" >> $BASH_ENV
+            source $BASH_ENV
+      - slack/notify:
+          channel: $SLACK_RELEASE_APPOVER_CHANNEL_ID # sdk-release-approver
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@chat-approver <https://sendbird.atlassian.net/browse/$RELEASE_TICKET_KEY|🔖 Chat iOS $RELEASE_VERSION release ticket> has been created!"
+                  }
+                }
+              ]
+            }
+            
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -50,3 +121,8 @@ workflows:
   built-and-test:
     jobs:
       - job-lint_and_test
+  create-release-ticket-workflow:
+    when: << pipeline.parameters.run_workflow_create_ticket >>
+    jobs:
+      - create-ticket:
+          context: sdk-release-bot

--- a/.github/workflows/release-ticket-creation.yml
+++ b/.github/workflows/release-ticket-creation.yml
@@ -1,0 +1,34 @@
+name: Release ticket creation on manual workflow trigger
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Release target branch name'
+        required: true
+
+jobs:
+  trigger-release-ticket-creation:
+    name: Trigger release ticket creation
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.inputs.branch_name, 'release/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Trigger CircleCI Job
+        run: |
+          API_RESULT=$(curl --request POST \
+            --url "https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline" \
+            --header "Circle-Token: ${{ secrets.CIRCLE_CI_API_TOKEN }}" \
+            --header "content-type: application/json" \
+            --data '{
+              "branch": "${{ github.event.inputs.branch_name }}",
+              "parameters": {
+                "run_workflow_create_ticket": true,
+              }
+            }')
+          echo "API_RESULT: ${API_RESULT}"
+          CIRCLE_CI_JOB_NUMBER=$(echo "${API_RESULT}" | jq -r '.number')
+          echo "::set-output name=DEPLOY_COMMENT_BODY::https://app.circleci.com/pipelines/github/${{ github.repository }}/$CIRCLE_CI_JOB_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CIRCLE_CI_API_TOKEN: ${{ secrets.CIRCLE_CI_API_TOKEN }}

--- a/.github/workflows/release-ticket-creation.yml
+++ b/.github/workflows/release-ticket-creation.yml
@@ -10,7 +10,7 @@ jobs:
   trigger-release-ticket-creation:
     name: Trigger release ticket creation
     runs-on: ubuntu-latest
-    # The branch name should starte with 'release/v'
+    # The branch name should starts with 'release/v'
     if: startsWith(github.event.inputs.branch_name, 'release/v')
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-ticket-creation.yml
+++ b/.github/workflows/release-ticket-creation.yml
@@ -10,7 +10,8 @@ jobs:
   trigger-release-ticket-creation:
     name: Trigger release ticket creation
     runs-on: ubuntu-latest
-    if: startsWith(github.event.inputs.branch_name, 'release/')
+    # The branch name should starte with 'release/v'
+    if: startsWith(github.event.inputs.branch_name, 'release/v')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description Of Changes
Addresses https://sendbird.atlassian.net/browse/CLNP-176 
This PR is a very beginning the project of automating our release process. Two small things are done in this PR, 

- [x] Added a new gh workflow file to receive a signal from outside of Github  e.g. Slack / GIthub CLI / Other 3party tools 
  👉🏻 This enables to create a release Jira ticket without navigating to Jira board or Github. 
(Got an idea from [a proposal](https://sendbird.atlassian.net/wiki/spaces/UIKitreact/pages/2101838231/Release+Automation#Concrete-Proposal-(June-23---2023)) from @sravan-s, see the Slack bot section)
Once this workflow file is merged into `main` branch, running this below command from a Slack channel will create a ticket.  Note that the command accepts only `branch_name` at the moment. 
```
/github workflow dispatch sendbird/sendbird-uikit-react --workflow release-ticket-reaction.yml -i branch_name=your-branch-name
```
The newly created ticket can be found in #sdk-release-approver channel in Slack. You can ask the approvers to check the ticket in the channel.
But yeah, the cmd is too long to remember. So I'm thinking of creating a short custom command in Slack for the sake of easy-use.

- [x] Modified the Circle CI config to take an advantage of existing Jira ticket creation pipeline 
 👉🏻 got the most of logic from the chat ios repo; https://github.com/sendbird/chat-ios/blob/develop/.github/workflows/pr-comment-bot.yml#L90