### PR TITLE
feat: Handling pending message for MFM

### DIFF
--- a/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
+++ b/src/modules/Channel/context/hooks/__test__/useSendMultipleFilesMessage.spec.ts
@@ -27,6 +27,14 @@ const globalContext: GlobalContextType = {};
 const mockFileList = [new File([], 'fileOne'), new File([], 'fileTwo')];
 
 describe('useSendMultipleFilesMessage', () => {
+  // URL.createObjectURL seems it doesn't work in the jest env.
+  beforeAll(() => {
+    global.URL.createObjectURL = jest.fn();
+  });
+  afterAll(() => {
+    (global.URL.createObjectURL as jest.Mock).mockReset();
+  });
+
   beforeEach(() => {
     globalContext.currentChannel = {
       url: uuidv4(),
@@ -84,11 +92,15 @@ describe('useSendMultipleFilesMessage', () => {
           },
         ],
       });
+
     expect(globalContext.pubSub?.publish)
       .toHaveBeenCalledWith(
         PUBSUB_TOPICS.SEND_MESSAGE_START,
         {
-          message: { mockMessageType: MockMessageStateType.PENDING },
+          message: {
+            mockMessageType: MockMessageStateType.PENDING,
+            fileInfoList: expect.any(Array<2>),
+          },
           channel: {
             url: globalContext.currentChannel?.url,
             sendMultipleFilesMessage: expect.any(Function),
@@ -255,7 +267,10 @@ describe('useSendMultipleFilesMessage', () => {
       .toHaveBeenCalledWith(
         PUBSUB_TOPICS.SEND_MESSAGE_START,
         {
-          message: { mockMessageType: MockMessageStateType.PENDING },
+          message: {
+            mockMessageType: MockMessageStateType.PENDING,
+            fileInfoList: expect.any(Array<2>),
+          },
           channel: globalContext.currentChannel,
         },
       );
@@ -307,7 +322,10 @@ describe('useSendMultipleFilesMessage', () => {
       .toHaveBeenCalledWith(
         PUBSUB_TOPICS.SEND_MESSAGE_START,
         {
-          message: { mockMessageType: MockMessageStateType.PENDING },
+          message: {
+            mockMessageType: MockMessageStateType.PENDING,
+            fileInfoList: expect.any(Array<2>),
+          },
           channel: globalContext.currentChannel,
         },
       );
@@ -371,7 +389,10 @@ describe('useSendMultipleFilesMessage', () => {
       .toHaveBeenCalledWith(
         PUBSUB_TOPICS.SEND_MESSAGE_START,
         {
-          message: { mockMessageType: MockMessageStateType.PENDING },
+          message: {
+            mockMessageType: MockMessageStateType.PENDING,
+            fileInfoList: expect.any(Array<2>),
+          },
           channel: globalContext.currentChannel,
         },
       );

--- a/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
@@ -74,8 +74,15 @@ export const useSendMultipleFilesMessage = ({
           logger.info('Channel: onFileUploaded during sending MFM', { requestId, index, error, uploadableFileInfo });
         })
         .onPending((pendingMessage) => {
+          logger.info('Channel: in progress of sending MFM', { pendingMessage, fileInfoList: messageParams.fileInfoList });
           pubSub.publish(PUBSUB_TOPICS.SEND_MESSAGE_START, {
-            message: pendingMessage,
+            message: {
+              ...pendingMessage,
+              fileInfoList: messageParams.fileInfoList.map((fileInfo) => ({
+                ...fileInfo,
+                url: URL.createObjectURL(fileInfo.file as File),
+              })),
+            },
             channel: currentChannel,
           });
           if (scrollRef) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -271,6 +271,10 @@ export const getUIKitMessageType = (
   if (isUserMessage(message as UserMessage)) {
     return isOGMessage(message as UserMessage) ? UIKitMessageTypes.OG : UIKitMessageTypes.TEXT;
   }
+  // This is only a safeguard to not return UNKNOWN for MFM.
+  if (isMultipleFilesMessage(message as FileMessage)) {
+    return UIKitMessageTypes.MULTIPLE_FILES;
+  }
   if (isFileMessage(message as FileMessage)) {
     if (isThumbnailMessage(message as FileMessage)) {
       return UIKitMessageTypes.THUMBNAIL;
@@ -279,10 +283,6 @@ export const getUIKitMessageType = (
       return UIKitFileTypes.VOICE;
     }
     return UIKitMessageTypes.FILE;
-  }
-  // This is only a safeguard to not return UNKNOWN for MFM.
-  if (isMultipleFilesMessage(message as FileMessage)) {
-    return UIKitMessageTypes.MULTIPLE_FILES;
   }
   return UIKitMessageTypes.UNKNOWN;
 };


### PR DESCRIPTION
[UIKIT-4468](https://sendbird.atlassian.net/browse/UIKIT-4468)

### Fix
* Generate URLs and put them into the pending MFM
* Expect the property fileInfoList of the pending MFM in the test code

[UIKIT-4468]: https://sendbird.atlassian.net/browse/UIKIT-4468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ