### PR TITLE
feat: add `reconnectOnIdle` option to ChannelProvider

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -584,6 +584,7 @@ declare module "SendbirdUIKitGlobal" {
     onMessageAnimated?: () => void;
     onMessageHighlighted?: () => void;
     scrollBehavior?: 'smooth' | 'auto';
+    reconnectOnIdle?: boolean;
   };
 
   export interface ChannelUIProps {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -746,6 +746,7 @@ type ChannelContextProps = {
   disableUserProfile?: boolean;
   disableMarkAsRead?: boolean;
   scrollBehavior?: 'smooth' | 'auto';
+  reconnectOnIdle?: boolean;
 };
 
 interface ChannelUIProps {

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -96,6 +96,7 @@ export type ChannelContextProps = {
   onMessageAnimated?: () => void;
   onMessageHighlighted?: () => void;
   scrollBehavior?: 'smooth' | 'auto';
+  reconnectOnIdle?: boolean;
 };
 
 interface MessageStoreInterface {
@@ -188,6 +189,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     onMessageAnimated,
     onMessageHighlighted,
     scrollBehavior = 'auto',
+    reconnectOnIdle,
   } = props;
 
   const globalStore = useSendbirdStateContext();
@@ -368,7 +370,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   }, [channelUrl, sdkInit]);
 
   // handling connection breaks
-  useHandleReconnect({ isOnline, replyType, disableMarkAsRead }, {
+  useHandleReconnect({ isOnline, replyType, disableMarkAsRead, reconnectOnIdle }, {
     logger,
     sdk,
     scrollRef,

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -189,7 +189,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     onMessageAnimated,
     onMessageHighlighted,
     scrollBehavior = 'auto',
-    reconnectOnIdle,
+    reconnectOnIdle = true,
   } = props;
 
   const globalStore = useSendbirdStateContext();

--- a/src/modules/Channel/context/hooks/__test__/useHandleReconnect.spec.ts
+++ b/src/modules/Channel/context/hooks/__test__/useHandleReconnect.spec.ts
@@ -1,0 +1,35 @@
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { renderHook, act } from '@testing-library/react';
+import useReconnectOnIdle from '../useReconnectOnIdle';
+
+describe('useReconnectOnIdle', () => {
+  beforeAll(() => {
+    // Mock dispatchEvent for the document object
+    document.dispatchEvent = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update shouldReconnect on tab visibility change', () => {
+    const hook = renderHook(() => useReconnectOnIdle(true, { url: 'url' } as GroupChannel));
+    expect(hook.result.current.shouldReconnect).toBe(false);
+
+    act(() => {
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(hook.result.current.shouldReconnect).toBe(false);
+  });
+
+  it('should not update shouldReconnect on isOnline change', () => {
+    const { result, rerender } = renderHook(({ isOnline }) => useReconnectOnIdle(isOnline, null), {
+      initialProps: { isOnline: false },
+    });
+    expect(result.current.shouldReconnect).toBe(false);
+
+    rerender({ isOnline: true });
+    expect(result.current.shouldReconnect).toBe(false);
+  });
+});

--- a/src/modules/Channel/context/hooks/__test__/useHandleReconnect.spec.ts
+++ b/src/modules/Channel/context/hooks/__test__/useHandleReconnect.spec.ts
@@ -6,6 +6,8 @@ describe('useReconnectOnIdle', () => {
   beforeAll(() => {
     // Mock dispatchEvent for the document object
     document.dispatchEvent = jest.fn();
+    jest.spyOn(document, 'addEventListener');
+    jest.spyOn(document, 'removeEventListener');
   });
 
   afterEach(() => {
@@ -13,7 +15,7 @@ describe('useReconnectOnIdle', () => {
   });
 
   it('should update shouldReconnect on tab visibility change', () => {
-    const hook = renderHook(() => useReconnectOnIdle(true, { url: 'url' } as GroupChannel));
+    const hook = renderHook(() => useReconnectOnIdle(true, { url: 'url' } as GroupChannel, true));
     expect(hook.result.current.shouldReconnect).toBe(false);
 
     act(() => {
@@ -24,12 +26,26 @@ describe('useReconnectOnIdle', () => {
   });
 
   it('should not update shouldReconnect on isOnline change', () => {
-    const { result, rerender } = renderHook(({ isOnline }) => useReconnectOnIdle(isOnline, null), {
+    const { result, rerender } = renderHook(({ isOnline }) => useReconnectOnIdle(isOnline, { url: 'url' } as GroupChannel, true), {
       initialProps: { isOnline: false },
     });
-    expect(result.current.shouldReconnect).toBe(false);
+    expect(result.current.shouldReconnect).toBe(true);
 
     rerender({ isOnline: true });
     expect(result.current.shouldReconnect).toBe(false);
+  });
+
+  it('should not update shouldReconnect if reconnectOnIdle is false', async () => {
+    const reconnectOnIdle = false;
+    renderHook(({ isOnline }) => useReconnectOnIdle(isOnline, { url: 'url' } as GroupChannel, reconnectOnIdle), {
+      initialProps: { isOnline: false },
+    });
+
+    const spy = jest.spyOn(document, 'addEventListener');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall).toEqual(['visibilitychange', expect.any(Function)]);
+    spy.mockRestore();
   });
 });

--- a/src/modules/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/modules/Channel/context/hooks/useHandleReconnect.ts
@@ -13,7 +13,7 @@ interface DynamicParams {
   isOnline: boolean;
   replyType?: string;
   disableMarkAsRead: boolean;
-  reconnectOnIdle?: boolean;
+  reconnectOnIdle: boolean;
 }
 
 interface StaticParams {
@@ -27,7 +27,7 @@ interface StaticParams {
 }
 
 function useHandleReconnect(
-  { isOnline, replyType, disableMarkAsRead, reconnectOnIdle = true }: DynamicParams,
+  { isOnline, replyType, disableMarkAsRead, reconnectOnIdle }: DynamicParams,
   {
     logger,
     sdk,

--- a/src/modules/Channel/context/hooks/useReconnectOnIdle.ts
+++ b/src/modules/Channel/context/hooks/useReconnectOnIdle.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+
+function useReconnectOnIdle(isOnline: boolean, currentGroupChannel: GroupChannel, reconnectOnIdle = true)
+  :{ shouldReconnect: boolean }
+{
+  const [isTabHidden, setIsTabHidden] = useState<boolean>(false);
+  const wasOffline = !isOnline;
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (reconnectOnIdle) {
+        setIsTabHidden(document.hidden);
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [reconnectOnIdle, document.hidden]);
+
+  const shouldReconnect = wasOffline && currentGroupChannel?.url != null && !isTabHidden;
+  return { shouldReconnect };
+}
+
+export default useReconnectOnIdle;

--- a/src/modules/Channel/index.tsx
+++ b/src/modules/Channel/index.tsx
@@ -37,6 +37,7 @@ const Channel: React.FC<ChannelProps> = (props: ChannelProps) => {
       onMessageAnimated={props?.onMessageAnimated}
       onMessageHighlighted={props?.onMessageHighlighted}
       scrollBehavior={props.scrollBehavior}
+      reconnectOnIdle={props.reconnectOnIdle}
     >
       <ChannelUI
         isLoading={props?.isLoading}


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-200 

Some users might not want to refetch the message list when the active browser tab is in the background and then comes back to the foreground. 
So, I added an option to the ChannelProvider: `reconnectOnIdle` (default: true), which prevents data refresh in the background.
