### PR TITLE
feat: export initialMessagesFetch callback from hook

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -59,6 +59,7 @@ export default {
   // Channel
   Channel: 'src/modules/Channel/index.tsx',
   'Channel/context': 'src/modules/Channel/context/ChannelProvider.tsx',
+  'Channel/hooks/useInitialMessagesFetch': 'src/modules/Channel/context/hooks/useInitialMessagesFetch.ts',
   'Channel/utils/getMessagePartsInfo': 'src/modules/Channel/components/MessageList/getMessagePartsInfo.ts',
   'Channel/utils/compareMessagesForGrouping': 'src/modules/Channel/context/compareMessagesForGrouping.ts',
   'Channel/components/ChannelHeader': 'src/modules/Channel/components/ChannelHeader/index.tsx',

--- a/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
+++ b/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
@@ -37,6 +37,13 @@ function useInitialMessagesFetch(
 ): () => void {
   const channelUrl = currentGroupChannel?.url;
 
+  /**
+   * useCallback(() => {}, [currentGroupChannel]) was buggy, that is why we did
+   * const channelUrl = currentGroupChannel && currentGroupChannel.url;
+   * useCallback(() => {}, [channelUrl])
+   * Again, this hook is supposed to execute when currentGroupChannel changes
+   * The 'channelUrl' here is not the same memory reference from Conversation.props
+   */
   const fetchMessages = useCallback(() => {
     logger.info('Channel useInitialMessagesFetch: Setup started', currentGroupChannel);
     setIsScrolled(false);
@@ -135,14 +142,6 @@ function useInitialMessagesFetch(
   }, [fetchMessages]);
 
   return fetchMessages;
-  /**
-   * Note - useEffect(() => {}, [currentGroupChannel])
-   * was buggy, that is why we did
-   * const channelUrl = currentGroupChannel && currentGroupChannel.url;
-   * useEffect(() => {}, [channelUrl])
-   * Again, this hook is supposed to execute when currentGroupChannel changes
-   * The 'channelUrl' here is not the same memory reference from Conversation.props
-   */
 }
 
 export default useInitialMessagesFetch;

--- a/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
+++ b/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { MessageListParams, ReplyType } from '@sendbird/chat/message';
 
 import * as utils from '../utils';
@@ -34,10 +34,10 @@ function useInitialMessagesFetch(
     setIsScrolled,
   }: UseInitialMessagesFetchOptions,
   { logger, scrollRef, messagesDispatcher }: UseInitialMessagesFetchParams,
-) {
+): () => void {
   const channelUrl = currentGroupChannel?.url;
 
-  useEffect(() => {
+  const fetchMessages = useCallback(() => {
     logger.info('Channel useInitialMessagesFetch: Setup started', currentGroupChannel);
     setIsScrolled(false);
     messagesDispatcher({
@@ -129,6 +129,12 @@ function useInitialMessagesFetch(
         });
     }
   }, [channelUrl, userFilledMessageListQuery, initialTimeStamp]);
+
+  useEffect(() => {
+    fetchMessages();
+  }, [fetchMessages]);
+
+  return fetchMessages;
   /**
    * Note - useEffect(() => {}, [currentGroupChannel])
    * was buggy, that is why we did


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-690

I took the logic inside of useInitialMessagesFetch's effect hook and made a callback function. And made the function to be returned from the hook to make it be from outside of UIKit. 

### tl;dr 
#### Before
```
function useInitialMessagesFetch(params): void {
  useEffect(() => {
     all the logics..
  }, [deps]}
}
```

#### After
```
function useInitialMessagesFetch(params): () => void {
  const fetchMessages() => useCallback(() => {
    all the logics..
  , [deps]}
  useEffect(() => {
     fetchMessages();
  }, [fetchMessages]}
  
  return fetchMessages;
}
```