### PR TITLE
fix: MessageInout cursor - use not-allowed instead of disabled

### DIFF
--- a/src/ui/MessageInput/index.scss
+++ b/src/ui/MessageInput/index.scss
@@ -119,7 +119,7 @@
 
 .sendbird-message-input__disabled {
   pointer-events: none;
-  cursor: disabled;
+  cursor: not-allowed;
   .sendbird-message-input--textarea {
     @include themed() {
       color: t(on-bg-4);


### PR DESCRIPTION
Fixes: https://github.com/sendbird/sendbird-uikit-react/pull/691
Thanks @roderickhsiao