### PR TITLE
fix: wrong isResendable cond check in openChannel/useResendMessageCallback 

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.9.9",
+    "@sendbird/chat": "^4.9.13",
     "@sendbird/uikit-tools": "0.0.1-alpha.40",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",

--- a/src/modules/Channel/context/hooks/useResendMessageCallback.js
+++ b/src/modules/Channel/context/hooks/useResendMessageCallback.js
@@ -11,7 +11,7 @@ function useResendMessageCallback({
   return useCallback((failedMessage) => {
     logger.info('Channel: Resending message has started', failedMessage);
     const { messageType, file } = failedMessage;
-    if (failedMessage?.isResendable) {
+    if (typeof failedMessage?.isResendable === 'boolean') {
       // Move the logic setting sendingStatus to pending into the reducer
       // eslint-disable-next-line no-param-reassign
       failedMessage.requestState = 'pending';

--- a/src/modules/Channel/context/hooks/useResendMessageCallback.js
+++ b/src/modules/Channel/context/hooks/useResendMessageCallback.js
@@ -11,7 +11,7 @@ function useResendMessageCallback({
   return useCallback((failedMessage) => {
     logger.info('Channel: Resending message has started', failedMessage);
     const { messageType, file } = failedMessage;
-    if (typeof failedMessage?.isResendable === 'boolean') {
+    if (failedMessage?.isResendable) {
       // Move the logic setting sendingStatus to pending into the reducer
       // eslint-disable-next-line no-param-reassign
       failedMessage.requestState = 'pending';

--- a/src/modules/OpenChannel/context/hooks/useResendMessageCallback.ts
+++ b/src/modules/OpenChannel/context/hooks/useResendMessageCallback.ts
@@ -25,7 +25,7 @@ function useResendMessageCallback(
     logger.info('OpenChannel | useResendMessageCallback: Resending message has started', failedMessage);
     // eslint-disable-next-line no-param-reassign
     const { messageType, file } = failedMessage as FileMessage;
-    if (typeof failedMessage?.isResendable === 'boolean') {
+    if (typeof failedMessage?.isResendable === 'boolean' && failedMessage.isResendable) {
       // eslint-disable-next-line no-param-reassign
       failedMessage.requestState = 'pending';
       messagesDispatcher({

--- a/src/modules/OpenChannel/context/hooks/useResendMessageCallback.ts
+++ b/src/modules/OpenChannel/context/hooks/useResendMessageCallback.ts
@@ -25,7 +25,7 @@ function useResendMessageCallback(
     logger.info('OpenChannel | useResendMessageCallback: Resending message has started', failedMessage);
     // eslint-disable-next-line no-param-reassign
     const { messageType, file } = failedMessage as FileMessage;
-    if (failedMessage && typeof failedMessage.isResendable === 'function' && failedMessage.isResendable) {
+    if (typeof failedMessage?.isResendable === 'boolean') {
       // eslint-disable-next-line no-param-reassign
       failedMessage.requestState = 'pending';
       messagesDispatcher({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,15 +2430,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat@npm:^4.9.9":
-  version: 4.9.9
-  resolution: "@sendbird/chat@npm:4.9.9"
+"@sendbird/chat@npm:^4.9.13":
+  version: 4.9.13
+  resolution: "@sendbird/chat@npm:4.9.13"
   peerDependencies:
     "@react-native-async-storage/async-storage": ^1.17.6
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
-  checksum: 74c327c62f3f898d84a75948d53706a9ec5fa960a787f36eff8beb9e6587543adb842245c6764bb862e9933e234f39208150140887d45f360a5dd69fe4738f7b
+  checksum: 22a548c399b5c91d12b3cc170f39e9c390f00b782fb0f39bf899934573ee4b000232a74940e7a5f0b6979cb64e2ac4b5ebe9ecb2693a1b7b863a3081f6a3f2d2
   languageName: node
   linkType: hard
 
@@ -2459,7 +2459,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^7.1.3
     "@rollup/plugin-replace": ^2.4.2
     "@rollup/plugin-typescript": ^8.2.1
-    "@sendbird/chat": ^4.9.9
+    "@sendbird/chat": ^4.9.13
     "@sendbird/uikit-tools": 0.0.1-alpha.40
     "@storybook/addon-actions": ^6.5.10
     "@storybook/addon-docs": ^6.5.10


### PR DESCRIPTION
~Fixes https://sendbird.atlassian.net/browse/CLNP-905~

`message.isResendable` type is function, and its return type is boolean.  So the way we've checked the value like 
```
if (failedMessage?.isResendable) { ... }
```

has been wrong but it should be if we really want to check its existence. 
```
if (typeof failedMessage?.isResendable === 'boolean') { ... }
```