### PR TITLE
feat: Alert file selection limit using global modal

### DIFF
--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -6,7 +6,8 @@ import Modal, { type ModalProps } from '../../ui/Modal';
 
 export type OpenGlobalModalProps = {
   modalProps: ModalProps;
-  childElement: ReactElement;
+  // childElement: ReactElement;
+  childElement: (props: { closeModal: () => void }) => ReactElement;
 };
 export interface GlobalModalProviderProps {
   children: ReactElement;
@@ -47,7 +48,11 @@ export const GlobalModalProvider = ({ children }: GlobalModalProviderProps) => {
               closeModal();
             }}
           >
-            {childElement}
+            {
+              childElement({
+                closeModal,
+              })
+            }
           </Modal>
         );
       });

--- a/src/ui/Modal/index.tsx
+++ b/src/ui/Modal/index.tsx
@@ -44,10 +44,12 @@ export interface ModalFooterProps {
   type?: ButtonTypes;
   onCancel: () => void;
   onSubmit: () => void;
+  hideCancelButton?: boolean;
 }
 export const ModalFooter = ({
   submitText,
   disabled = false,
+  hideCancelButton = false,
   type = ButtonTypes.DANGER,
   onSubmit,
   onCancel,
@@ -55,11 +57,13 @@ export const ModalFooter = ({
   const { stringSet } = useContext(LocalizationContext);
   return (
     <div className="sendbird-modal__footer">
-      <Button type={ButtonTypes.SECONDARY} onClick={onCancel}>
-        <Label type={LabelTypography.BUTTON_1} color={LabelColors.ONBACKGROUND_1}>
-          {stringSet.BUTTON__CANCEL}
-        </Label>
-      </Button>
+      {!hideCancelButton && (
+        <Button type={ButtonTypes.SECONDARY} onClick={onCancel}>
+          <Label type={LabelTypography.BUTTON_1} color={LabelColors.ONBACKGROUND_1}>
+            {stringSet.BUTTON__CANCEL}
+          </Label>
+        </Button>
+      )}
       <Button type={type} disabled={disabled} onClick={onSubmit}>
         {submitText}
       </Button>


### PR DESCRIPTION
### Feat
* feat: add a props - hideCancelButton to the ui/Modal component
* fix: change the childElement props type to a function returning element
* feat: alert file selection limit using global modal

<img src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/e44d2bd2-3910-4ddc-8b1c-6e30f5be558d" width="600"/>
<img width="600" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/69fc24c1-7049-4070-a558-1fe32965a2f2" />
