### PR TITLE
fix: Remove a logic blocking adding an empty channel to the ChannelList

### DIFF
--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -140,9 +140,6 @@ export default function channelListReducer(
           const { allChannels = [], currentUserId, currentChannel, channelListQuery, disableAutoSelect } = state;
           const { unreadMessageCount } = channel;
 
-          // Do not display the channel when it's created (and not sent a message yet)
-          if (action.type === channelListActions.ON_USER_JOINED && !channel?.lastMessage) return state;
-
           if (channelListQuery) {
             if (filterChannelListParams(channelListQuery, channel, currentUserId)) {
               // Good to [add to/keep in] the ChannelList


### PR DESCRIPTION
[CLNP-1196](https://sendbird.atlassian.net/browse/CLNP-1196)

### Issue
We have blocked adding a new empty channel to the ChannelList. But it's not considered with the ChannelListQuery, and there was a use case that needed to add super group channels to the ChannelList.

It's fine to remove this logic because ChannelListQuery filters the empty channels by referring to its `includeEmpty` options.

### Fix
* Remove the logic blocking adding an empty channel to the ChannelList because the ChannelListQuery should judge it

[CLNP-1196]: https://sendbird.atlassian.net/browse/CLNP-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ