### PR TITLE
fix: precise object dependency in effect hook

### DIFF
--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -221,7 +221,11 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
         sdk?.groupChannel?.removeGroupChannelHandler(sdkChannelHandlerId);
       }
     };
-  }, [sdkIntialized, userFilledChannelListQuery, sortChannelList]);
+  }, [
+    sdkIntialized,
+    sortChannelList,
+    Object.entries(userFilledChannelListQuery ?? {}).map(([key, value]) => key + value).join(),
+  ]);
 
   useEffect(() => {
     let typingHandlerId = '';


### PR DESCRIPTION
Found the issue while I was testing https://sendbird.atlassian.net/browse/SBISSUE-14025.

If user passes custom `queries(: object)` prop to Channel module, it'll cause unnecessary re-rendering in this effect hook. So I just made it more precise so the deps array don;t waste the resource to compare the object diff and make unnecessary side effect.