### PR TITLE
feat: Keep keyboard open after sending the message

### DIFF
--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -360,6 +360,8 @@ const MessageInput = React.forwardRef((props, ref) => {
       const params = { message: messageText, mentionTemplate };
       onSendMessage(params);
       resetInput(ref);
+      // important: keeps the keyboard open -> must add test on refactor
+      textField.focus();
       setIsInput(false);
       setHeight();
     }


### PR DESCRIPTION
This is default how it is in Mobile world
Also, its good practice to focus on Input on desktop

Fixes: https://sendbird.atlassian.net/browse/SBISSUE-12824