### PR TITLE
fix: Improve isVoiceMessage parameter exception handling

### DIFF
--- a/src/utils/__tests__/isVoiceMessage.spec.ts
+++ b/src/utils/__tests__/isVoiceMessage.spec.ts
@@ -66,6 +66,11 @@ describe('Global-utils/isVoiceMessage', () => {
         type: undefined,
       } as unknown as FileMessage),
     ).toBeFalse();
+    const cloneMockVoiceMessage = { ...mockVoiceMessage } as any;
+    delete cloneMockVoiceMessage.type;
+    expect(
+      isVoiceMessage(cloneMockVoiceMessage as unknown as FileMessage),
+    ).toBeFalse();
   });
   it('should filter user messages', () => {
     expect(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -178,10 +178,14 @@ export const isAudioMessageMimeType = (type: string): boolean => (/^audio\//.tes
 export const isVoiceMessageMimeType = (type: string): boolean => (/^voice\//.test(type));
 export const isVoiceMessage = (message: Nullable<FileMessage | UserMessage>): boolean => {
   // ex) audio/m4a OR audio/m4a;sbu_type=voice
-  if (!(message && isFileMessage(message)) || !(message as FileMessage).type) {
+  if (!message
+    || !isFileMessage(message)
+    || !(message as FileMessage)?.type
+    || (typeof (message as FileMessage).type) !== 'string'
+  ) {
     return false;
   }
-  const [mimeType, typeParameter] = (message as FileMessage).type.split(';');
+  const [mimeType = '', typeParameter = ''] = (message as FileMessage).type?.split(';') ?? [];
 
   if (!isAudioMessageMimeType(mimeType)) {
     return false;


### PR DESCRIPTION
### Issue
There was an error when our QA team tried E2E test automation.
```
Cannot read properties of undefined (reading 'split')
TypeError: Cannot read properties of undefined (reading 'split')
  at isVoiceMessage
  at ChannelPreview
```
The `isVoiceMessage` function can be called with the other types of messages and some of them(UserMessage) may not have the `type` property.

#### Fix
* fix: add exception handling for file message's type property
* test: add test for when the `type` property doesn't exist