### PR TITLE
release: 3.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog - v3
-
-## [v3.6.9] (Oct 6 2023)
+## [v3.6.10] (Oct 11 2023)
 ### Fixes:
 * (in Safari) Display the placeholder of the MessageInput when the input text is cleared
 * Remove duplicated CSS line
+* (in iOS) fix focusing on the chat screen starts from the top in Mobile device
+* Move to the top in the ChannelList when the current user but a different peer sends a message
+  
+## [v3.6.9] (Oct 6 2023)
+### Fixes:
 * Able to see the quoted messages regardless of the ReplyType
 * Improve the types of the function props of `ui/MessageInput` component
   ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.6.9",
+  "version": "3.6.10",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -56,7 +56,6 @@ const MessageList: React.FC<MessageListProps> = ({
     replyType,
     loading,
     isScrolled,
-    setIsScrolled,
     unreadSince,
   } = useChannelContext();
 


### PR DESCRIPTION
## [v3.6.10] (Oct 11 2023)
### Fixes:
* (in Safari) Display the placeholder of the MessageInput when the input text is cleared
* Remove duplicated CSS line
* (in iOS) fix focusing on the chat screen starts from the top in Mobile device