### PR TITLE
chore: Change Trunk-Based Development to Scaled

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## For Internal Contributors
 
-* Follow the trunk workflow(https://trunkbaseddevelopment.com/)
+* Follow the Scaled Trunk-Based Development workflow(https://trunkbaseddevelopment.com/)
 * Branch naming format -> `{type}/TICKET_ID/description`
   * Where type = `feat` / `feature` / `fix` / `chore` / `doc` / `release`
 * Always receive PR review approvals


### PR DESCRIPTION
I wrote Trunk-Based Development before, but in strict sense,
everyone commit directly to trunk in this method.

Scaled Trunk-Based Development is more apt to describe our flow. 

Scaled Trunk-Based Development is best done with short-lived
feature branches: one person over a couple of days (max) and flowing
through Pull-Request style code-review & build automation before
"integrating" (merging) into main
