### PR TITLE
fix: Pending message doesnt have isUserMessage method

### DIFF
--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -146,7 +146,9 @@ export default function reducer(state, action) {
         ...state,
         allMessages: [
           ...state.allMessages,
-          { ...action.payload },
+          // Message should not be spread here
+          // it will loose some methods like `isUserMessage`
+          action.payload,
         ],
       };
     case actionTypes.SEND_MESSAGEGE_SUCESS: {


### PR DESCRIPTION
If you spread message object in reducer, it will loose
some methods such as `isUserMessage`

Fixes: https://sendbird.atlassian.net/browse/CLNP-523