### PR TITLE
fix: Move message list scroll when the last message is edited

### DIFF
--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -33,8 +33,7 @@ type MessageUIProps = {
   hasSeparator?: boolean;
   chainTop?: boolean;
   chainBottom?: boolean;
-  handleScroll?: () => void;
-  handleMessageListHeightChange?: () => void;
+  handleScroll?: (isAffectedOnlyGround?: boolean) => void;
   // for extending
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
@@ -49,7 +48,6 @@ const Message = ({
   chainTop,
   chainBottom,
   handleScroll,
-  handleMessageListHeightChange,
   renderCustomSeparator,
   renderEditInput,
   renderMessage,
@@ -136,6 +134,10 @@ const Message = ({
     }));
   }, [mentionedUserIds]);
 
+  useLayoutEffect(() => {
+    // Keep the scrollBottom value after fetching new message list
+    handleScroll?.();
+  }, []);
   /**
    * Move the messsage list scroll
    * when the message's height is changed by `showEdit` OR `message.reactions`
@@ -143,9 +145,9 @@ const Message = ({
   useDidMountEffect(() => {
     handleScroll?.();
   }, [showEdit, message?.reactions?.length]);
-  useLayoutEffect(() => {
-    handleMessageListHeightChange?.();
-  }, []);
+  useDidMountEffect(() => {
+    handleScroll?.(true);
+  }, [message?.updatedAt]);
 
   useLayoutEffect(() => {
     let animationTimeout = null;

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -33,7 +33,7 @@ type MessageUIProps = {
   hasSeparator?: boolean;
   chainTop?: boolean;
   chainBottom?: boolean;
-  handleScroll?: (isAffectedOnlyGround?: boolean) => void;
+  handleScroll?: (isBottomMessageAffected?: boolean) => void;
   // for extending
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -124,8 +124,7 @@ const MessageList: React.FC<MessageListProps> = ({
    *    when each message's height is changed by `reactions` OR `showEdit`
    * 2. Keep the scrollBottom value after fetching new message list
    */
-  const moveScroll = (_isBottomMessageAffected?: boolean): void => {
-    const isBottomMessageAffected = _isBottomMessageAffected ?? false;
+  const moveScroll = (isBottomMessageAffected = false): void => {
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -120,25 +120,18 @@ const MessageList: React.FC<MessageListProps> = ({
   };
 
   /**
-   * Move the messsage list scroll
-   * when each message's height is changed by `reactions` OR `showEdit`
+   * 1. Move the messsage list scroll
+   *    when each message's height is changed by `reactions` OR `showEdit`
+   * 2. Keep the scrollBottom value after fetching new message list
    */
-  const handleMessageHeightChange = () => {
+  const moveScroll = (_isAffectedOnlyGround?: boolean): void => {
+    const isAffectedOnlyGround = _isAffectedOnlyGround ?? false;
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
-      if (scrollBottom < bottom) {
+      if (scrollBottom < bottom
+        && (!isAffectedOnlyGround || scrollBottom < SCROLL_BUFFER)) {
         // Move the scroll as much as the height of the message has changed
-        current.scrollTop += bottom - scrollBottom;
-      }
-    }
-  };
-  // Keep the scrollBottom value after fetching new message list
-  const handleMessageListHeightChange = () => {
-    const current = scrollRef?.current;
-    if (current) {
-      const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
-      if (scrollBottom < bottom) {
         current.scrollTop += bottom - scrollBottom;
       }
     }
@@ -193,8 +186,7 @@ const MessageList: React.FC<MessageListProps> = ({
             return (
               <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
                 <Message
-                  handleScroll={handleMessageHeightChange}
-                  handleMessageListHeightChange={handleMessageListHeightChange}
+                  handleScroll={moveScroll}
                   renderMessage={renderMessage}
                   message={m}
                   hasSeparator={hasSeparator}

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -124,13 +124,13 @@ const MessageList: React.FC<MessageListProps> = ({
    *    when each message's height is changed by `reactions` OR `showEdit`
    * 2. Keep the scrollBottom value after fetching new message list
    */
-  const moveScroll = (_isAffectedOnlyGround?: boolean): void => {
-    const isAffectedOnlyGround = _isAffectedOnlyGround ?? false;
+  const moveScroll = (_isBottomMessageAffected?: boolean): void => {
+    const isBottomMessageAffected = _isBottomMessageAffected ?? false;
     const current = scrollRef?.current;
     if (current) {
       const bottom = current.scrollHeight - current.scrollTop - current.offsetHeight;
       if (scrollBottom < bottom
-        && (!isAffectedOnlyGround || scrollBottom < SCROLL_BUFFER)) {
+        && (!isBottomMessageAffected || scrollBottom < SCROLL_BUFFER)) {
         // Move the scroll as much as the height of the message has changed
         current.scrollTop += bottom - scrollBottom;
       }


### PR DESCRIPTION
* remove the duplicated functions: handleMessageHeightChange, and handleMessageListHeightChange
  AND combine them into one function: `moveScroll`

* add optional params to the `moveScroll`
  for moving the scroll only when the last message is reached to the bottom

* move scroll only when the last message's updatedAt is changed