### PR TITLE
[v3.6.2] (June 30 2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - v3
 
+## [v3.6.2] (June 30 2023)
+
+### Fix:
+* UIKit@3.6.0 build error on CRA (#668)
+  UIKit@3.6.0 wouldnt work by default on CRA
+  because of module resolution error on uikit-tools
+  This is fixed in uikit-tools, and released in 40.alpha
+  see: https://github.com/sendbird/sendbird-uikit-core-ts/pull/55
+
 ## [v3.6.1] (June 30 2023)
 
 ### Feat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [v3.6.2] (June 30 2023)
 
-### Fix:
+### Fixes:
 * UIKit@3.6.0 build error on CRA (#668)
   UIKit@3.6.0 wouldnt work by default on CRA
   because of module resolution error on uikit-tools
   This is fixed in uikit-tools, and released in 40.alpha
   see: https://github.com/sendbird/sendbird-uikit-core-ts/pull/55
+* Improve invitation modal submit btn disable condition
+  Modify the invitation modal disable condition to not include the
+  logged-in user for the user counting logic
 
 ## [v3.6.1] (June 30 2023)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
### Fix:
* UIKit@3.6.0 build error on CRA (#668)
  UIKit@3.6.0 wouldnt work by default on CRA
  because of module resolution error on uikit-tools
  This is fixed in uikit-tools, and released in 40.alpha
  see: https://github.com/sendbird/sendbird-uikit-core-ts/pull/55

Fixes: https://sendbird.atlassian.net/browse/SDKRLSD-892