### PR TITLE
hotfix: modify invitation modal submit btn disable cond

### DIFF
--- a/src/modules/CreateChannel/components/InviteUsers/__tests__/index.spec.tsx
+++ b/src/modules/CreateChannel/components/InviteUsers/__tests__/index.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom/matchers';
+import InviteUsers from '../index';
+
+jest.mock('../../../context/CreateChannelProvider', () => ({
+  useCreateChannelContext: jest.fn(() => ({
+    onBeforeCreateChannel: jest.fn(),
+    onCreateChannel: jest.fn(),
+    overrideInviteUser: jest.fn(),
+    createChannel: jest.fn().mockResolvedValue({}),
+    type: 'group',
+  })),
+}));
+
+// Mock createPortal function to render content directly without portal
+jest.mock('react-dom', () => ({
+  ...jest.requireActual('react-dom'),
+  createPortal: (node) => node,
+}));
+
+describe('InviteUsers', () => {
+  it('should enable the modal submit button when there is only the logged-in user is in the user list', () => {
+    const userListQuery = jest.fn(() => ({
+      hasNext: false,
+      next: jest.fn().mockResolvedValue([
+        { userId: 'user1' },
+      ]),
+    }));
+
+    render(<InviteUsers userListQuery={userListQuery} />);
+
+    const submitButton = screen.getByText('Create');
+    expect(submitButton).toBeEnabled();
+  });
+
+  // TODO: add this case too
+  // it('should disable the modal submit button when there are users on the list but none are checked', () => {
+  // })
+});

--- a/src/modules/CreateChannel/components/InviteUsers/index.tsx
+++ b/src/modules/CreateChannel/components/InviteUsers/index.tsx
@@ -92,8 +92,9 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
       submitText={submitText}
       type={ButtonTypes.PRIMARY}
       // Disable the create button if no users are selected,
-      // but if there's no users to display, then the create button should be enabled
-      disabled={users.length > 0 && Object.keys(selectedUsers).length === 0}
+      // but if there's only the logged-in user in the user list,
+      // then the create button should be enabled
+      disabled={users.length > 1 && Object.keys(selectedUsers).length === 0}
       onCancel={onCancel}
       onSubmit={() => {
         const selectedUserList = Object.keys(selectedUsers).length > 0


### PR DESCRIPTION
Following PR after #665 
Couldn't realized that `users` list include the logged-in user as well and shouldn't count the user in this condition.

Reported by https://sendbird.slack.com/archives/C04TSUD6KV1/p1688111690523829?thread_ts=1688003922.764459&cid=C04TSUD6KV1