### PR TITLE
fix: Apply isMultipleFilesMessageEnabled to channel and thread

### DIFF
--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -177,7 +177,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     children,
     isReactionEnabled,
     isMessageGroupingEnabled = true,
-    isMultipleFilesMessageEnabled = false,
+    isMultipleFilesMessageEnabled,
     showSearchIcon,
     animatedMessage,
     highlightedMessage,

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -76,6 +76,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
     onBeforeSendFileMessage,
     onBeforeSendVoiceMessage,
     onBeforeSendMultipleFilesMessage,
+    isMultipleFilesMessageEnabled,
     // User Profile
     disableUserProfile,
     renderUserProfile,
@@ -233,6 +234,7 @@ export const ThreadProvider: React.FC<ThreadProviderProps> = (props: ThreadProvi
         message: propsMessage,
         onHeaderActionClick,
         onMoveToParentMessage,
+        isMultipleFilesMessageEnabled,
         // ThreadContextInitialState
         currentChannel,
         allThreadMessages,


### PR DESCRIPTION
* fix: toss isMultipleFilesMessageEnabled props in ThreadProvider
* fix: do not set the default value of isMultipleFilesMessageEnabled in Module