### PR TITLE
feat: apply localThreadMessages to the ThreadContext

### DIFF
--- a/scripts/index.d.ts
+++ b/scripts/index.d.ts
@@ -1122,7 +1122,8 @@ declare module "SendbirdUIKitGlobal" {
 
   export interface ThreadContextInitialState {
     currentChannel: GroupChannel;
-    allThreadMessages: Array<BaseMessage>;
+    allThreadMessages: Array<CoreMessageType>;
+    localThreadMessages: Array<CoreMessageType>;
     parentMessage: SendableMessageType;
     channelState: ChannelStateTypes;
     parentMessageState: ParentMessageStateTypes;

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -175,7 +175,6 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
           MemorizedThreadList || (
             <ThreadList
               className="sendbird-thread-ui__thread-list"
-              allThreadMessages={allThreadMessages}
               renderMessage={renderMessage}
               renderCustomSeparator={renderCustomSeparator}
               scrollRef={scrollRef}

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -107,6 +107,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
   const {
     currentChannel,
     allThreadMessages,
+    localThreadMessages,
     parentMessage,
     channelState,
     threadListState,
@@ -234,6 +235,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
         // ThreadContextInitialState
         currentChannel,
         allThreadMessages,
+        localThreadMessages,
         parentMessage,
         channelState,
         threadListState,

--- a/src/modules/Thread/context/dux/initialState.ts
+++ b/src/modules/Thread/context/dux/initialState.ts
@@ -1,16 +1,16 @@
 import { EmojiContainer } from '@sendbird/chat';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
-import { BaseMessage } from '@sendbird/chat/message';
 import {
   ChannelStateTypes,
   ParentMessageStateTypes,
   ThreadListStateTypes,
 } from '../../types';
-import { SendableMessageType } from '../../../../utils';
+import { CoreMessageType, SendableMessageType } from '../../../../utils';
 
 export interface ThreadContextInitialState {
   currentChannel: GroupChannel;
-  allThreadMessages: Array<BaseMessage>;
+  allThreadMessages: Array<CoreMessageType>;
+  localThreadMessages: Array<CoreMessageType>;
   parentMessage: SendableMessageType;
   channelState: ChannelStateTypes;
   parentMessageState: ParentMessageStateTypes;
@@ -26,6 +26,7 @@ export interface ThreadContextInitialState {
 const initialState: ThreadContextInitialState = {
   currentChannel: null,
   allThreadMessages: [],
+  localThreadMessages: [],
   parentMessage: null,
   channelState: ChannelStateTypes.NIL,
   parentMessageState: ParentMessageStateTypes.NIL,

--- a/src/modules/Thread/context/dux/reducer.ts
+++ b/src/modules/Thread/context/dux/reducer.ts
@@ -205,12 +205,15 @@ export default function reducer(
         allThreadMessages: state.allThreadMessages?.filter((msg) => (
           msg?.messageId !== messageId
         )),
+        localThreadMessages: state.localThreadMessages?.filter((msg) => (
+          msg?.messageId !== messageId
+        )),
       };
     }
     case actionTypes.ON_MESSAGE_DELETED_BY_REQ_ID: {
       return {
         ...state,
-        allThreadMessages: state.allThreadMessages.filter((m) => (
+        localThreadMessages: state.localThreadMessages.filter((m) => (
           !compareIds((m as SendableMessageType).reqId, action.payload)
         )),
       };
@@ -311,30 +314,32 @@ export default function reducer(
       const { message } = action.payload;
       return {
         ...state,
-        allThreadMessages: [
-          ...state.allThreadMessages,
+        localThreadMessages: [
+          ...state.localThreadMessages,
           message,
         ],
       };
     }
     case actionTypes.SEND_MESSAGE_SUCESS: {
       const { message } = action.payload;
-      const filteredThreadMessages = state.allThreadMessages.filter((m) => (
-        !compareIds((m as UserMessage)?.reqId, message?.reqId)
-      ));
       return {
         ...state,
         allThreadMessages: [
-          ...filteredThreadMessages,
+          ...state.allThreadMessages.filter((m) => (
+            !compareIds((m as UserMessage)?.reqId, message?.reqId)
+          )),
           message,
         ],
+        localThreadMessages: state.localThreadMessages.filter((m) => (
+          !compareIds((m as UserMessage)?.reqId, message?.reqId)
+        )),
       };
     }
     case actionTypes.SEND_MESSAGE_FAILURE: {
       const { message } = action.payload;
       return {
         ...state,
-        allThreadMessages: state.allThreadMessages.map((m) => (
+        localThreadMessages: state.localThreadMessages.map((m) => (
           compareIds((m as UserMessage)?.reqId, message?.reqId)
             ? message
             : m

--- a/src/modules/Thread/context/hooks/useSendUserMessageCallback.ts
+++ b/src/modules/Thread/context/hooks/useSendUserMessageCallback.ts
@@ -81,10 +81,6 @@ export default function useSendUserMessageCallback({
         })
         .onSucceeded((message) => {
           logger.info('Thread | useSendUserMessageCallback: Sending user message succeeded.', message);
-          threadDispatcher({
-            type: ThreadContextActionTypes.SEND_MESSAGE_SUCESS,
-            payload: { message },
-          });
           // because Thread doesn't subscribe SEND_USER_MESSAGE
           pubSub.publish(topics.SEND_USER_MESSAGE, {
             channel: currentChannel,


### PR DESCRIPTION
Fix
* Divide the `allThreadMessages` into the `allThreadMessages` and `localThreadMessages`
  * The `localThreadMessages` includes the pending and failed messages
  * The `allThreadMessages` won't include those sending status messages