### PR TITLE
fix: Remove setMarkAsDelivered from the useFetchChannelList

### DIFF
--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -24,6 +24,7 @@ import setupChannelList, {
 } from '../utils';
 import { uuidv4 } from '../../../utils/uuid';
 import { noop } from '../../../utils/utils';
+import { DELIVERY_RECEIPT } from '../../../utils/consts';
 
 import * as channelListActions from '../dux/actionTypes';
 
@@ -350,8 +351,7 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
 
   const fetchChannelList = useFetchChannelList({
     channelSource,
-    premiumFeatureList,
-    disableMarkAsDelivered,
+    disableMarkAsDelivered: disableMarkAsDelivered || !premiumFeatureList.some((feature) => feature === DELIVERY_RECEIPT),
   }, {
     channelListDispatcher,
     logger,

--- a/src/modules/ChannelList/context/hooks/__tests__/useFetchChannelList.spec.ts
+++ b/src/modules/ChannelList/context/hooks/__tests__/useFetchChannelList.spec.ts
@@ -4,7 +4,6 @@ import { GroupChannelListQuery } from '@sendbird/chat/groupChannel';
 
 import { useFetchChannelList } from '../useFetchChannelList';
 import { mockChannelList } from '../channelList.mock';
-import { DELIVERY_RECEIPT } from '../../../../../utils/consts';
 import { CustomUseReducerDispatcher, Logger } from '../../../../../lib/SendbirdState';
 import { Nullable } from '../../../../../types';
 import { MarkAsDeliveredSchedulerType } from '../../../../../lib/hooks/useMarkAsDeliveredScheduler';
@@ -16,7 +15,6 @@ interface GlobalContextType {
   markAsDeliveredScheduler: Nullable<MarkAsDeliveredSchedulerType>,
   logger: Nullable<Logger>,
 }
-const mockPremiumFeatureList = [DELIVERY_RECEIPT];
 const globalContext = {} as GlobalContextType;
 
 describe('useFetchChannelList', () => {
@@ -54,7 +52,6 @@ describe('useFetchChannelList', () => {
     const hook = renderHook(
       () => useFetchChannelList({
         channelSource: mockChannelSource,
-        premiumFeatureList: mockPremiumFeatureList,
         disableMarkAsDelivered: false,
       }, {
         channelListDispatcher: channelListDispatcher as CustomUseReducerDispatcher,
@@ -93,7 +90,6 @@ describe('useFetchChannelList', () => {
           ...mockChannelSource,
           next: jest.fn(() => Promise.reject(mockError)),
         } as unknown as GroupChannelListQuery,
-        premiumFeatureList: mockPremiumFeatureList,
         disableMarkAsDelivered: false,
       }, {
         channelListDispatcher: channelListDispatcher as CustomUseReducerDispatcher,
@@ -131,7 +127,6 @@ describe('useFetchChannelList', () => {
           ...mockChannelSource,
           hasNext: false,
         } as unknown as GroupChannelListQuery,
-        premiumFeatureList: mockPremiumFeatureList,
         disableMarkAsDelivered: false,
       }, {
         channelListDispatcher: channelListDispatcher as CustomUseReducerDispatcher,

--- a/src/modules/ChannelList/context/hooks/useFetchChannelList.ts
+++ b/src/modules/ChannelList/context/hooks/useFetchChannelList.ts
@@ -5,11 +5,9 @@ import { Nullable } from '../../../../types';
 import { CustomUseReducerDispatcher, Logger } from '../../../../lib/SendbirdState';
 import { MarkAsDeliveredSchedulerType } from '../../../../lib/hooks/useMarkAsDeliveredScheduler';
 import * as channelListActions from '../../dux/actionTypes';
-import { DELIVERY_RECEIPT } from '../../../../utils/consts';
 
 interface DynamicProps {
   channelSource: Nullable<GroupChannelListQuery>;
-  premiumFeatureList: string[];
   disableMarkAsDelivered: boolean;
 }
 interface StaticProps {
@@ -20,7 +18,6 @@ interface StaticProps {
 
 export const useFetchChannelList = ({
   channelSource,
-  premiumFeatureList,
   disableMarkAsDelivered,
 }: DynamicProps, {
   channelListDispatcher,
@@ -28,7 +25,6 @@ export const useFetchChannelList = ({
   markAsDeliveredScheduler,
 }: StaticProps) => {
   return useCallback(async () => {
-    const setMarkAsDelivered = premiumFeatureList.find((feature) => feature === DELIVERY_RECEIPT);
     if (!channelSource?.hasNext) {
       logger.info('ChannelList: not able to fetch');
       return;
@@ -45,7 +41,7 @@ export const useFetchChannelList = ({
         type: channelListActions.FETCH_CHANNELS_SUCCESS,
         payload: channelList,
       });
-      if (setMarkAsDelivered && !disableMarkAsDelivered) {
+      if (!disableMarkAsDelivered) {
         logger.info('ChannelList: mark as delivered to fetched channels');
         // eslint-disable-next-line no-unused-expressions
         channelList?.forEach((channel) => {
@@ -63,7 +59,6 @@ export const useFetchChannelList = ({
     }
   }, [
     channelSource,
-    premiumFeatureList,
     disableMarkAsDelivered,
   ]);
 };


### PR DESCRIPTION
### To apply this review
https://github.com/sendbird/sendbird-uikit-react/pull/708#discussion_r1290975624

### Fix
* remove setMarkAsDelivered from the useFetchChannelList
* calculate from outside whether to ignore the delivery receipt