### PR TITLE
bug-fix: Channel preview of lastMessage being MFM should display first file type not first file name.

### DIFF
--- a/src/modules/ChannelList/components/ChannelPreview/__tests__/ChannelPreview.spec.js
+++ b/src/modules/ChannelList/components/ChannelPreview/__tests__/ChannelPreview.spec.js
@@ -39,6 +39,7 @@ describe('ChannelPreview', () => {
     const channel4 = {
       lastMessage: {
         name: 'file1',
+        type: 'wefiwfiwj',
         isUserMessage: () => false,
         isFileMessage: () => true,
         isMultipleFilesMessage: () => false,
@@ -46,7 +47,28 @@ describe('ChannelPreview', () => {
     };
     const channel5 = {
       lastMessage: {
-        fileInfoList: [{ fileName: 'file1' }, { fileName: 'file2' }],
+        name: 'file2',
+        type: 'image/jpg',
+        isUserMessage: () => false,
+        isFileMessage: () => true,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel6 = {
+      lastMessage: {
+        name: 'file3',
+        type: 'image/gif',
+        isUserMessage: () => false,
+        isFileMessage: () => true,
+        isMultipleFilesMessage: () => false,
+      }
+    };
+    const channel7 = {
+      lastMessage: {
+        fileInfoList: [
+          { fileName: 'file1', mimeType: 'video/mp4', },
+          { fileName: 'file2', mimeType: 'image/gif', }
+        ],
         isUserMessage: () => false,
         isFileMessage: () => false,
         isMultipleFilesMessage: () => true,
@@ -63,10 +85,16 @@ describe('ChannelPreview', () => {
     ).toBe(text);
     expect(
       getLastMessage(channel4)
-    ).toBe('file1');
+    ).toBe('File');
     expect(
       getLastMessage(channel5)
-    ).toBe('file1');
+    ).toBe('Photo');
+    expect(
+      getLastMessage(channel6)
+    ).toBe('GIF');
+    expect(
+      getLastMessage(channel7)
+    ).toBe('Video');
   });
 
   test('utils/getChannelTitle returns channelTitle', function () {

--- a/src/modules/ChannelList/components/ChannelPreview/utils.js
+++ b/src/modules/ChannelList/components/ChannelPreview/utils.js
@@ -2,8 +2,10 @@ import isToday from 'date-fns/isToday';
 import format from 'date-fns/format';
 import isThisYear from 'date-fns/isThisYear';
 import isYesterday from 'date-fns/isYesterday';
-import { truncateString } from '../../../../utils';
+import {isGif, isImage, isVideo, truncateString} from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
+import {match} from "ts-pattern";
+import {getSupportingFileType} from "../../../../ui/OpenchannelThumbnailMessage/utils";
 
 /* eslint-disable default-param-last */
 export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelStringSet) => {
@@ -50,18 +52,26 @@ export const getTotalMembers = (channel) => (
     : 0
 );
 
+const getChannelPreviewFileDisplayString = (mimeType) => {
+  return mimeType
+    ? match(mimeType)
+      .when(isGif, () => 'GIF')
+      .when(isImage, () => 'Photo')
+      .when(isVideo, () => 'Video')
+      .otherwise(() => 'File')
+    : 'File';
+}
+
 const getPrettyLastMessage = (message = null) => {
-  const MAXLEN = 30;
   if (!message) return '';
   if (message.isFileMessage()) {
-    return truncateString(message.name, MAXLEN);
+    return getChannelPreviewFileDisplayString(message.type);
   }
   if (message.isMultipleFilesMessage()) {
     const { fileInfoList } = message;
-    if (fileInfoList.length > 0) {
-      return truncateString(fileInfoList[0].fileName, MAXLEN);
-    }
-    return '';
+    return fileInfoList.length > 0
+      ? getChannelPreviewFileDisplayString(fileInfoList[0].mimeType)
+      : '';
   }
   return message.message ?? '';
 };

--- a/src/modules/ChannelList/components/ChannelPreview/utils.js
+++ b/src/modules/ChannelList/components/ChannelPreview/utils.js
@@ -2,10 +2,10 @@ import isToday from 'date-fns/isToday';
 import format from 'date-fns/format';
 import isThisYear from 'date-fns/isThisYear';
 import isYesterday from 'date-fns/isYesterday';
-import {isGif, isImage, isVideo, truncateString} from '../../../../utils';
+import {
+  isGif, isImage, isVideo,
+} from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
-import {match} from "ts-pattern";
-import {getSupportingFileType} from "../../../../ui/OpenchannelThumbnailMessage/utils";
 
 /* eslint-disable default-param-last */
 export const getChannelTitle = (channel = {}, currentUserId, stringSet = LabelStringSet) => {
@@ -53,14 +53,17 @@ export const getTotalMembers = (channel) => (
 );
 
 const getChannelPreviewFileDisplayString = (mimeType) => {
-  return mimeType
-    ? match(mimeType)
-      .when(isGif, () => 'GIF')
-      .when(isImage, () => 'Photo')
-      .when(isVideo, () => 'Video')
-      .otherwise(() => 'File')
-    : 'File';
-}
+  if (isGif(mimeType)) {
+    return 'GIF';
+  }
+  if (isImage(mimeType)) {
+    return 'Photo';
+  }
+  if (isVideo(mimeType)) {
+    return 'Video';
+  }
+  return 'File';
+};
 
 const getPrettyLastMessage = (message = null) => {
   if (!message) return '';


### PR DESCRIPTION
bug-fix: Channel preview of lastMessage being MFM should display first file type not first file name.

Fixes: [UIKIT-4512](https://sendbird.atlassian.net/browse/UIKIT-4512)

TOBE
<img width="593" alt="Screen Shot 2023-09-25 at 2 33 28 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/a7b0be29-bc0b-4cfe-aa42-ef9aff298812">

THIS PR
<img width="481" alt="Screen Shot 2023-09-25 at 2 49 38 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/a7242db0-cdcd-4f25-92f0-47275f4511b0">
<img width="1237" alt="Screen Shot 2023-09-25 at 2 49 48 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/d8c0964e-2276-4b63-ba58-a45ad76aeb66">


[UIKIT-4512]: https://sendbird.atlassian.net/browse/UIKIT-4512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ