### PR TITLE
fix: cjs entry path and package.json

### DIFF
--- a/scripts/package.template.json
+++ b/scripts/package.template.json
@@ -19,7 +19,7 @@
     "API"
   ],
   "type": "module",
-  "main": "dist/cjs/index.js",
+  "main": "cjs/index.js",
   "style": "dist/index.css",
   "typings": "index.d.ts",
   "module": "index.js",

--- a/scripts/post_build.js
+++ b/scripts/post_build.js
@@ -52,17 +52,9 @@ function movePackageJSON() {
 
 function copyCJSPackageJSON() {
   const packageJSONDistPath = path.resolve(getDistPath('/cjs'), 'package.json');
-  const cleanedUpPackageJSON = cleanupPackageJSON(packageJson);
-
-  delete cleanedUpPackageJSON.files;
-  delete cleanedUpPackageJSON.scripts;
-  delete cleanedUpPackageJSON.devDependencies;
-  delete cleanedUpPackageJSON.module;
-
   fs.writeFileSync(
     packageJSONDistPath,
     JSON.stringify({
-      ...cleanedUpPackageJSON,
       main: 'index.js',
       type: 'commonjs',
       typings: '../index.d.ts',


### PR DESCRIPTION
- Fix CJS entry file path
```
@sendbird/uikit-react
├── cjs
│   └── index.js  >> should point here (cjs/index.js)
└── dist  >> but, point here (dist/cjs/index.js)
    └── index.css 
```
- Remove unused fields in `cjs/package.json`
![image](https://github.com/sendbird/sendbird-uikit-react/assets/26326015/c6d23590-e1e5-4b77-a134-c0310560af9a)
