### PR TITLE
feat: make jira ticket creation workflow fail explicitly

### DIFF
--- a/.github/workflows/release-ticket-creation.yml
+++ b/.github/workflows/release-ticket-creation.yml
@@ -21,6 +21,26 @@ jobs:
             exit 1
           fi
 
+      - name: Check if branch exists
+        id: check_branch
+        run: |
+          set -x
+          set -o pipefail
+          branch_name="${{ github.event.inputs.branch_name }}"
+          git ls-remote --exit-code --heads origin "$branch_name" | grep -q "$branch_name"
+          if [[ ${PIPESTATUS[1]} -eq 0 ]]; then
+            echo "BRANCH_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "BRANCH_EXISTS=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create branch if it doesn't exist
+        if: steps.check_branch.outputs.branch_exists == 1
+        run: |
+          branch_name="${{ github.event.inputs.branch_name }}"
+          git checkout -b "$branch_name"
+          git push origin "$branch_name"
+
       - name: Trigger CircleCI Job
         run: |
           set -x

--- a/.github/workflows/release-ticket-creation.yml
+++ b/.github/workflows/release-ticket-creation.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Trigger CircleCI Job
         run: |
+          set -x
           API_RESULT=$(curl --request POST \
             --url "https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline" \
             --header "Circle-Token: ${{ secrets.CIRCLECI_API_TOKEN }}" \
@@ -35,4 +36,21 @@ jobs:
             }')
           echo "API_RESULT: ${API_RESULT}"
           CIRCLE_CI_JOB_NUMBER=$(echo "${API_RESULT}" | jq -r '.number')
-          echo "::set-output name=DEPLOY_COMMENT_BODY::https://app.circleci.com/pipelines/github/${{ github.repository }}/$CIRCLE_CI_JOB_NUMBER"
+
+          if [[ $? -eq 0 ]]; then
+            HTTP_STATUS=$(echo "${API_RESULT}" | jq -r '.status')
+
+            if [[ $HTTP_STATUS == "success" ]]; then
+              echo "CircleCI Job Triggered: $CIRCLE_CI_JOB_NUMBER"
+              echo "DEPLOY_COMMENT_BODY=https://app.circleci.com/pipelines/github/${{ github.repository }}/$CIRCLE_CI_JOB_NUMBER" >> $GITHUB_ENV
+              echo "JOB_STATUS=success" >> $GITHUB_OUTPUT
+            else
+              echo "CircleCI Job Trigger Failed"
+              echo "JOB_STATUS=failure" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          else
+            echo "API request failed"
+            echo "JOB_STATUS=failure" >> $GITHUB_OUTPUT
+            exit 1
+          fi


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-255

Currently, the release Jira ticket creation workflow gets passed even though there's an error with Circle API request. 
So made a change to get failed when it gets an error on this step. 
<img width="1197" alt="Screenshot 2023-06-30 at 2 54 08 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/10060731/6bd32d2e-7db6-49ec-adf7-5b7c674918d0">

With this change, the warning in the image should be gone too. Just followed a suggestion here https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
