### PR TITLE
feat: omit 'appId' from SendbirdChatInitParams

### DIFF
--- a/src/lib/hooks/useConnect/setupConnection.ts
+++ b/src/lib/hooks/useConnect/setupConnection.ts
@@ -34,13 +34,14 @@ export function setUpParams({
   sdkInitParams?: SendbirdChatInitParams;
 }): SendbirdChat {
   const params = {
-    appId,
     modules: [
       new GroupChannelModule(),
       new OpenChannelModule(),
     ],
     newInstance: true,
-    ...sdkInitParams,
+    ...(sdkInitParams ?? {}),
+    // appId shouldn't be overrided
+    appId,
   };
   if (customApiHost) {
     params['customApiHost'] = customApiHost;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -247,4 +247,4 @@ export type UIKitOptions = PartialDeep<{
   openChannel: SBUConfig['openChannel']['channel'];
 }>;
 
-export type SendbirdChatInitParams = SendbirdChatParams<Module[]>;
+export type SendbirdChatInitParams = Omit<SendbirdChatParams<Module[]>, 'appId'>;

--- a/src/modules/App/types.ts
+++ b/src/modules/App/types.ts
@@ -9,8 +9,9 @@ import {
   UserListQuery,
   RenderUserProfileProps,
   SendBirdProviderConfig,
-  SendbirdChatInitParams,
 } from '../../types';
+
+import { SendbirdChatInitParams } from '../../lib/types';
 
 export interface AppLayoutProps {
   isReactionEnabled?: boolean;


### PR DESCRIPTION
Addressing a feedback from @sravan-s after #692 merged. `appId` is better not to override just to be safe. 