### PR TITLE
fix: util functions logic of verifying message type

### DIFF
--- a/src/utils/__tests__/utils.spec.js
+++ b/src/utils/__tests__/utils.spec.js
@@ -1,4 +1,4 @@
-import { binarySearch, isUrl } from '../index';
+import { UIKitMessageTypes, binarySearch, getUIKitMessageType, isAdminMessage, isFileMessage, isUrl, isUserMessage } from '../index';
 
 describe('Global-utils', () => {
   it('should find right index with binarySearch', () => {
@@ -16,6 +16,95 @@ describe('Global-utils', () => {
       expect(targetIndexPlusOne).toEqual(index);
     });
   });
+});
+
+describe('Global-utils: verify message type util functions', () => {
+  it('should return true for each message', () => {
+    const mockUserMessage = {
+      messageId: 0,
+      isUserMessage: () => true,
+      isFileMessage: () => false,
+      isAdminMessage: () => false,
+      messageType: 'user',
+    };
+    expect(isUserMessage(mockUserMessage)).toBe(true);
+    expect(isFileMessage(mockUserMessage)).toBe(false);
+    expect(isAdminMessage(mockUserMessage)).toBe(false);
+    const mockFileMessage = {
+      messageId: 1,
+      isUserMessage: () => false,
+      isFileMessage: () => true,
+      isAdminMessage: () => false,
+      messageType: 'file',
+    };
+    expect(isUserMessage(mockFileMessage)).toBe(false);
+    expect(isFileMessage(mockFileMessage)).toBe(true);
+    expect(isAdminMessage(mockFileMessage)).toBe(false);
+    const mockAdminMessage = {
+      messageId: 2,
+      isUserMessage: () => false,
+      isFileMessage: () => false,
+      isAdminMessage: () => true,
+      messageType: 'admin',
+    };
+    expect(isUserMessage(mockAdminMessage)).toBe(false);
+    expect(isFileMessage(mockAdminMessage)).toBe(false);
+    expect(isAdminMessage(mockAdminMessage)).toBe(true);
+  });
+
+  it('should return true with incomplete properties', () => {
+    expect(isUserMessage({ isUserMessage: () => true })).toBe(true);
+    expect(isUserMessage({ messageType: 'user' })).toBe(true);
+    expect(isFileMessage({ isFileMessage: () => true })).toBe(true);
+    expect(isFileMessage({ messageType: 'file' })).toBe(true);
+    expect(isAdminMessage({ isAdminMessage: () => true })).toBe(true);
+    expect(isAdminMessage({ messageType: 'admin' })).toBe(true);
+  });
+
+  it('should refer to the method first rather than messageType', () => {
+    const mockUserMessage = {
+      messageId: 0,
+      isUserMessage: () => true,
+      isFileMessage: () => false,
+      isAdminMessage: () => false,
+      messageType: 'file',
+    };
+    expect(isUserMessage(mockUserMessage)).toBe(true);
+    expect(isFileMessage(mockUserMessage)).toBe(false);
+    expect(isAdminMessage(mockUserMessage)).toBe(false);
+    expect(isUserMessage({ isUserMessage: () => false, messageType: 'user' })).toBe(false);
+    const mockFileMessage = {
+      messageId: 1,
+      isUserMessage: () => false,
+      isFileMessage: () => true,
+      isAdminMessage: () => false,
+      messageType: 'admin',
+    };
+    expect(isUserMessage(mockFileMessage)).toBe(false);
+    expect(isFileMessage(mockFileMessage)).toBe(true);
+    expect(isAdminMessage(mockFileMessage)).toBe(false);
+    expect(isFileMessage({ isFileMessage: () => false, messsageType: 'file' })).toBe(false);
+    const mockAdminMessage = {
+      messageId: 2,
+      isUserMessage: () => false,
+      isFileMessage: () => false,
+      isAdminMessage: () => true,
+      messageType: 'user',
+    };
+    expect(isUserMessage(mockAdminMessage)).toBe(false);
+    expect(isFileMessage(mockAdminMessage)).toBe(false);
+    expect(isAdminMessage(mockAdminMessage)).toBe(true);
+    expect(isAdminMessage({ isAdminMessage: () => false, messageType: 'admin' })).toBe(false);
+  });
+
+  it('should verify edge case of MultipleFilesMessage', () => {
+    expect(
+      getUIKitMessageType({
+        isFileMessage: () => false,
+        messageType: 'file',
+      })
+    ).toBe(UIKitMessageTypes.UNKNOWN);
+  })
 });
 
 describe('isURL', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -128,13 +128,25 @@ export const isSentStatus = (state: string): boolean => (
 );
 
 export const isAdminMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
-  message && (message?.isAdminMessage?.() || (message?.messageType === 'admin'))
+  message && (
+    message['isAdminMessage'] && typeof message.isAdminMessage === 'function'
+      ? message.isAdminMessage()
+      : message?.messageType === 'admin'
+  )
 );
 export const isUserMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
-  message && (message?.isUserMessage?.() || (message?.messageType === 'user'))
+  message && (
+    message['isUserMessage'] && typeof message.isUserMessage === 'function'
+      ? message.isUserMessage()
+      : message?.messageType === 'user'
+  )
 );
 export const isFileMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
-  message && (message?.isFileMessage?.() || (message?.messageType === 'file'))
+  message && (
+    message['isFileMessage'] && typeof message.isFileMessage === 'function'
+      ? message.isFileMessage()
+      : message?.messageType === 'file'
+  )
 );
 export const isParentMessage = (message: AdminMessage | UserMessage | FileMessage): boolean => (
   !message.parentMessageId && !message.parentMessage && (message.threadInfo?.replyCount ?? 0) > 0


### PR DESCRIPTION
fix: util functions logic of verifying message type

refer to the `is~~~` method first rather than the messageType to verify each message type
* isAdminMessage, isUserMessage, isFileMessage
refer to the messageType only when those methods don't exist

[UIKIT-4301](https://sendbird.atlassian.net/browse/UIKIT-4301)

[UIKIT-4301]: https://sendbird.atlassian.net/browse/UIKIT-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ