### PR TITLE
fix: Fetch more messages even if result size is larger

### DIFF
--- a/src/modules/Channel/context/dux/__tests__/reducers.spec.js
+++ b/src/modules/Channel/context/dux/__tests__/reducers.spec.js
@@ -126,7 +126,7 @@ describe('Messages-Reducers', () => {
     expect(nextState.hasMoreNext).toEqual(true);
   });
 
-  it('should validate unexpected additional messages are fetched FETCH_PREV_MESSAGES_SUCCESS', () => {
+  it('should not set `hasMorePrev: false` when additional messages are fetched in FETCH_PREV_MESSAGES_SUCCESS', () => {
     // request size < response size
     const MESSAGE_LIST_SIZE = 20;
     const mockData = generateMockChannel();
@@ -145,7 +145,7 @@ describe('Messages-Reducers', () => {
         messages: new Array(MESSAGE_LIST_SIZE + 1).fill({}),
       }
     });
-    expect(nextState.hasMorePrev).toEqual(false);
+    expect(nextState.hasMorePrev).toEqual(true);
     expect(nextState.hasMoreNext).toEqual(true);
   });
 

--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -70,7 +70,7 @@ export default function reducer(state, action) {
         return state;
       }
       const hasMorePrev = ((messages?.length ?? 0)
-        === (state?.messageListParams?.prevResultSize ?? PREV_RESULT_SIZE) + 1);
+        >= (state?.messageListParams?.prevResultSize ?? PREV_RESULT_SIZE) + 1);
       const oldestMessageTimeStamp = getOldestMessageTimeStamp(messages);
 
       // Remove duplicated messages


### PR DESCRIPTION
In some customer's case, the server returns 32 messages even when we
asked for 31. Even though its an issue coming from server, we shouldnt set
`hasMorePrev` to false when result size is larger than query

Fixes: https://sendbird.atlassian.net/browse/SBISSUE-12994
Fixes: https://sendbird.atlassian.net/browse/CLNP-349
