### PR TITLE
Add shade on hover over MFM ImageRenderer + GIF Icon for gif

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -2145,6 +2145,8 @@ declare module '@sendbird/uikit-react/ui/ImageRenderer' {
     defaultComponent?: (() => React.ReactElement) | React.ReactElement;
     onLoad?: () => void;
     onError?: () => void;
+    shadeOnHover?: boolean;
+    isGif?: boolean;
   }
   const ImageRenderer: React.FC<ImageRendererProps>;
   export default ImageRenderer;

--- a/src/modules/App/stories/integrated-app.scss
+++ b/src/modules/App/stories/integrated-app.scss
@@ -6,7 +6,7 @@
   width: 100vw;
   justify-content: center;
   align-items: center;
-  font-family: var(--sendbird-font-family-default);;
+  font-family: var(--sendbird-font-family-default);
   @include themed() {
     background-color: t(bg-8);
     color: t(on-bg-1);

--- a/src/modules/ChannelList/stories/index.stories.js
+++ b/src/modules/ChannelList/stories/index.stories.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 
 import Sendbird from '../../../lib/Sendbird';
-const appId = process.env.STORYBOOK_APP_ID;;
+const appId = process.env.STORYBOOK_APP_ID;
 const userId = 'sendbird';
 
 import ChannelList from '../../ChannelList';

--- a/src/ui/ImageRenderer/index.scss
+++ b/src/ui/ImageRenderer/index.scss
@@ -1,3 +1,5 @@
+@import '../../styles/variables';
+
 .sendbird-image-renderer {
   overflow: hidden;
   position: relative;
@@ -11,4 +13,39 @@
 .sendbird-image-renderer__image {
   width: 320px;
   height: 180px;
+}
+
+.sendbird-multiple-files-image-renderer__image-cover {
+  position: absolute;
+  top: 0px;
+  display: none;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  background-color: var(--sendbird-light-overlay-01);
+}
+
+.sendbird-image-renderer:hover {
+  .sendbird-multiple-files-image-renderer__image-cover {
+    display: inline-flex;
+  }
+}
+
+.sendbird-multiple-files-image-renderer__icon-wrapper {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .sendbird-multiple-files-image-renderer__icon-wrapper__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: var(--sendbird-light-background-50);
+  }
 }

--- a/src/ui/ImageRenderer/index.tsx
+++ b/src/ui/ImageRenderer/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo, ReactElement } from 'react';
 import './index.scss';
 import numberToPx from '../../utils/numberToPx';
 import { useDynamicSideLength } from './useDynamicSideLength';
+import Icon, { IconTypes, IconColors } from '../Icon';
 
 /*
   ImageRenderer displays image with url or source
@@ -32,6 +33,8 @@ export interface ImageRendererProps {
   borderRadius?: string | number;
   onLoad?: () => void;
   onError?: () => void;
+  shadeOnHover?: boolean;
+  isGif?: boolean;
 }
 
 const ImageRenderer = ({
@@ -48,6 +51,8 @@ const ImageRenderer = ({
   borderRadius = null,
   onLoad = () => { /* noop */ },
   onError = () => { /* noop */ },
+  shadeOnHover,
+  isGif = false,
 }: ImageRendererProps): ReactElement => {
   const [showDefaultComponent, setShowDefaultComponent] = useState(false);
   const [showPlaceHolder, setShowPlaceHolder] = useState(true);
@@ -137,6 +142,28 @@ const ImageRenderer = ({
           )
       }
       {HiddenImageLoader}
+      {
+        shadeOnHover && <div
+        className="sendbird-multiple-files-image-renderer__image-cover"
+        style={{
+          borderRadius: getBorderRadiusForImageRenderer(circle, borderRadius),
+        }}
+      />
+      }
+      {
+        isGif && (
+          <div className="sendbird-multiple-files-image-renderer__icon-wrapper">
+            <div className="sendbird-multiple-files-image-renderer__icon-wrapper__icon">
+              <Icon
+                type={IconTypes.GIF}
+                fillColor={IconColors.GRAY}
+                width="34px"
+                height="34px"
+              />
+            </div>
+          </div>
+        )
+      }
     </div>
   );
 };

--- a/src/ui/MessageInput/index.scss
+++ b/src/ui/MessageInput/index.scss
@@ -17,7 +17,7 @@
     height: 56px;
     overflow-y: scroll;
     letter-spacing: normal;
-    padding: 18px 64px 18px 16px;;
+    padding: 18px 64px 18px 16px;
     box-sizing: border-box;
     resize: none;
     font-family: var(--sendbird-font-family-default);

--- a/src/ui/MobileMenu/mobile-menu-reacted-members.scss
+++ b/src/ui/MobileMenu/mobile-menu-reacted-members.scss
@@ -18,7 +18,7 @@
   display: inline-flex;
   gap: 4px;
   flex-direction: row;
-  align-items: center;;
+  align-items: center;
 }
 
 .sendbird-message__bottomsheet__reactor-list {

--- a/src/ui/MultipleFilesMessageItemBody/index.tsx
+++ b/src/ui/MultipleFilesMessageItemBody/index.tsx
@@ -13,6 +13,7 @@ import {
   MULTIPLE_FILES_IMAGE_SIDE_LENGTH,
   MULTIPLE_FILES_IMAGE_THUMBNAIL_SIDE_LENGTH,
 } from './const';
+import { isGifFileInfo } from "../../utils";
 
 export const ThreadMessageKind = {
   PARENT: 'parent',
@@ -94,6 +95,8 @@ export default function MultipleFilesMessageItemBody({
                 maxSideLength={MULTIPLE_FILES_IMAGE_SIDE_LENGTH.CHAT_WEB}
                 height={MULTIPLE_FILES_IMAGE_SIDE_LENGTH[threadMessageKindKey]}
                 borderRadius={MULTIPLE_FILES_IMAGE_BORDER_RADIUS[threadMessageKindKey]}
+                shadeOnHover={true}
+                isGif={isGifFileInfo(fileInfo)}
                 defaultComponent={
                   <div
                     className="sendbird-multiple-files-image-renderer__thumbnail__placeholder"

--- a/src/ui/MultipleFilesMessageItemBody/index.tsx
+++ b/src/ui/MultipleFilesMessageItemBody/index.tsx
@@ -13,7 +13,7 @@ import {
   MULTIPLE_FILES_IMAGE_SIDE_LENGTH,
   MULTIPLE_FILES_IMAGE_THUMBNAIL_SIDE_LENGTH,
 } from './const';
-import { isGifFileInfo } from "../../utils";
+import { isGifFileInfo } from '../../utils';
 
 export const ThreadMessageKind = {
   PARENT: 'parent',

--- a/src/ui/ThumbnailMessageItemBody/index.scss
+++ b/src/ui/ThumbnailMessageItemBody/index.scss
@@ -51,7 +51,7 @@
     display: none;
     width: 100%;
     height: 270px;
-    border-radius: 16px;;
+    border-radius: 16px;
     background-color: var(--sendbird-light-overlay-01);
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -230,6 +230,9 @@ export const isVideoMessage = (message: SendableMessageType): boolean => (
 export const isGifMessage = (message: SendableMessageType): boolean => (
   message && isThumbnailMessage(message) && isGif((message as FileMessage).type)
 );
+export const isGifFileInfo = (fileInfo: UploadedFileInfo): boolean => (
+  fileInfo && isGif(fileInfo.mimeType)
+);
 export const isAudioMessage = (message: FileMessage): boolean => message && isFileMessage(message) && isAudio(message.type);
 export const isAudioMessageMimeType = (type: string): boolean => (/^audio\//.test(type));
 export const isVoiceMessageMimeType = (type: string): boolean => (/^voice\//.test(type));


### PR DESCRIPTION
Add shade on hover over MFM ImageRenderer + GIF Icon for gif.

Fixes: [CLNP-4494](https://sendbird.atlassian.net/browse/CLNP-4494)

<img width="1239" alt="Screen Shot 2023-09-21 at 5 50 34 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/cbb5befd-6dfd-4739-8efb-914fc8d1d78c">
<img width="532" alt="Screen Shot 2023-09-21 at 5 49 25 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/14c6ef8c-f82b-45cb-8a5f-55c44ba7aa15">
<img width="506" alt="Screen Shot 2023-09-21 at 5 49 39 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/9b5731fc-026a-43d9-8e6c-0268805eb566">
<img width="599" alt="Screen Shot 2023-09-21 at 5 49 44 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/6e5f60c4-ed5e-4746-9c70-969ada35d8c8">
