### PR TITLE
feat: Update ChannelPreview to support MFM lastMessage.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
   },
-  parser: "@babel/eslint-parser",
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -20,31 +20,31 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: [ 'react', 'babel', '@typescript-eslint' ],
+  plugins: ['react', 'babel', '@typescript-eslint'],
   rules: {
     // uncomment 'linebreak-style' to build in windows - its not adviced to commit from windows
     // read more - https://community.perforce.com/s/article/3096
     // ['linebreak-style']: 0,
-    "import/extensions": [
-      "error",
-      "ignorePackages",
+    'import/extensions': [
+      'error',
+      'ignorePackages',
       {
-        "js": "never",
-        "jsx": "never",
-        "ts": "never",
-        "tsx": "never",
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
       },
     ],
-    "react/forbid-prop-types": 0,
+    'react/forbid-prop-types': 0,
     // we don't want to force to define function component only
-    "react/function-component-definition": "off",
-    "no-unused-expressions": "off",
-    "@typescript-eslint/no-unused-expressions": ["error"],
+    'react/function-component-definition': 'off',
+    'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions': ['error'],
   },
   settings: {
-    "import/resolver": {
+    'import/resolver': {
       node: {
-        extensions: [".js", ".jsx", ".ts", ".tsx"],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     },
   },

--- a/src/modules/ChannelList/components/ChannelPreview/__tests__/ChannelPreview.spec.js
+++ b/src/modules/ChannelList/components/ChannelPreview/__tests__/ChannelPreview.spec.js
@@ -13,9 +13,45 @@ jest.setSystemTime(new Date('March 2, 2022 08:15:52'));
 describe('ChannelPreview', () => {
   test('utils/getLastMessage returns lastMessage', function () {
     const text = 'example-text';
-    const channel = {};
-    const channel2 = { lastMessage: { message: '' } };
-    const channel3 = { lastMessage: { message: text } };
+    const channel = {
+      lastMessage: {
+        isUserMessage: () => true,
+        isFileMessage: () => false,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel2 = {
+      lastMessage: {
+        message: '',
+        isUserMessage: () => true,
+        isFileMessage: () => false,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel3 = {
+      lastMessage: {
+        message: text,
+        isUserMessage: () => true,
+        isFileMessage: () => false,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel4 = {
+      lastMessage: {
+        name: 'file1',
+        isUserMessage: () => false,
+        isFileMessage: () => true,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel5 = {
+      lastMessage: {
+        fileInfoList: [{ fileName: 'file1' }, { fileName: 'file2' }],
+        isUserMessage: () => false,
+        isFileMessage: () => false,
+        isMultipleFilesMessage: () => true,
+      }
+    };
     expect(
       getLastMessage(channel)
     ).toBe('');
@@ -25,6 +61,12 @@ describe('ChannelPreview', () => {
     expect(
       getLastMessage(channel3)
     ).toBe(text);
+    expect(
+      getLastMessage(channel4)
+    ).toBe('file1');
+    expect(
+      getLastMessage(channel5)
+    ).toBe('file1');
   });
 
   test('utils/getChannelTitle returns channelTitle', function () {

--- a/src/modules/ChannelList/components/ChannelPreview/utils.js
+++ b/src/modules/ChannelList/components/ChannelPreview/utils.js
@@ -5,6 +5,9 @@ import isYesterday from 'date-fns/isYesterday';
 
 import { truncateString } from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
+import {match} from "ts-pattern";
+import {TOKEN_TYPES} from "../../../Message/utils/tokens/types";
+import {BaseMessage, MessageType} from "@sendbird/chat/message";
 
 /* eslint-disable default-param-last */
 export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelStringSet) => {
@@ -51,13 +54,18 @@ export const getTotalMembers = (channel) => (
     : 0
 );
 
-const getPrettyLastMessage = (message = {}) => {
+const getPrettyLastMessage = (message = null) => {
   const MAXLEN = 30;
-  const { messageType, name } = message;
-  if (messageType === 'file') {
-    return truncateString(name, MAXLEN);
+  if (!message) return '';
+  if (message.isFileMessage()) {
+    return truncateString(message.name, MAXLEN);
   }
-  return message.message;
+  if (message.isMultipleFilesMessage()) {
+    const { fileInfoList } = message;
+    if (fileInfoList.length > 0) return fileInfoList[0].fileName;
+    return '';
+  }
+  return message.message ?? '';
 };
 
 export const getLastMessage = (channel) => (channel?.lastMessage ? getPrettyLastMessage(channel?.lastMessage) : '');

--- a/src/modules/ChannelList/components/ChannelPreview/utils.js
+++ b/src/modules/ChannelList/components/ChannelPreview/utils.js
@@ -58,7 +58,9 @@ const getPrettyLastMessage = (message = null) => {
   }
   if (message.isMultipleFilesMessage()) {
     const { fileInfoList } = message;
-    if (fileInfoList.length > 0) return fileInfoList[0].fileName;
+    if (fileInfoList.length > 0) {
+      return truncateString(fileInfoList[0].fileName, MAXLEN);
+    }
     return '';
   }
   return message.message ?? '';

--- a/src/modules/ChannelList/components/ChannelPreview/utils.js
+++ b/src/modules/ChannelList/components/ChannelPreview/utils.js
@@ -2,12 +2,8 @@ import isToday from 'date-fns/isToday';
 import format from 'date-fns/format';
 import isThisYear from 'date-fns/isThisYear';
 import isYesterday from 'date-fns/isYesterday';
-
 import { truncateString } from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
-import {match} from "ts-pattern";
-import {TOKEN_TYPES} from "../../../Message/utils/tokens/types";
-import {BaseMessage, MessageType} from "@sendbird/chat/message";
 
 /* eslint-disable default-param-last */
 export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelStringSet) => {

--- a/src/modules/ChannelList/stories/index.stories.js
+++ b/src/modules/ChannelList/stories/index.stories.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 
 import Sendbird from '../../../lib/Sendbird';
 const appId = process.env.STORYBOOK_APP_ID;;
-const userId = 'sendbird';
+const userId = 'sendbird'; // Change this to 'sendbird1' for testing MultipleFilesMessage.
 
 import ChannelList from '../../ChannelList';
 import { getSdk } from '../../../lib/selectors';

--- a/src/modules/ChannelList/stories/index.stories.js
+++ b/src/modules/ChannelList/stories/index.stories.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 
 import Sendbird from '../../../lib/Sendbird';
 const appId = process.env.STORYBOOK_APP_ID;;
-const userId = 'sendbird'; // Change this to 'sendbird1' for testing MultipleFilesMessage.
+const userId = 'sendbird';
 
 import ChannelList from '../../ChannelList';
 import { getSdk } from '../../../lib/selectors';


### PR DESCRIPTION
Fixes: [UIKIT-4351](https://sendbird.atlassian.net/browse/UIKIT-4351)

Displays name of the first file in mfm.fileInfoList

[UIKIT-4351]: https://sendbird.atlassian.net/browse/UIKIT-4351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="620" alt="Screen Shot 2023-08-30 at 2 18 44 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/0ae81875-5465-4211-817b-0ab0d4cd490b">