### PR TITLE
feat: Add interface of customizing message CURD actions

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -34,6 +34,7 @@ declare module "SendbirdUIKitGlobal" {
     MessageSearchQuery,
     MessageSearchQueryParams,
     MultipleFilesMessage,
+    MultipleFilesMessageCreateParams,
     UserMessage,
     UserMessageCreateParams,
     UserMessageUpdateParams,
@@ -578,6 +579,8 @@ declare module "SendbirdUIKitGlobal" {
     startingPoint?: number;
     onBeforeSendUserMessage?(text: string, quotedMessage?: SendableMessageType): UserMessageCreateParams;
     onBeforeSendFileMessage?(file: File, quotedMessage?: SendableMessageType): FileMessageCreateParams;
+    onBeforeSendVoiceMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
+    onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
     onBeforeUpdateUserMessage?(text: string): UserMessageUpdateParams;
     onChatHeaderActionClick?(event: React.MouseEvent<HTMLElement>): void;
     onSearchClick?(): void;
@@ -1076,6 +1079,10 @@ declare module "SendbirdUIKitGlobal" {
     message: SendableMessageType;
     onHeaderActionClick?: () => void;
     onMoveToParentMessage?: (props: { message: SendableMessageType, channel: GroupChannel }) => void;
+    onBeforeSendUserMessage?: (message: string, quotedMessage?: SendableMessageType) => UserMessageCreateParams;
+    onBeforeSendFileMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
+    onBeforeSendVoiceMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
+    onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
     disableUserProfile?: boolean;
     renderUserProfile?: (props: { user: User, close: () => void }) => React.ReactElement;
   }

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -10,6 +10,7 @@ import type { GroupChannel, SendbirdGroupChat } from '@sendbird/chat/groupChanne
 import type {
   BaseMessage,
   FileMessageCreateParams,
+  MultipleFilesMessageCreateParams,
   UserMessage,
   UserMessageCreateParams,
   UserMessageUpdateParams,
@@ -81,8 +82,9 @@ export type ChannelContextProps = {
   onBeforeSendUserMessage?(text: string, quotedMessage?: SendableMessageType): UserMessageCreateParams;
   onBeforeSendFileMessage?(file: File, quotedMessage?: SendableMessageType): FileMessageCreateParams;
   onBeforeUpdateUserMessage?(text: string): UserMessageUpdateParams;
-  onChatHeaderActionClick?(event: React.MouseEvent<HTMLElement>): void;
   onBeforeSendVoiceMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
+  onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
+  onChatHeaderActionClick?(event: React.MouseEvent<HTMLElement>): void;
   onSearchClick?(): void;
   onBackClick?(): void;
   replyType?: ReplyType;
@@ -179,6 +181,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     onBeforeSendFileMessage,
     onBeforeUpdateUserMessage,
     onBeforeSendVoiceMessage,
+    onBeforeSendMultipleFilesMessage,
     onChatHeaderActionClick,
     onSearchClick,
     onBackClick,
@@ -395,7 +398,11 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     { logger },
   );
   const [messageInputRef, sendMessage] = useSendMessageCallback(
-    { currentGroupChannel, onBeforeSendUserMessage, isMentionEnabled },
+    {
+      currentGroupChannel,
+      isMentionEnabled,
+      onBeforeSendUserMessage,
+    },
     {
       logger,
       pubSub,
@@ -404,7 +411,11 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     },
   );
   const [sendFileMessage] = useSendFileMessageCallback(
-    { currentGroupChannel, onBeforeSendFileMessage, imageCompression },
+    {
+      currentGroupChannel,
+      imageCompression,
+      onBeforeSendFileMessage,
+    },
     {
       logger,
       pubSub,
@@ -426,8 +437,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
   );
   const [sendMultipleFilesMessage] = useSendMultipleFilesMessage({
     currentChannel: currentGroupChannel,
-    // Open interface to <Channel /> & <ChannelProvider >
-    // onBeforeSendMultipleFilesMessage: (params) => params,
+    onBeforeSendMultipleFilesMessage,
   }, {
     logger,
     pubSub,

--- a/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
@@ -5,14 +5,14 @@ import type {
   UploadableFileInfo,
 } from '@sendbird/chat/message';
 
-import { SendableMessageType } from 'SendbirdUIKitGlobal';
 import type { Logger } from '../../../../lib/SendbirdState';
 import type { Nullable } from '../../../../types';
 import PUBSUB_TOPICS from '../../../../lib/pubSub/topics';
 import { scrollIntoLast } from '../utils';
+import { SendableMessageType } from '../../../../utils';
 
 export type OnBeforeSendMFMType = (
-  params: MultipleFilesMessageCreateParams,
+  files: Array<File>,
   quoteMessage?: SendableMessageType,
 ) => MultipleFilesMessageCreateParams;
 
@@ -61,7 +61,7 @@ export const useSendMultipleFilesMessage = ({
       messageParams.parentMessageId = quoteMessage.messageId;
     }
     if (typeof onBeforeSendMultipleFilesMessage === 'function') {
-      messageParams = onBeforeSendMultipleFilesMessage(messageParams);
+      messageParams = onBeforeSendMultipleFilesMessage(files, quoteMessage);
     }
     logger.info('Channel: Start sending MFM', { messageParams });
     try {

--- a/src/modules/Channel/context/hooks/useSendVoiceMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendVoiceMessageCallback.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import { FileMessageCreateParams, MessageMetaArray } from '@sendbird/chat/message';
-import { Logger } from '../../../../lib/SendbirdState';
+
+import type { Logger } from '../../../../lib/SendbirdState';
 import * as messageActionTypes from '../dux/actionTypes';
 import * as utils from '../utils';
 import topics from '../../../../lib/pubSub/topics';
@@ -12,10 +13,11 @@ import {
   VOICE_MESSAGE_FILE_NAME,
   VOICE_MESSAGE_MIME_TYPE,
 } from '../../../../utils/consts';
-import { SendableMessageType } from '../../../../utils';
+import type { SendableMessageType } from '../../../../utils';
+import type { Nullable } from '../../../../types';
 
 interface DynamicParams {
-  currentGroupChannel: GroupChannel;
+  currentGroupChannel: Nullable<GroupChannel>;
   onBeforeSendVoiceMessage?: (file: File, quoteMessage?: SendableMessageType) => FileMessageCreateParams;
 }
 interface StaticParams {
@@ -37,6 +39,9 @@ export const useSendVoiceMessageCallback = ({
   messagesDispatcher,
 }: StaticParams): Array<FuncType> => {
   const sendMessage = useCallback((file: File, duration: number, quoteMessage: SendableMessageType) => {
+    if (!currentGroupChannel) {
+      return;
+    }
     const messageParams: FileMessageCreateParams = (
       onBeforeSendVoiceMessage
       && typeof onBeforeSendVoiceMessage === 'function'

--- a/src/modules/Channel/index.tsx
+++ b/src/modules/Channel/index.tsx
@@ -22,6 +22,8 @@ const Channel: React.FC<ChannelProps> = (props: ChannelProps) => {
       onBeforeSendUserMessage={props?.onBeforeSendUserMessage}
       onBeforeSendFileMessage={props?.onBeforeSendFileMessage}
       onBeforeUpdateUserMessage={props?.onBeforeUpdateUserMessage}
+      onBeforeSendVoiceMessage={props?.onBeforeSendVoiceMessage}
+      onBeforeSendMultipleFilesMessage={props?.onBeforeSendMultipleFilesMessage}
       onChatHeaderActionClick={props?.onChatHeaderActionClick}
       onSearchClick={props?.onSearchClick}
       onBackClick={props?.onBackClick}

--- a/src/modules/Thread/context/hooks/useSendFileMessage.ts
+++ b/src/modules/Thread/context/hooks/useSendFileMessage.ts
@@ -10,6 +10,7 @@ import { SendableMessageType } from '../../../../utils';
 
 interface DynamicProps {
   currentChannel: GroupChannel;
+  onBeforeSendFileMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
 }
 interface StaticProps {
   logger: Logger;
@@ -26,6 +27,7 @@ export type SendFileMessageFunctionType = (file: File, quoteMessage?: SendableMe
 
 export default function useSendFileMessageCallback({
   currentChannel,
+  onBeforeSendFileMessage,
 }: DynamicProps, {
   logger,
   pubSub,
@@ -41,7 +43,7 @@ export default function useSendFileMessageCallback({
       }
       return params;
     };
-    const params = createParamsDefault();
+    const params = onBeforeSendFileMessage?.(file, quoteMessage) ?? createParamsDefault();
     logger.info('Thread | useSendFileMessageCallback: Sending file message start.', params);
 
     currentChannel?.sendFileMessage(params)

--- a/src/modules/Thread/context/hooks/useSendUserMessageCallback.ts
+++ b/src/modules/Thread/context/hooks/useSendUserMessageCallback.ts
@@ -8,9 +8,11 @@ import { ThreadContextActionTypes } from '../dux/actionTypes';
 import topics from '../../../../lib/pubSub/topics';
 import { SendableMessageType } from '../../../../utils';
 
+export type OnBeforeSendUserMessageType = (message: string, quoteMessage?: SendableMessageType) => UserMessageCreateParams;
 interface DynamicProps {
   isMentionEnabled: boolean;
   currentChannel: GroupChannel;
+  onBeforeSendUserMessage?: OnBeforeSendUserMessageType;
 }
 interface StaticProps {
   logger: Logger;
@@ -28,6 +30,7 @@ export type SendMessageParams = {
 export default function useSendUserMessageCallback({
   isMentionEnabled,
   currentChannel,
+  onBeforeSendUserMessage,
 }: DynamicProps, {
   logger,
   pubSub,
@@ -36,7 +39,7 @@ export default function useSendUserMessageCallback({
   const sendMessage = useCallback((props: SendMessageParams) => {
     const {
       message,
-      quoteMessage = null,
+      quoteMessage,
       mentionTemplate,
       mentionedUsers,
     } = props;
@@ -57,7 +60,7 @@ export default function useSendUserMessageCallback({
       return params;
     };
 
-    const params = createDefaultParams();
+    const params = onBeforeSendUserMessage?.(message, quoteMessage) ?? createDefaultParams();
     logger.info('Thread | useSendUserMessageCallback: Sending user message start.', params);
 
     if (currentChannel?.sendUserMessage) {

--- a/src/modules/Thread/index.tsx
+++ b/src/modules/Thread/index.tsx
@@ -19,6 +19,11 @@ const Thread: React.FC<ThreadProps> = (props: ThreadProps) => {
     message,
     onHeaderActionClick,
     onMoveToParentMessage,
+    // onBeforeSend~~~Message
+    onBeforeSendUserMessage,
+    onBeforeSendFileMessage,
+    onBeforeSendVoiceMessage,
+    onBeforeSendMultipleFilesMessage,
     // ThreadUIProps
     renderHeader,
     renderParentMessageInfo,
@@ -38,6 +43,10 @@ const Thread: React.FC<ThreadProps> = (props: ThreadProps) => {
         message={message}
         onHeaderActionClick={onHeaderActionClick}
         onMoveToParentMessage={onMoveToParentMessage}
+        onBeforeSendUserMessage={onBeforeSendUserMessage}
+        onBeforeSendFileMessage={onBeforeSendFileMessage}
+        onBeforeSendVoiceMessage={onBeforeSendVoiceMessage}
+        onBeforeSendMultipleFilesMessage={onBeforeSendMultipleFilesMessage}
       >
         <ThreadUI
           renderHeader={renderHeader}


### PR DESCRIPTION
[UIKIT-4450](https://sendbird.atlassian.net/browse/UIKIT-4450)

### Feat
* Create a props `onBeforeSendMultipleFilesMessage` to the Channel and Thread module
### Fix
* Add some props types that we have missed in the public interface
  * Channel: onBeforeSendVoiceMessage
  * Thread: onBeforeSendUserMessage, onBeforeSendFileMessage, onBeforeSendVoiceMessage
* Apply onBeforeSendUserMessage & onBeforeSendFileMessage to the Thread.
  We have missed applying these customizing props in the Thread module


[UIKIT-4450]: https://sendbird.atlassian.net/browse/UIKIT-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ