### PR TITLE
fix: Image, video, and file transfer is not possible in open channels

### DIFF
--- a/src/modules/OpenChannel/context/hooks/useFileUploadCallback.ts
+++ b/src/modules/OpenChannel/context/hooks/useFileUploadCallback.ts
@@ -22,7 +22,7 @@ interface StaticParams {
   messagesDispatcher: (props: { type: string, payload: any }) => void;
 }
 
-type CallbackReturn = (file: File) => void;
+type CallbackReturn = (files: Array<File> | File) => void;
 
 function useFileUploadCallback({
   currentOpenChannel,
@@ -32,8 +32,13 @@ function useFileUploadCallback({
 }: DynamicParams,
 { sdk, logger, messagesDispatcher, scrollRef }: StaticParams,
 ): CallbackReturn {
-  return useCallback((file) => {
+  return useCallback((files) => {
     if (sdk) {
+      /**
+       * OpenChannel does not currently support file lists.
+       * However, this change is made to maintain interface consistency with group channels.
+       */
+      const file = Array.isArray(files) ? files[0] : files;
       const {
         compressionRate,
         resizingWidth,

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -521,7 +521,8 @@ const MessageInput = React.forwardRef((props, ref) => {
                   ref={fileInputRef}
                   // It will affect to <Channel /> and <Thread />
                   onChange={(event) => {
-                    onFileUpload([...event.currentTarget.files]);
+                    const { files } = event.currentTarget;
+                    onFileUpload(files && files.length === 1 ? files[0] : [...files]);
                     event.target.value = '';
                   }}
                   accept={getMimeTypesUIKitAccepts(acceptableMimeTypes)}


### PR DESCRIPTION
* fix: accepting parameter type to Array<File> or File in the useFileUploadCallback