### PR TITLE
Combine single and multi file viewer

### DIFF
--- a/src/ui/FileViewer/hooks/mapProps.ts
+++ b/src/ui/FileViewer/hooks/mapProps.ts
@@ -1,0 +1,30 @@
+import { FileInfo, FileViewerComponentProps, SingleFileViewer, ViewerType, ViewerTypes } from "../types";
+
+/**
+ * Converts file/fileinfo[] into nice props for FileViewer
+ * // shouldnt even need to be a hook. maybe simplify this to a function
+ */
+export function mapProps({ props, idx }: {
+  props: FileViewerComponentProps;
+  idx: number;
+}): FileInfo {
+  if (props.viewerType !== ViewerTypes.SINGLE && props.viewerType !== ViewerTypes.MULTI) {
+    throw new Error('FileViewer: props is required');
+  }
+  if (props.viewerType === ViewerTypes.MULTI) {
+    const file = props.fileInfoList[idx];
+    return {
+      // do default props
+      name: file.fileName || '',
+      type: file.mimeType || '',
+      url: file.url,
+    };
+  }
+  // single
+  const file = props as SingleFileViewer;
+  return {
+    name: file.name,
+    type: file.type,
+    url: file.url,
+  };
+}

--- a/src/ui/FileViewer/hooks/useKeyPress.ts
+++ b/src/ui/FileViewer/hooks/useKeyPress.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from "react";
+
+export function useKeyPress({
+  onClose,
+  incrementIdx,
+  decrementIdx,
+  ref,
+}: {
+  onClose: (e: globalThis.MouseEvent) => void;
+  incrementIdx: () => void;
+  decrementIdx: () => void;
+  ref: React.RefObject<HTMLDivElement>;
+}) {
+  const target = ref.current;
+  // if this doesnt work, try return onKeyDown and spread it on the div
+  const onKeyDown = useCallback((event) => {
+    // maybe use a ts-matching library
+    switch (event.key) {
+      case 'Escape':
+        onClose(event);
+        break;
+      case 'ArrowLeft':
+        decrementIdx();
+        break;
+      case 'ArrowRight':
+        incrementIdx();
+        break;
+      // also -> close on esc click
+      default:
+        break;
+    }
+    event.preventDefault();
+  }, [onClose, incrementIdx, decrementIdx]);
+  useEffect(() => {
+    target?.addEventListener('keydown', onKeyDown);
+    return () => {
+      target?.removeEventListener('keydown', onKeyDown);
+    };
+  }, [target]);
+
+}

--- a/src/ui/FileViewer/hooks/useViewerState.ts
+++ b/src/ui/FileViewer/hooks/useViewerState.ts
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { FileViewerComponentProps, ViewerTypes } from "../types";
+import { noop } from "../../../utils/utils";
+import { mapProps } from "./mapProps";
+
+export function useViewerState({ props }: { props: FileViewerComponentProps }): {
+  idx: number,
+  incrementIdx: () => void,
+  decrementIdx: () => void,
+  hasNext: boolean,
+  hasPrev: boolean,
+  name: string,
+  // maybe rename to mimeType
+  type: string,
+  url: string,
+} {
+  // you can keep the file info list in state
+  // todo - reset message idx on close
+  const [idx, setIdx] = useState(0);
+  const { name, type, url } = mapProps({ props, idx });
+  if (props.viewerType === ViewerTypes.MULTI) {
+    return {
+      idx,
+      incrementIdx: () => {
+        if (idx === props.fileInfoList.length - 1) {
+          return;
+        }
+        setIdx((prev) => prev + 1);
+      },
+      decrementIdx: () => {
+        if (idx === 0) {
+          return;
+        }
+        setIdx((prev) => prev - 1);
+      },
+      // todo - add more state
+      hasNext: false, // boolean -> implement
+      hasPrev: false, // boolean -> implements
+      name, // string
+      type, // string
+      url, // string
+    };
+  }
+  return {
+    idx,
+    incrementIdx: noop,
+    decrementIdx: noop,
+    hasNext: false,
+    hasPrev: false,
+    name, // string
+    type, // string
+    url, // string
+  };
+}

--- a/src/ui/FileViewer/types.ts
+++ b/src/ui/FileViewer/types.ts
@@ -1,5 +1,8 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
 
+import { UploadedFileInfo } from "@sendbird/chat/message";
+
+// to do reafctor this to -> as const pattern
 export type SupportedImageMimesType = 'image/jpeg' | 'image/jpg' | 'image/png' | 'image/gif' | 'image/svg+xml' | 'image/webp';
 export type SupportedVideoMimesType = 'video/mpeg' | 'video/ogg' | 'video/webm' | 'video/mp4';
 export type SupportedMimesType = SupportedImageMimesType | SupportedVideoMimesType;
@@ -32,3 +35,41 @@ export const unSupported = (type: SupportedMimesType): boolean => (
 );
 
 export default { ...SUPPORTED_MIMES };
+
+export const ViewerTypes = {
+  SINGLE: 'SINGLE',
+  MULTI: 'MULTI',
+} as const;
+export type ViewerType = keyof typeof ViewerTypes;
+
+export interface SenderInfo {
+  profileUrl: string;
+  nickname: string;
+}
+export interface FileInfo {
+  name: string;
+  type: string;
+  url: string;
+}
+export interface SingleFileViewer extends SenderInfo, FileInfo {
+  // this is a type guard
+  viewerType?: typeof ViewerTypes.SINGLE,
+  isByMe?: boolean;
+  disableDelete?: boolean;
+  onClose: (e: MouseEvent) => void;
+  onDelete: (e: MouseEvent) => void;
+}
+
+export interface MultiFileViewer extends SenderInfo {
+  viewerType: typeof ViewerTypes.MULTI;
+  onClose: (e: MouseEvent) => void;
+  fileInfoList: UploadedFileInfo[];
+  currentIndex: number;
+  onClickLeft: () => void;
+  onClickRight: () => void;
+  // I added this
+  isByMe?: boolean;
+  // disableDelete?: boolean;
+}
+
+export type FileViewerComponentProps = SingleFileViewer | MultiFileViewer;


### PR DESCRIPTION
This is a n example to merge single/multi file viewer ~
There are two ways to do this, and this is one ->
Option 1. As in this PR, I made a `ViewerTypes` flag to deterministically detect the kind of props to recive(If single/undefined -> we assume single file, for backward compactability. Multi has to be explicitly flagged)
Option 2. We deduce ViewerTypes from list of files in the Message -> if there is only one, assume it is single, otherwise multi

Anyways, generic idea is -> calculate the current picture inside ``useViewerState``
Keep click handlers in separate hook..