### PR TITLE
[CLNP-1150] fix: Textbox placeholder disappears when message is cleared in Safari

### DIFF
--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -124,14 +124,30 @@ describe('ui/MessageInput', () => {
     ).toBe(0);
   });
 
-  it("should not render the placeholder text if only white spaces are present", () => {
-    const { container } = render(
-      <MessageInput onSendMessage={noop} value="   " />
-    );
+  it("should not render the placeholder text if only white spaces are present", async () => {
+    const textRef = { current: { textContent: null } };
+    const mockText = '   ';
+    const { container, rerender } = render(<MessageInput ref={textRef} />);
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, mockText);
+    expect(input.textContent).toBe(mockText);
+
+    await rerender(<MessageInput ref={textRef} />);
     expect(
       container.getElementsByClassName("sendbird-message-input--placeholder")
         .length
     ).toBe(0);
+  });
+
+  it("should render the placeholder text if there's no text in the input", async() => {
+    const textRef = { current: { textContent: null } };
+    const { container } = render(<MessageInput ref={textRef} />);
+
+    expect(
+      container.getElementsByClassName("sendbird-message-input--placeholder")
+        .length
+    ).toBe(1);
   });
 
   it('should call sendMessage with valid string', async () => {

--- a/src/ui/MessageInput/index.jsx
+++ b/src/ui/MessageInput/index.jsx
@@ -397,7 +397,6 @@ const MessageInput = React.forwardRef((props, ref) => {
     setHeight,
   });
 
-  const textField = ref?.current;
   return (
     <form
       className={getClassName([
@@ -427,7 +426,7 @@ const MessageInput = React.forwardRef((props, ref) => {
               e.preventDefault();
             } else {
               if (!e.shiftKey && e.key === MessageInputKeys.Enter
-                && textField?.textContent?.trim().length > 0
+                && ref?.current?.textContent?.trim().length > 0
                 && e?.nativeEvent?.isComposing !== true
               ) {
                 e.preventDefault();
@@ -456,13 +455,13 @@ const MessageInput = React.forwardRef((props, ref) => {
           onInput={() => {
             setHeight();
             onStartTyping();
-            setIsInput(textField?.textContent?.trim().length > 0);
+            setIsInput(ref?.current?.textContent?.trim().length > 0);
             useMentionedLabelDetection();
           }}
           onPaste={onPaste}
         />
         {/* placeholder */}
-        {textField?.innerText?.length === 0 && (
+        {(ref?.current?.textContent?.length ?? 0) === 0 && (
           <Label
             className="sendbird-message-input--placeholder"
             type={LabelTypography.BODY_1}


### PR DESCRIPTION
Resolves https://sendbird.atlassian.net/browse/SBISSUE-13846

This issue happens only in Safari.

#### AS-IS 
![asis](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/2faf8f9f-b16c-44a1-bc3f-eb54e3aae871)

If some texts are removed from the input box, the placeholder msg just disappears. 


#### TO-BE
![tobe](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/daecea36-f269-4bc5-b448-8f2f05786040)

With this patch, the placeholder msg should be returned if nothing left in the text field. This is the commonly expected behavior. 


