### PR TITLE
fix: Verify the fetched message list size with MessageListParams

### DIFF
--- a/src/modules/Channel/context/dux/__tests__/reducers.spec.js
+++ b/src/modules/Channel/context/dux/__tests__/reducers.spec.js
@@ -80,6 +80,144 @@ describe('Messages-Reducers', () => {
     expect(nextState.latestMessageTimeStamp).not.toEqual(mockData.allMessages[mockData.allMessages.length - 1].createdAt);
   });
 
+  it('should get prev message list considering messageListParams FETCH_PREV_MESSAGES_SUCCESS', () => {
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: MESSAGE_LIST_SIZE,
+        nextResultSize: MESSAGE_LIST_SIZE,
+      }
+    }, {
+      type: actionTypes.FETCH_PREV_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+        // MESSAGE_LIST_SIZE + 1: because server gives the response including a current message
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(true);
+    expect(nextState.hasMoreNext).toEqual(true);
+  });
+
+  it('should verify there is no more messages FETCH_PREV_MESSAGES_SUCCESS', () => {
+    // request size > response size
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: 30,
+        nextResultSize: 30,
+      }
+    }, {
+      type: actionTypes.FETCH_PREV_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(false);
+    expect(nextState.hasMoreNext).toEqual(true);
+  });
+
+  it('should validate unexpected additional messages are fetched FETCH_PREV_MESSAGES_SUCCESS', () => {
+    // request size < response size
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: 10,
+        nextResultSize: 10,
+      }
+    }, {
+      type: actionTypes.FETCH_PREV_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(false);
+    expect(nextState.hasMoreNext).toEqual(true);
+  });
+
+  it('should get next message list considering messageListParams FETCH_NEXT_MESSAGES_SUCCESS', () => {
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: MESSAGE_LIST_SIZE,
+        nextResultSize: MESSAGE_LIST_SIZE,
+      }
+    }, {
+      type: actionTypes.FETCH_NEXT_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+        // MESSAGE_LIST_SIZE + 1: because server gives the response including a current message
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(true);
+    expect(nextState.hasMoreNext).toEqual(true);
+  });
+
+  it('should verify there is no more messages FETCH_NEXT_MESSAGES_SUCCESS', () => {
+    // request size > response size
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: 30,
+        nextResultSize: 30,
+      }
+    }, {
+      type: actionTypes.FETCH_NEXT_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(true);
+    expect(nextState.hasMoreNext).toEqual(false);
+  });
+
+  it('should validate unexpected additional messages are fetched FETCH_NEXT_MESSAGES_SUCCESS', () => {
+    // request size < response size
+    const MESSAGE_LIST_SIZE = 20;
+    const mockData = generateMockChannel();
+    const nextState = reducers({
+      ...mockData,
+      hasMorePrev: true,
+      hasMoreNext: true,
+      messageListParams: {
+        prevResultSize: 10,
+        nextResultSize: 10,
+      }
+    }, {
+      type: actionTypes.FETCH_NEXT_MESSAGES_SUCCESS,
+      payload: {
+        currentGroupChannel: mockData.currentGroupChannel,
+        messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
+      }
+    });
+    expect(nextState.hasMorePrev).toEqual(true);
+    expect(nextState.hasMoreNext).toEqual(false);
+  });
+
   it('should set pending message on SEND_MESSAGEGE_START', () => {
     const mockData = generateMockChannel();
     const nextState = reducers(mockData, {

--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -69,7 +69,7 @@ export default function reducer(state, action) {
       if (!(currentGroupChannel?.url === state.currentGroupChannel?.url)) {
         return state;
       }
-      const hasMorePrev = messages && messages.length === PREV_RESULT_SIZE + 1;
+      const hasMorePrev = messages && ((messages?.length ?? 0) === (state?.messageListParams?.prevResultSize ?? PREV_RESULT_SIZE) + 1);
       const oldestMessageTimeStamp = getOldestMessageTimeStamp(messages);
 
       // Remove duplicated messages
@@ -108,7 +108,7 @@ export default function reducer(state, action) {
       if (!(currentGroupChannel?.url === state.currentGroupChannel?.url)) {
         return state;
       }
-      const hasMoreNext = messages && messages.length === NEXT_RESULT_SIZE + 1;
+      const hasMoreNext = messages && ((messages?.length ?? 0) === (state?.messageListParams?.nextResultSize ?? NEXT_RESULT_SIZE) + 1);
       const latestMessageTimeStamp = getLatestMessageTimeStamp(messages);
 
       // sort ~

--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -69,7 +69,8 @@ export default function reducer(state, action) {
       if (!(currentGroupChannel?.url === state.currentGroupChannel?.url)) {
         return state;
       }
-      const hasMorePrev = messages && ((messages?.length ?? 0) === (state?.messageListParams?.prevResultSize ?? PREV_RESULT_SIZE) + 1);
+      const hasMorePrev = ((messages?.length ?? 0)
+        === (state?.messageListParams?.prevResultSize ?? PREV_RESULT_SIZE) + 1);
       const oldestMessageTimeStamp = getOldestMessageTimeStamp(messages);
 
       // Remove duplicated messages
@@ -108,7 +109,8 @@ export default function reducer(state, action) {
       if (!(currentGroupChannel?.url === state.currentGroupChannel?.url)) {
         return state;
       }
-      const hasMoreNext = messages && ((messages?.length ?? 0) === (state?.messageListParams?.nextResultSize ?? NEXT_RESULT_SIZE) + 1);
+      const hasMoreNext = ((messages?.length ?? 0)
+        === (state?.messageListParams?.nextResultSize ?? NEXT_RESULT_SIZE) + 1);
       const latestMessageTimeStamp = getLatestMessageTimeStamp(messages);
 
       // sort ~


### PR DESCRIPTION
fix: Verify the fetched message list size
  - if it's the same as the requested size of the MessageListParams

chore: Add test case for verifying fetched message list size

[CLNP-430](https://sendbird.atlassian.net/browse/CLNP-430)

[CLNP-430]: https://sendbird.atlassian.net/browse/CLNP-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ