### PR TITLE
feat: Divide message list in the MessagesStore

### DIFF
--- a/scripts/index_d_ts
+++ b/scripts/index_d_ts
@@ -619,7 +619,14 @@ declare module "SendbirdUIKitGlobal" {
   export type SendableMessageType = UserMessage | FileMessage | MultipleFilesMessage;
 
   export interface MessageStoreInterface {
+    /**
+     * Note: allMessages will contain only 'succeeded' messages from the next minor version - v3.7.0
+     */
     allMessages: CoreMessageType[];
+    /**
+     * localMessages: An array of 'pending' and 'failed' messages
+     */
+    localMessages: CoreMessageType[];
     loading?: boolean;
     initialized?: boolean;
     unreadSince?: string;

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -38,6 +38,7 @@ const MessageList: React.FC<MessageListProps> = ({
 }) => {
   const {
     allMessages,
+    localMessages,
     hasMorePrev,
     hasMoreNext,
     setInitialTimeStamp,
@@ -192,6 +193,32 @@ const MessageList: React.FC<MessageListProps> = ({
                   renderMessage={renderMessage}
                   message={m}
                   hasSeparator={hasSeparator}
+                  chainTop={chainTop}
+                  chainBottom={chainBottom}
+                  renderCustomSeparator={renderCustomSeparator}
+                />
+              </MessageProvider>
+            );
+          })}
+          {localMessages.map((m, idx) => {
+            const {
+              chainTop,
+              chainBottom,
+            } = getMessagePartsInfo({
+              allMessages: allMessagesFiltered,
+              replyType,
+              isMessageGroupingEnabled,
+              currentIndex: idx,
+              currentMessage: m,
+              currentChannel: currentGroupChannel,
+            });
+            const isByMe = (m as UserMessage)?.sender?.userId === store?.config?.userId;
+            return (
+              <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
+                <Message
+                  handleScroll={moveScroll}
+                  renderMessage={renderMessage}
+                  message={m}
                   chainTop={chainTop}
                   chainBottom={chainBottom}
                   renderCustomSeparator={renderCustomSeparator}

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -104,6 +104,7 @@ export type ChannelContextProps = {
 
 interface MessageStoreInterface {
   allMessages: CoreMessageType[];
+  localMessages: CoreMessageType[];
   loading: boolean;
   initialized: boolean;
   unreadSince: string;
@@ -237,6 +238,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
 
   const {
     allMessages,
+    localMessages,
     loading,
     initialized,
     unreadSince,
@@ -474,6 +476,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
 
       // messagesStore
       allMessages,
+      localMessages,
       loading,
       initialized,
       unreadSince,

--- a/src/modules/Channel/context/dux/data.mock.js
+++ b/src/modules/Channel/context/dux/data.mock.js
@@ -7,6 +7,7 @@ export const generateMockChannel = () => ({
   messageListParams: null,
   oldestMessageTimeStamp: 1582004042250,
   latestMessageTimeStamp: 1582004214188,
+  localMessages: [],
   allMessages: [{
     "messageId": 390280166,
     "messageType": "user",

--- a/src/modules/Channel/context/dux/initialState.js
+++ b/src/modules/Channel/context/dux/initialState.js
@@ -2,6 +2,10 @@ export default {
   initialized: false,
   loading: true,
   allMessages: [],
+  /**
+   * localMessages: pending & failed messages
+   */
+  localMessages: [],
   currentGroupChannel: { members: [] },
   // for scrollup
   hasMorePrev: false,

--- a/src/modules/Channel/context/dux/reducers.js
+++ b/src/modules/Channel/context/dux/reducers.js
@@ -142,14 +142,11 @@ export default function reducer(state, action) {
       };
     }
     case actionTypes.SEND_MESSAGE_START:
+      // Message should not be spread here
+      // it will loose some methods like `isUserMessage`
       return {
         ...state,
-        allMessages: [
-          ...state.allMessages,
-          // Message should not be spread here
-          // it will loose some methods like `isUserMessage`
-          action.payload,
-        ],
+        localMessages: [...state.localMessages, action.payload],
       };
     case actionTypes.SEND_MESSAGE_SUCESS: {
       const message = action.payload;
@@ -158,21 +155,10 @@ export default function reducer(state, action) {
       ));
       // [Policy] Pending messages and failed messages
       // must always be at the end of the message list
-      const pendingIndex = filteredMessages.findIndex((msg) => (
-        msg?.sendingStatus === 'pending' || msg?.sendingStatus === 'failed'
-      ));
       return {
         ...state,
-        allMessages: pendingIndex > -1
-          ? [
-            ...filteredMessages.slice(0, pendingIndex),
-            message,
-            ...filteredMessages.slice(pendingIndex),
-          ]
-          : [
-            ...filteredMessages,
-            message,
-          ],
+        allMessages: [...filteredMessages, message],
+        localMessages: state.localMessages.filter((m) => m?.reqId !== message?.reqId),
       };
     }
     case actionTypes.SEND_MESSAGE_FAILURE: {
@@ -180,7 +166,7 @@ export default function reducer(state, action) {
       action.payload.failed = true;
       return {
         ...state,
-        allMessages: state.allMessages.map((m) => (
+        localMessages: state.localMessages.map((m) => (
           compareIds(m.reqId, action.payload.reqId)
             ? action.payload
             : m


### PR DESCRIPTION
### Issue
When succeding to sending multiple messages in a very short time, some of the pending messages are not removed from the message list.
We anticipate this is a timing issue.

### Fix
* To operate the message list safely, we are going to make another message list `localMessages` inside of the MessagesStore.
* From the next minor version `v3.7.0`, the `allMessages` will be deprecated or changed.
  * The current `allMessages` will only include the 'succeeded' messages, and the `localMessages` will contain the 'pending' and 'failed' messages.