### PR TITLE
feat: Update GIF/Video icon color.

### DIFF
--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.scss
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.scss
@@ -108,7 +108,7 @@
 
 .sendbird-parent-message-info-item__thumbnail-message__icon-wrapper__icon {
   align-items: center;
-  background-color: var(--sendbird-light-background-50);
+  background-color: var(--sendbird-light-ondark-01);
   border-radius: 50%;
   display: inline-flex;
   height: 56px;

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -263,7 +263,7 @@ export default function ParentMessageInfoItem({
               <div className="sendbird-parent-message-info-item__thumbnail-message__icon-wrapper__icon">
                 <Icon
                   type={isVideoMessage(message) ? IconTypes.PLAY : IconTypes.GIF}
-                  fillColor={IconColors.GRAY}
+                  fillColor={IconColors.ON_BACKGROUND_2}
                   width="34px"
                   height="34px"
                 />

--- a/src/ui/ImageRenderer/index.scss
+++ b/src/ui/ImageRenderer/index.scss
@@ -46,6 +46,6 @@
     width: 56px;
     height: 56px;
     border-radius: 50%;
-    background-color: var(--sendbird-light-background-50);
+    background-color: var(--sendbird-light-ondark-01);
   }
 }

--- a/src/ui/ImageRenderer/index.tsx
+++ b/src/ui/ImageRenderer/index.tsx
@@ -156,7 +156,7 @@ const ImageRenderer = ({
             <div className="sendbird-multiple-files-image-renderer__icon-wrapper__icon">
               <Icon
                 type={IconTypes.GIF}
-                fillColor={IconColors.GRAY}
+                fillColor={IconColors.ON_BACKGROUND_2}
                 width="34px"
                 height="34px"
               />

--- a/src/ui/QuoteMessage/index.tsx
+++ b/src/ui/QuoteMessage/index.tsx
@@ -162,7 +162,7 @@ export default function QuoteMessage({
                   <div className="sendbird-quote-message__replied-message__thumbnail-message__cover__icon">
                     <Icon
                       type={IconTypes.PLAY}
-                      fillColor={IconColors.GRAY}
+                      fillColor={IconColors.ON_BACKGROUND_2}
                       width="14px"
                       height="14px"
                     />
@@ -175,7 +175,7 @@ export default function QuoteMessage({
                 <div className="sendbird-quote-message__replied-message__thumbnail-message__cover__icon">
                   <Icon
                     type={IconTypes.GIF}
-                    fillColor={IconColors.GRAY}
+                    fillColor={IconColors.ON_BACKGROUND_2}
                     width="14px"
                     height="14px"
                   />

--- a/src/ui/ThumbnailMessageItemBody/index.scss
+++ b/src/ui/ThumbnailMessageItemBody/index.scss
@@ -77,7 +77,7 @@
       width: 56px;
       height: 56px;
       border-radius: 50%;
-      background-color: var(--sendbird-light-background-50);
+      background-color: var(--sendbird-light-ondark-01);
     }
   }
 }

--- a/src/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/ui/ThumbnailMessageItemBody/index.tsx
@@ -80,7 +80,7 @@ export default function ThumbnailMessageItemBody({
             <div className="sendbird-thumbnail-message-item-body__icon-wrapper__icon">
               <Icon
                 type={isVideoMessage(message) ? IconTypes.PLAY : IconTypes.GIF}
-                fillColor={IconColors.GRAY}
+                fillColor={IconColors.ON_BACKGROUND_2}
                 width="34px"
                 height="34px"
               />


### PR DESCRIPTION
Update GIF/Video icon color.

Fixes: [UIKIT-4499](https://sendbird.atlassian.net/browse/UIKIT-4499)

[UIKIT-4499]: https://sendbird.atlassian.net/browse/UIKIT-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1237" alt="Screen Shot 2023-09-22 at 3 08 22 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/17337e80-7b1a-4fe5-82d9-1245a6389982">
