### PR TITLE
fix: add missing date locale to unread since string

### DIFF
--- a/src/modules/Channel/components/UnreadCount/index.tsx
+++ b/src/modules/Channel/components/UnreadCount/index.tsx
@@ -22,7 +22,7 @@ const UnreadCount: React.FC<UnreadCountProps> = ({
   onClick,
   lastReadAt,
 }: UnreadCountProps) => {
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet, dateLocale } = useContext(LocalizationContext);
 
   const unreadSince = useMemo(() => {
     // TODO: Remove this on v4
@@ -31,7 +31,7 @@ const UnreadCount: React.FC<UnreadCountProps> = ({
       timeArray?.splice(-2, 0, stringSet.CHANNEL__MESSAGE_LIST__NOTIFICATION__ON);
       return timeArray.join(' ');
     } else if (lastReadAt) {
-      return format(lastReadAt, stringSet.DATE_FORMAT__MESSAGE_LIST__NOTIFICATION__UNREAD_SINCE);
+      return format(lastReadAt, stringSet.DATE_FORMAT__MESSAGE_LIST__NOTIFICATION__UNREAD_SINCE, { locale: dateLocale });
     }
   }, [time, lastReadAt]);
 


### PR DESCRIPTION
## Changes
- add missing date locale in `DATE_FORMAT__MESSAGE_LIST__NOTIFICATION__UNREAD_SINCE`

ticket: [CLNP-1344]

[CLNP-1344]: https://sendbird.atlassian.net/browse/CLNP-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ