### PR TITLE
bug-fix: Allow delete failed messages when offline third refix.

### DIFF
--- a/src/ui/MessageItemMenu/index.tsx
+++ b/src/ui/MessageItemMenu/index.tsx
@@ -212,12 +212,9 @@ export default function MessageItemMenu({
                 <MenuItem
                   className="sendbird-message-item-menu__list__menu-item menu-item-delete"
                   onClick={() => {
-                    if (disabled) {
-                      return;
-                    }
                     if (isFailedMessage(message)) {
                       channelStore?.deleteMessage?.(message);
-                    } else {
+                    } else if (!disabled) {
                       showRemove(true);
                       closeDropdown();
                     }


### PR DESCRIPTION
Fixes: [UIKIT-4535](https://sendbird.atlassian.net/browse/UIKIT-4535)

- if sending status is failed, delete without propmpt irregardless of network connection state.
- if all other sending status, show delete prompt IFF disabled is false.

[UIKIT-4535]: https://sendbird.atlassian.net/browse/UIKIT-4535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ