### PR TITLE
fix: Move to the top in the ChannelList

### DIFF
--- a/src/modules/ChannelList/dux/reducers.js
+++ b/src/modules/ChannelList/dux/reducers.js
@@ -160,7 +160,7 @@ export default function reducer(state, action) {
             allChannels: getChannelsWithUpsertedChannel(allChannels, channel),
           };
         }
-        const nextChannel = (channel?.url === state.currentChannel?.url)
+        const nextChannel = (channel?.url === state?.currentChannel?.url)
           ? state.allChannels[state.allChannels[0].url === channel?.url ? 1 : 0]
           // if coming channel is first of channel list, current channel will be the next one
           : state.currentChannel;
@@ -170,16 +170,17 @@ export default function reducer(state, action) {
           allChannels: state.allChannels.filter(({ url }) => url !== channel?.url),
         };
       }
-      // if its only an unread message count change, dont push to top
-      if (unreadMessageCount === 0) {
-        const currentChannel = allChannels.find(({ url }) => url === channel?.url);
-        const currentUnreadCount = currentChannel && currentChannel.unreadMessageCount;
-        if (currentUnreadCount === 0) {
-          return {
-            ...state,
-            allChannels: state.allChannels.map((ch) => (ch.url === channel?.url ? channel : ch)),
-          };
-        }
+
+      if (
+        unreadMessageCount === 0
+        // Do not move to the top when marking as read the channel
+        && channel?.lastMessage?.sender?.userId !== state.currentUserId
+        // Move to the top when the current user but different peer sends the message
+      ) {
+        return {
+          ...state,
+          allChannels: state.allChannels.map((ch) => (ch.url === channel?.url ? channel : ch)),
+        };
       }
       return {
         ...state,


### PR DESCRIPTION
[SBISSUE-13601](https://sendbird.atlassian.net/browse/SBISSUE-13601)

### Issue
* The channel item hasn't moved to the top when the current user sends messages from different devices

### Fix
* Move to the top in the ChannelList when the current user but a different peer sends a message

[SBISSUE-13601]: https://sendbird.atlassian.net/browse/SBISSUE-13601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ