### PR TITLE
fix: Remove the duplicated UserProfileProvider from OpenChannelSettings

### DIFF
--- a/src/modules/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
+++ b/src/modules/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
@@ -45,42 +45,40 @@ const OpenChannelUI: React.FC<OpenChannelUIProps> = ({
     );
   }
   return (
-    <UserProfileProvider isOpenChannel>
-      <div className='sendbird-openchannel-settings'>
-        {
-          channel?.isOperator(user) && (
-            renderOperatorUI?.() || (
-              <OperatorUI />
-            )
+    <div className='sendbird-openchannel-settings'>
+      {
+        channel?.isOperator(user) && (
+          renderOperatorUI?.() || (
+            <OperatorUI />
           )
-        }
-        {
-          !(channel?.isOperator(user)) && (
-            <div className="sendbird-openchannel-settings__participant">
-              <div className="sendbird-openchannel-settings__header">
-                <Label type={LabelTypography.H_2} color={LabelColors.ONBACKGROUND_1}>
-                  {stringSet.OPEN_CHANNEL_SETTINGS__PARTICIPANTS_TITLE}
-                </Label>
-                <Icon
-                  type={IconTypes.CLOSE}
-                  className="sendbird-openchannel-settings__close-icon"
-                  height="24px"
-                  width="24px"
-                  onClick={() => {
-                    onCloseClick();
-                  }}
-                />
-              </div>
-              {
-                renderParticipantList?.() || (
-                  <ParticipantUI />
-                )
-              }
+        )
+      }
+      {
+        !(channel?.isOperator(user)) && (
+          <div className="sendbird-openchannel-settings__participant">
+            <div className="sendbird-openchannel-settings__header">
+              <Label type={LabelTypography.H_2} color={LabelColors.ONBACKGROUND_1}>
+                {stringSet.OPEN_CHANNEL_SETTINGS__PARTICIPANTS_TITLE}
+              </Label>
+              <Icon
+                type={IconTypes.CLOSE}
+                className="sendbird-openchannel-settings__close-icon"
+                height="24px"
+                width="24px"
+                onClick={() => {
+                  onCloseClick();
+                }}
+              />
             </div>
-          )
-        }
-      </div>
-    </UserProfileProvider>
+            {
+              renderParticipantList?.() || (
+                <ParticipantUI />
+              )
+            }
+          </div>
+        )
+      }
+    </div>
   );
 };
 

--- a/src/modules/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
+++ b/src/modules/OpenChannelSettings/components/OpenChannelSettingsUI/index.tsx
@@ -3,7 +3,6 @@ import './open-channel-ui.scss';
 import React, { useContext } from 'react';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useOpenChannelSettingsContext } from '../../context/OpenChannelSettingsProvider';
-import { UserProfileProvider } from '../../../../lib/UserProfileContext';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 
 import InvalidChannel from '../InvalidChannel';


### PR DESCRIPTION
### Issue
There has been UserProfileProvider in both places in the OpenChannelSettings module
1. OpenChannelSettingsProvider
2. OpenChannelSettingsUI

We applied the `renderUserProfile` props to the UserProfileProvider under the OpenChannelSettingsProvider
However, the other one under the OpenChannelSettingsUI blocked it.

### Fix
* remove the duplicated UserProfileProvider from OpenChannelSettings to apply the `renderUserProfile` props