### PR TITLE
feat: create a custom hook useSendMultipleFilesMessage

### DIFF
--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -156,6 +156,8 @@ export default function reducer(state, action) {
       const filteredMessages = state.allMessages.filter((m) => (
         m?.reqId !== message?.reqId
       ));
+      // [Policy] Pending messages and failed messages
+      // must always be at the end of the message list
       const pendingIndex = filteredMessages.findIndex((msg) => (
         msg?.sendingStatus === 'pending' || msg?.sendingStatus === 'failed'
       ));

--- a/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
+++ b/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
@@ -54,7 +54,22 @@ describe('useSendMultipleFilesMessage', () => {
     sendMultipleFilesMessage(mockFileList);
 
     expect(globalContext.currentChannel?.sendMultipleFilesMessage)
-      .toHaveBeenCalledWith({ fileInfoList: [{ file: mockFileList[0] }, { file: mockFileList[1] }] });
+      .toHaveBeenCalledWith({
+        fileInfoList: [
+          {
+            file: mockFileList[0],
+            fileName: mockFileList[0].name,
+            fileSize: mockFileList[0].size,
+            mimeType: mockFileList[0].type,
+          },
+          {
+            file: mockFileList[1],
+            fileName: mockFileList[1].name,
+            fileSize: mockFileList[1].size,
+            mimeType: mockFileList[1].type,
+          },
+        ],
+      });
     expect(globalContext.pubSub?.publish)
       .toHaveBeenCalledWith(
         PUBSUB_TOPICS.SEND_MESSAGE_START,
@@ -205,7 +220,20 @@ describe('useSendMultipleFilesMessage', () => {
 
     expect(globalContext.currentChannel?.sendMultipleFilesMessage)
       .toHaveBeenCalledWith({
-        fileInfoList: [{ file: mockFileList[0] }, { file: mockFileList[1] }],
+        fileInfoList: [
+          {
+            file: mockFileList[0],
+            fileName: mockFileList[0].name,
+            fileSize: mockFileList[0].size,
+            mimeType: mockFileList[0].type,
+          },
+          {
+            file: mockFileList[1],
+            fileName: mockFileList[1].name,
+            fileSize: mockFileList[1].size,
+            mimeType: mockFileList[1].type,
+          },
+        ],
         isReplyToChannel: true,
         parentMessageId: mockSentMessage.messageId,
       });

--- a/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
+++ b/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
@@ -1,0 +1,307 @@
+import { RefObject, createRef } from 'react';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { renderHook } from '@testing-library/react';
+
+import {
+  UseSendMFMDynamicParams,
+  UseSendMFMStaticParams,
+  useSendMultipleFilesMessage,
+} from '../useSendMultipleFilesMessage';
+import { CustomUseReducerDispatcher, Logger } from '../../../../../lib/SendbirdState';
+import {
+  MockMessageRequestHandlerType,
+  getMockMessageRequestHandler,
+} from '../../../../../utils/testMocks/messageRequestHandler';
+import PUBSUB_TOPICS from '../../../../../lib/pubSub/topics';
+import { SEND_MESSAGEGE_SUCESS, SEND_MESSAGE_FAILURE } from '../../dux/actionTypes';
+import { MockMessageStateType, mockSentMessage } from '../../../../../utils/testMocks/message';
+import { UserMessage } from '@sendbird/chat/message';
+
+interface UseSendMFMParams extends UseSendMFMDynamicParams, UseSendMFMStaticParams {
+  messageRequestHandler: MockMessageRequestHandlerType;
+}
+type GlobalContextType = {
+  [K in keyof UseSendMFMParams]?: UseSendMFMParams[K];
+};
+const globalContext: GlobalContextType = {};
+const mockFileList = [new File([], 'fileOne'), new File([], 'fileTwo')];
+
+describe('useSendMultipleFilesMessage', () => {
+  beforeEach(() => {
+    globalContext.currentChannel = { sendMultipleFilesMessage: jest.fn(() => getMockMessageRequestHandler()) } as unknown as GroupChannel;
+    globalContext.onBeforeSendMultipleFilesMessage = (params) => params;
+    globalContext.logger = { info: jest.fn(), warning: jest.fn(), error: jest.fn() };
+    globalContext.pubSub = { publish: jest.fn() };
+    globalContext.scrollRef = createRef<HTMLDivElement>();
+    globalContext.messagesDispatcher = jest.fn();
+  });
+
+  it('should check sending MFM', () => {
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: globalContext.currentChannel as GroupChannel,
+        onBeforeSendMultipleFilesMessage: globalContext.onBeforeSendMultipleFilesMessage,
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    sendMultipleFilesMessage(mockFileList);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .toHaveBeenCalledWith({ fileInfoList: [{ file: mockFileList[0] }, { file: mockFileList[1] }] });
+    expect(globalContext.pubSub?.publish)
+      .toHaveBeenCalledWith(
+        PUBSUB_TOPICS.SEND_MESSAGE_START,
+        {
+          message: { mockMessageType: MockMessageStateType.PENDING },
+          channel: globalContext.currentChannel,
+        },
+      );
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalledWith({
+        type: SEND_MESSAGE_FAILURE,
+        payload: { mockMessageType: MockMessageStateType.FAILED },
+      });
+    expect(globalContext.messagesDispatcher)
+      .toHaveBeenCalledWith({
+        type: SEND_MESSAGEGE_SUCESS,
+        payload: { mockMessageType: MockMessageStateType.SUCCEEDED },
+      });
+  });
+
+  it('should check sending MFM failed', () => {
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        // this mock channel will fail sending MFM -> getMockMessageRequestHandler(false)
+        currentChannel: { sendMultipleFilesMessage: jest.fn(() => getMockMessageRequestHandler(false)) } as unknown as GroupChannel,
+        onBeforeSendMultipleFilesMessage: globalContext.onBeforeSendMultipleFilesMessage,
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    sendMultipleFilesMessage(mockFileList);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .not.toHaveBeenCalled();
+    expect(globalContext.pubSub?.publish)
+      .not.toHaveBeenCalled();
+    expect(globalContext.messagesDispatcher)
+      .toHaveBeenCalledWith({
+        type: SEND_MESSAGE_FAILURE,
+        payload: { mockMessageType: MockMessageStateType.FAILED },
+      });
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalledWith({
+        type: SEND_MESSAGEGE_SUCESS,
+        payload: { mockMessageType: MockMessageStateType.SUCCEEDED },
+      });
+  });
+
+  it('should not send message when receiving empty files', () => {
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: { sendMultipleFilesMessage: jest.fn(() => getMockMessageRequestHandler()) } as unknown as GroupChannel,
+        onBeforeSendMultipleFilesMessage: globalContext.onBeforeSendMultipleFilesMessage,
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    // receiving an empty array
+    sendMultipleFilesMessage([]);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .not.toHaveBeenCalled();
+    expect(globalContext.pubSub?.publish)
+      .not.toHaveBeenCalled();
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalled();
+  });
+
+  it('should not send message when receiving an array of one file', () => {
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: { sendMultipleFilesMessage: jest.fn(() => getMockMessageRequestHandler()) } as unknown as GroupChannel,
+        onBeforeSendMultipleFilesMessage: globalContext.onBeforeSendMultipleFilesMessage,
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    // receiving only one file
+    sendMultipleFilesMessage([mockFileList[0]]);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .not.toHaveBeenCalled();
+    expect(globalContext.pubSub?.publish)
+      .not.toHaveBeenCalled();
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalled();
+  });
+
+  it('should apply the quoteMessage', () => {
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: globalContext.currentChannel as GroupChannel,
+        onBeforeSendMultipleFilesMessage: globalContext.onBeforeSendMultipleFilesMessage,
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    // send multiple files message with a quote message
+    sendMultipleFilesMessage(mockFileList, mockSentMessage as unknown as UserMessage);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .toHaveBeenCalledWith({
+        fileInfoList: [{ file: mockFileList[0] }, { file: mockFileList[1] }],
+        isReplyToChannel: true,
+        parentMessageId: mockSentMessage.messageId,
+      });
+    expect(globalContext.pubSub?.publish)
+      .toHaveBeenCalledWith(
+        PUBSUB_TOPICS.SEND_MESSAGE_START,
+        {
+          message: { mockMessageType: MockMessageStateType.PENDING },
+          channel: globalContext.currentChannel,
+        },
+      );
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalledWith({
+        type: SEND_MESSAGE_FAILURE,
+        payload: { mockMessageType: MockMessageStateType.FAILED },
+      });
+    expect(globalContext.messagesDispatcher)
+      .toHaveBeenCalledWith({
+        type: SEND_MESSAGEGE_SUCESS,
+        payload: { mockMessageType: MockMessageStateType.SUCCEEDED },
+      });
+  });
+
+  it('should apply the onBeforeSendMultipleFilesMessage', () => {
+    const newParamsOptions = {
+      customType: 'custom-type',
+      fileInfoList: [new File([], 'newFileOne'), new File([], 'newFileTwo')].map((file) => ({ file })),
+    };
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: globalContext.currentChannel as GroupChannel,
+        // modify the message create params before sending a message
+        onBeforeSendMultipleFilesMessage: (params) => ({
+          ...params,
+          ...newParamsOptions,
+        }),
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    sendMultipleFilesMessage(mockFileList);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .toHaveBeenCalledWith(newParamsOptions);
+    expect(globalContext.pubSub?.publish)
+      .toHaveBeenCalledWith(
+        PUBSUB_TOPICS.SEND_MESSAGE_START,
+        {
+          message: { mockMessageType: MockMessageStateType.PENDING },
+          channel: globalContext.currentChannel,
+        },
+      );
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalledWith({
+        type: SEND_MESSAGE_FAILURE,
+        payload: { mockMessageType: MockMessageStateType.FAILED },
+      });
+    expect(globalContext.messagesDispatcher)
+      .toHaveBeenCalledWith({
+        type: SEND_MESSAGEGE_SUCESS,
+        payload: { mockMessageType: MockMessageStateType.SUCCEEDED },
+      });
+  });
+
+  it('should have higher priority with onBeforeSendMultipleFilesMessage rather than quoteMessage', () => {
+    const newParamsOptions = {
+      customType: 'custom-type',
+      fileInfoList: [new File([], 'newFileOne'), new File([], 'newFileTwo')].map((file) => ({ file })),
+      parentMessageId: 1111,
+    };
+    const { result } = renderHook(() => (
+      useSendMultipleFilesMessage({
+        currentChannel: globalContext.currentChannel as GroupChannel,
+        // modify the message create params before sending a message
+        onBeforeSendMultipleFilesMessage: (params) => ({
+          ...params,
+          // upsert the properties for the quote message
+          ...newParamsOptions,
+        }),
+      }, {
+        logger: globalContext.logger as Logger,
+        pubSub: globalContext.pubSub,
+        scrollRef: globalContext.scrollRef as RefObject<HTMLDivElement>,
+        messagesDispatcher: globalContext.messagesDispatcher as CustomUseReducerDispatcher,
+      })
+    ));
+    const [sendMultipleFilesMessage] = result.current;
+
+    // send multiple files message with a quote message
+    sendMultipleFilesMessage(mockFileList, mockSentMessage as unknown as UserMessage);
+
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .toHaveBeenCalledWith({
+        isReplyToChannel: true,
+        ...newParamsOptions,
+      });
+    expect(globalContext.currentChannel?.sendMultipleFilesMessage)
+      .not.toHaveBeenCalledWith({
+        customType: newParamsOptions.customType,
+        fileInfoList: newParamsOptions.fileInfoList,
+        isReplyToChannel: true,
+        parentMessageId: mockSentMessage.messageId,
+      });
+    expect(globalContext.pubSub?.publish)
+      .toHaveBeenCalledWith(
+        PUBSUB_TOPICS.SEND_MESSAGE_START,
+        {
+          message: { mockMessageType: MockMessageStateType.PENDING },
+          channel: globalContext.currentChannel,
+        },
+      );
+    expect(globalContext.messagesDispatcher)
+      .not.toHaveBeenCalledWith({
+        type: SEND_MESSAGE_FAILURE,
+        payload: { mockMessageType: MockMessageStateType.FAILED },
+      });
+    expect(globalContext.messagesDispatcher)
+      .toHaveBeenCalledWith({
+        type: SEND_MESSAGEGE_SUCESS,
+        payload: { mockMessageType: MockMessageStateType.SUCCEEDED },
+      });
+  });
+});

--- a/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
@@ -1,0 +1,88 @@
+import { useCallback } from 'react';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { FileMessage, MultipleFilesMessageCreateParams, UserMessage } from '@sendbird/chat/message';
+
+import { CustomUseReducerDispatcher, Logger } from '../../../../lib/SendbirdState';
+import { scrollIntoLast } from '../utils';
+import PUBSUB_TOPICS from '../../../../lib/pubSub/topics';
+import * as messageActionTypes from '../dux/actionTypes';
+
+export type OnBeforeSendMFMType = (
+  params: MultipleFilesMessageCreateParams,
+  quoteMessage?: UserMessage | FileMessage,
+) => MultipleFilesMessageCreateParams;
+
+export interface UseSendMFMDynamicParams {
+  currentChannel: GroupChannel,
+  onBeforeSendMultipleFilesMessage?: OnBeforeSendMFMType,
+}
+export interface UseSendMFMStaticParams {
+  logger: Logger,
+  pubSub: any,
+  scrollRef: React.RefObject<HTMLDivElement>;
+  messagesDispatcher: CustomUseReducerDispatcher;
+}
+type FunctionType = (files: Array<File>, quoteMessage?: UserMessage | FileMessage) => void;
+
+export const useSendMultipleFilesMessage = ({
+  currentChannel,
+  onBeforeSendMultipleFilesMessage,
+}: UseSendMFMDynamicParams, {
+  logger,
+  pubSub,
+  scrollRef,
+  messagesDispatcher,
+}: UseSendMFMStaticParams): Array<FunctionType> => {
+  const sendMessage = useCallback((files: Array<File>, quoteMessage?: UserMessage | FileMessage): void => {
+    if (files.length <= 1) {
+      logger.error('Channel: Sending MFM failed, because there are no multiple files.', { files });
+      return;
+    }
+    let messageParams: MultipleFilesMessageCreateParams = {
+      fileInfoList: files.map((file) => ({ file })),
+    };
+    if (quoteMessage) {
+      messageParams.isReplyToChannel = true;
+      messageParams.parentMessageId = quoteMessage.messageId;
+    }
+    if (typeof onBeforeSendMultipleFilesMessage === 'function') {
+      messageParams = onBeforeSendMultipleFilesMessage(messageParams);
+    }
+    logger.info('Channel: Start sending MFM', { messageParams });
+    currentChannel.sendMultipleFilesMessage(messageParams)
+      /**
+       * We don't operate the onFileUploaded event for now
+       * until we will add UI/UX for it
+       */
+      // .onFileUploaded((requestId, index, uploadableFileInfo, err) => {})
+      .onPending((pendingMessage) => {
+        /**
+         * pubSub is used instead of messagesDispatcher
+         * to avoid redundantly calling `messageActionTypes.SEND_MESSAGEGE_START`
+         */
+        pubSub.publish(PUBSUB_TOPICS.SEND_MESSAGE_START, {
+          message: pendingMessage,
+          channel: currentChannel,
+        });
+        setTimeout(() => scrollIntoLast(0, scrollRef));
+      })
+      .onFailed((error, failedMessage) => {
+        logger.error('Channel: Sending MFM failed.', { error, failedMessage });
+        messagesDispatcher({
+          type: messageActionTypes.SEND_MESSAGE_FAILURE,
+          payload: failedMessage,
+        });
+      })
+      .onSucceeded((succeededMessage) => {
+        logger.info('Channel: Sending voice message success!', { succeededMessage });
+        messagesDispatcher({
+          type: messageActionTypes.SEND_MESSAGEGE_SUCESS,
+          payload: succeededMessage,
+        });
+      });
+  }, [
+    currentChannel,
+    onBeforeSendMultipleFilesMessage,
+  ]);
+  return [sendMessage];
+};

--- a/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
-import { FileMessage, MultipleFilesMessageCreateParams, UserMessage } from '@sendbird/chat/message';
+import { FileMessage, MultipleFilesMessageCreateParams, UploadableFileInfo, UserMessage } from '@sendbird/chat/message';
 
 import { Logger } from '../../../../lib/SendbirdState';
 import { scrollIntoLast } from '../utils';
@@ -40,7 +40,12 @@ export const useSendMultipleFilesMessage = ({
       return;
     }
     let messageParams: MultipleFilesMessageCreateParams = {
-      fileInfoList: files.map((file) => ({ file })),
+      fileInfoList: files.map((file: File): UploadableFileInfo => ({
+        file,
+        fileName: file.name,
+        fileSize: file.size,
+        mimeType: file.type,
+      })),
     };
     if (quoteMessage) {
       messageParams.isReplyToChannel = true;
@@ -55,7 +60,9 @@ export const useSendMultipleFilesMessage = ({
        * We don't operate the onFileUploaded event for now
        * until we will add UI/UX for it
        */
-      // .onFileUploaded((requestId, index, uploadableFileInfo, err) => {})
+      .onFileUploaded((requestId, index, uploadableFileInfo, error) => {
+        logger.info('Channel: onFileUploaded during sending MFM', { requestId, index, error, uploadableFileInfo });
+      })
       .onPending((pendingMessage) => {
         pubSub.publish(PUBSUB_TOPICS.SEND_MESSAGE_START, {
           message: pendingMessage,

--- a/src/modules/Thread/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Thread/context/hooks/useSendMultipleFilesMessage.ts
@@ -1,0 +1,7 @@
+export * from '../../../Channel/context/hooks/useSendMultipleFilesMessage';
+/**
+ * We have to reduce the duplicated logics between the modules Channel and Thread.
+ * We need to make a new directory place for both and bring the duplicated logics
+ * to there.
+ * The most of the custom hooks should be there.
+ */

--- a/src/utils/testMocks/error.ts
+++ b/src/utils/testMocks/error.ts
@@ -1,0 +1,10 @@
+export interface MockErrorType {
+  code: number;
+}
+
+/**
+ * We can add a policy for the mock instances
+ */
+export const mockError = {
+  code: 0,
+};

--- a/src/utils/testMocks/message.ts
+++ b/src/utils/testMocks/message.ts
@@ -1,0 +1,19 @@
+export enum MockMessageStateType {
+  PENDING = 'PENDING',
+  FAILED = 'FAILED',
+  SUCCEEDED = 'SUCCEEDED',
+  SENT = 'SENT',
+}
+export interface MockMessageType {
+  messageId: 0,
+  mockMessageType: MockMessageStateType;
+}
+
+// TODO: Improve the property details of these mock messages
+export const mockPendingMessage = { mockMessageType: MockMessageStateType.PENDING };
+export const mockFailedMessage = { mockMessageType: MockMessageStateType.FAILED };
+export const mockSucceededMessage = { mockMessageType: MockMessageStateType.SUCCEEDED };
+export const mockSentMessage = {
+  messageId: 0,
+  mockMessageType: MockMessageStateType.SENT,
+};

--- a/src/utils/testMocks/messageRequestHandler.ts
+++ b/src/utils/testMocks/messageRequestHandler.ts
@@ -1,39 +1,51 @@
+import { FileInfo } from '@sendbird/chat/message';
 import { MockErrorType, mockError } from './error';
 import { MockMessageType, mockFailedMessage, mockPendingMessage, mockSucceededMessage } from './message';
 
 type OnPendingCallbackType = (pendingMessage: MockMessageType) => void;
 type OnFailedCallbackType = (error: MockErrorType, failedMessage: MockMessageType) => void;
 type OnSucceededCallbackType = (succeededMessage: MockMessageType) => void;
+type OnFileUploadedCallbackType = (requestId: number, index: number, fileInfo: FileInfo, error: MockErrorType) => void;
 
 export type MockMessageRequestHandlerType = {
   onPending: (callback?: OnPendingCallbackType) => MockMessageRequestHandlerType,
   onFailed: (callback?: OnFailedCallbackType) => MockMessageRequestHandlerType,
   onSucceeded: (callback?: OnSucceededCallbackType) => MockMessageRequestHandlerType,
+  onFileUploaded: (callback?: OnFileUploadedCallbackType) => MockMessageRequestHandlerType,
 };
 
-const getOnPending = (isSucceeded = true) => jest.fn((callback) => {
-  if (isSucceeded) {
+const getOnPending = (isForSucceeded = true) => jest.fn((callback) => {
+  if (isForSucceeded) {
     callback(mockPendingMessage);
   }
-  return getMockMessageRequestHandler(isSucceeded);
+  return getMockMessageRequestHandler(isForSucceeded);
 });
-const getOnFailed = (isSucceeded = true) => jest.fn((callback) => {
-  if (!isSucceeded) {
+const getOnFailed = (isForSucceeded = true) => jest.fn((callback) => {
+  if (!isForSucceeded) {
     callback(mockError, mockFailedMessage);
   }
-  return getMockMessageRequestHandler(isSucceeded);
+  return getMockMessageRequestHandler(isForSucceeded);
 });
-const getOnSucceeded = (isSucceeded = true) => jest.fn((callback) => {
-  if (isSucceeded) {
+const getOnSucceeded = (isForSucceeded = true) => jest.fn((callback) => {
+  if (isForSucceeded) {
     callback(mockSucceededMessage);
   }
-  return getMockMessageRequestHandler(isSucceeded);
+  return getMockMessageRequestHandler(isForSucceeded);
+});
+const getOnFileUploaded = (isForSucceeded = true) => jest.fn((callback) => {
+  if (isForSucceeded) {
+    // TODO: Improve this logic
+    // - we don't test this event handler now
+    callback(0, 0, {}, null);
+  }
+  return getMockMessageRequestHandler(isForSucceeded);
 });
 
-export function getMockMessageRequestHandler(isSucceeded = true): MockMessageRequestHandlerType {
+export function getMockMessageRequestHandler(isForSucceeded = true): MockMessageRequestHandlerType {
   return {
-    onPending: getOnPending(isSucceeded),
-    onFailed: getOnFailed(isSucceeded),
-    onSucceeded: getOnSucceeded(isSucceeded),
+    onPending: getOnPending(isForSucceeded),
+    onFailed: getOnFailed(isForSucceeded),
+    onSucceeded: getOnSucceeded(isForSucceeded),
+    onFileUploaded: getOnFileUploaded(isForSucceeded),
   };
 }

--- a/src/utils/testMocks/messageRequestHandler.ts
+++ b/src/utils/testMocks/messageRequestHandler.ts
@@ -1,0 +1,39 @@
+import { MockErrorType, mockError } from './error';
+import { MockMessageType, mockFailedMessage, mockPendingMessage, mockSucceededMessage } from './message';
+
+type OnPendingCallbackType = (pendingMessage: MockMessageType) => void;
+type OnFailedCallbackType = (error: MockErrorType, failedMessage: MockMessageType) => void;
+type OnSucceededCallbackType = (succeededMessage: MockMessageType) => void;
+
+export type MockMessageRequestHandlerType = {
+  onPending: (callback?: OnPendingCallbackType) => MockMessageRequestHandlerType,
+  onFailed: (callback?: OnFailedCallbackType) => MockMessageRequestHandlerType,
+  onSucceeded: (callback?: OnSucceededCallbackType) => MockMessageRequestHandlerType,
+};
+
+const getOnPending = (isSucceeded = true) => jest.fn((callback) => {
+  if (isSucceeded) {
+    callback(mockPendingMessage);
+  }
+  return getMockMessageRequestHandler(isSucceeded);
+});
+const getOnFailed = (isSucceeded = true) => jest.fn((callback) => {
+  if (!isSucceeded) {
+    callback(mockError, mockFailedMessage);
+  }
+  return getMockMessageRequestHandler(isSucceeded);
+});
+const getOnSucceeded = (isSucceeded = true) => jest.fn((callback) => {
+  if (isSucceeded) {
+    callback(mockSucceededMessage);
+  }
+  return getMockMessageRequestHandler(isSucceeded);
+});
+
+export function getMockMessageRequestHandler(isSucceeded = true): MockMessageRequestHandlerType {
+  return {
+    onPending: getOnPending(isSucceeded),
+    onFailed: getOnFailed(isSucceeded),
+    onSucceeded: getOnSucceeded(isSucceeded),
+  };
+}


### PR DESCRIPTION
[UIKIT-4246](https://sendbird.atlassian.net/browse/UIKIT-4246)

### Feat
* Create a custom hook `useSendMultipleFilesMessage`
* Add some mock util functions for the MessageRequestHandler, Message, and Error instances
> Internal: You can import this hook from the `context/hooks` under the Channel and Thread modules.

#### How to use
```javascript
import { useSendMultipleFilesMessage } from '~/context/hooks/useSendMultipleFilesMessage'

const MultipleFilesInput = () => {
  return (
    <input
      type="file"
      onChange={(event) => {
        sendMultipleFilesMessage(event.target.files)
      }}
    />
  )
}
```

[UIKIT-4246]: https://sendbird.atlassian.net/browse/UIKIT-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ