### PR TITLE
bug-fix: Display "n Photos" for MFM in quote reply

### DIFF
--- a/src/ui/QuoteMessageInput/index.tsx
+++ b/src/ui/QuoteMessageInput/index.tsx
@@ -72,7 +72,9 @@ export default function QuoteMessageInput({
           {isGifMessage(fileMessage) && stringSet.QUOTE_MESSAGE_INPUT__FILE_TYPE_GIF}
           {isUserMessage(replyingMessage as UserMessage) && (replyingMessage as UserMessage).message}
           {getUIKitMessageType(replyingMessage) === UIKitMessageTypes.FILE && getMessageFirstFileName(fileMessage)}
-          {isMultipleFilesMessage(replyingMessage as CoreMessageType) && getMessageFirstFileName(fileMessage)}
+          {
+            isMultipleFilesMessage(replyingMessage as CoreMessageType)
+            && `${(fileMessage as MultipleFilesMessage).fileInfoList.length} Photos`}
           {isVoiceMessage(replyingMessage as FileMessage) && stringSet.VOICE_MESSAGE}
         </Label>
       </div>


### PR DESCRIPTION
Fixes: [UIKIT-4524](https://sendbird.atlassian.net/browse/UIKIT-4524)

<img width="800" alt="Screen Shot 2023-10-17 at 3 06 28 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/4cd1ef6d-0b1d-4549-8616-594ab3e5f6e4">
<img width="508" alt="Screen Shot 2023-10-17 at 3 06 13 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/16806397/edb49f42-9ead-4575-96e5-299a6fe5a711">

[UIKIT-4524]: https://sendbird.atlassian.net/browse/UIKIT-4524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ