### PR TITLE
fix: Improve Image Compression feature

### DIFF
--- a/src/modules/Channel/components/MessageInput/index.tsx
+++ b/src/modules/Channel/components/MessageInput/index.tsx
@@ -117,7 +117,7 @@ const MessageInputWrapper = (
   }, [mentionedUserIds]);
 
   // MFM
-  const [handleUploadFiles] = useHandleUploadFiles({
+  const handleUploadFiles = useHandleUploadFiles({
     sendFileMessage,
     sendMultipleFilesMessage,
     quoteMessage,

--- a/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
+++ b/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
@@ -11,7 +11,7 @@ import { ButtonTypes } from '../../../../ui/Button';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import { ModalFooter } from '../../../../ui/Modal';
 import { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
-import { compressImages } from '../../../../utils/compressImage';
+import { compressImages } from '../../../../utils/compressImages';
 
 /**
  * The handleUploadFiles is a function sending a FileMessage and MultipleFilesMessage

--- a/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
+++ b/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
@@ -94,12 +94,12 @@ export const useHandleUploadFiles = ({
     }
 
     // Image Compression
-    const { compressedImages, notCompressedFiles } = await compressImages({
+    const { compressedFiles } = await compressImages({
       files,
       imageCompression,
       logger,
     });
-    const sendingFiles = compressedImages.concat(notCompressedFiles);
+    const sendingFiles = compressedFiles;
 
     // Send File Message
     if (sendingFiles.length === 1) {

--- a/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
+++ b/src/modules/Channel/components/MessageInput/useHandleUploadFiles.tsx
@@ -11,6 +11,7 @@ import { ButtonTypes } from '../../../../ui/Button';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import { ModalFooter } from '../../../../ui/Modal';
 import { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
+import { compressImages } from '../../../../utils/compressImage';
 
 /**
  * The handleUploadFiles is a function sending a FileMessage and MultipleFilesMessage
@@ -25,7 +26,6 @@ interface useHandleUploadFilesDynamicProps {
 interface useHandleUploadFilesStaticProps {
   logger: Logger;
 }
-export type HandleUploadFunctionType = (files: File[]) => void;
 
 export const useHandleUploadFiles = ({
   sendFileMessage,
@@ -33,15 +33,16 @@ export const useHandleUploadFiles = ({
   quoteMessage,
 }: useHandleUploadFilesDynamicProps, {
   logger,
-}: useHandleUploadFilesStaticProps): Array<HandleUploadFunctionType> => {
+}: useHandleUploadFilesStaticProps) => {
   const { stringSet } = useLocalization();
   const { config } = useSendbirdStateContext();
+  const { imageCompression } = config;
   const uikitUploadSizeLimit = config?.uikitUploadSizeLimit;
   const uikitMultipleFilesMessageLimit = config?.uikitMultipleFilesMessageLimit;
   const { openModal } = useGlobalModalContext();
 
-  const handleUploadFiles = useCallback((files: File[]) => {
-    // Validate Paremeters
+  const handleUploadFiles = useCallback(async (files: File[]) => {
+    // Validate Parameters
     if (!sendFileMessage || !sendMultipleFilesMessage) {
       logger.warning('Channel|useHandleUploadFiles: required functions are undefined', { sendFileMessage, sendMultipleFilesMessage });
       return;
@@ -69,6 +70,7 @@ export const useHandleUploadFiles = ({
       });
       return;
     }
+    // Validate file sizes
     if (files.some((file: File) => file.size > uikitUploadSizeLimit)) {
       // The default value of uikitUploadSizeLimit is 26MB
       logger.info(`Channel|useHandleUploadFiles: Cannot upload file size exceeding ${uikitUploadSizeLimit}`);
@@ -91,15 +93,26 @@ export const useHandleUploadFiles = ({
       return;
     }
 
-    if (files.length === 1) {
+    // Image Compression
+    const { compressedImages, notCompressedFiles } = await compressImages({
+      files,
+      imageCompression,
+      logger,
+    });
+    const sendingFiles = compressedImages.concat(notCompressedFiles);
+
+    // Send File Message
+    if (sendingFiles.length === 1) {
       logger.info('Channel|useHandleUploadFiles: sending one file.');
-      const [file] = files;
+      const [file] = sendingFiles;
       sendFileMessage(file, quoteMessage);
-    } else if (files.length > 1) {
+    } else if (sendingFiles.length > 1) {
       logger.info('Channel|useHandleUploadFiles: sending multiple files.');
+
+      // Divide to images & non-images
       const imageFiles: Array<File> = [];
       const otherFiles: Array<File> = [];
-      files.forEach((file: File) => {
+      sendingFiles.forEach((file: File) => {
         if (isImage(file.type)) {
           imageFiles.push(file);
         } else {
@@ -130,5 +143,5 @@ export const useHandleUploadFiles = ({
     quoteMessage,
   ]);
 
-  return [handleUploadFiles];
+  return handleUploadFiles;
 };

--- a/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
@@ -28,7 +28,7 @@ export default function useSendFileMessageCallback(
   { logger, pubSub, scrollRef, messagesDispatcher }: UseSendFileMessageCallbackParams,
 ) {
   const sendMessage = useCallback(
-    (compressedFile: File, quoteMessage = null) => new Promise<FileMessage>(async (resolve, reject) => {
+    (compressedFile: File, quoteMessage = null) => new Promise<FileMessage>((resolve, reject) => {
       // Create FileMessageParams
       let params: FileMessageCreateParams = onBeforeSendFileMessage?.(compressedFile, quoteMessage);
       if (!params) {

--- a/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
@@ -1,16 +1,16 @@
 import React, { useCallback } from 'react';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { FileMessage, FileMessageCreateParams } from '@sendbird/chat/message';
 
 import * as messageActionTypes from '../dux/actionTypes';
 import { ChannelActionTypes } from '../dux/actionTypes';
 import * as utils from '../utils';
 import topics from '../../../../lib/pubSub/topics';
 import { PublishingModuleType } from '../../../internalInterfaces';
-import { GroupChannel } from '@sendbird/chat/groupChannel';
 import { LoggerInterface } from '../../../../lib/Logger';
 import { PubSubTypes } from '../../../../lib/pubSub';
 import { SendableMessageType } from '../../../../utils';
 import { SendBirdState } from '../../../../lib/types';
-import { FileMessage, FileMessageCreateParams } from '@sendbird/chat/message';
 
 type UseSendFileMessageCallbackOptions = {
   currentGroupChannel: null | GroupChannel;
@@ -28,169 +28,60 @@ export default function useSendFileMessageCallback(
   { logger, pubSub, scrollRef, messagesDispatcher }: UseSendFileMessageCallbackParams,
 ) {
   const sendMessage = useCallback(
-    (file: File, quoteMessage = null) => new Promise<FileMessage>((resolve, reject) => {
-      const { compressionRate, resizingWidth, resizingHeight } = imageCompression ?? {};
-      const shouldCreateCustomParams = onBeforeSendFileMessage && typeof onBeforeSendFileMessage === 'function';
-
-      const compressibleFileType = file.type === 'image/jpg' || file.type === 'image/png' || file.type === 'image/jpeg';
-      const compressibleRatio = compressionRate > 0 && compressionRate < 1;
-      // pxToNumber returns null if values are invalid
-      const compressibleDiamensions = utils.pxToNumber(resizingWidth) || utils.pxToNumber(resizingHeight);
-
-      const canCompressImage = compressibleFileType && (compressibleRatio || compressibleDiamensions);
-
-      const createParamsDefault = (fileToSend: File) => {
-        const params: FileMessageCreateParams = {
-          file: fileToSend,
-        };
+    (compressedFile: File, quoteMessage = null) => new Promise<FileMessage>(async (resolve, reject) => {
+      // Create FileMessageParams
+      let params: FileMessageCreateParams = onBeforeSendFileMessage?.(compressedFile, quoteMessage);
+      if (!params) {
+        params = { file: compressedFile };
         if (quoteMessage) {
           params.isReplyToChannel = true;
           params.parentMessageId = quoteMessage.messageId;
         }
-        return params;
-      };
-
-      if (canCompressImage) {
-        // Using image compression
-        try {
-          // TODO: Extract image compression logic to utils.
-          const image = document.createElement('img');
-          image.src = URL.createObjectURL(file);
-          image.onload = () => {
-            URL.revokeObjectURL(image.src);
-            const canvas = document.createElement('canvas');
-            const imageWdith = image.naturalWidth || image.width;
-            const imageHeight = image.naturalHeight || image.height;
-
-            let targetWidth = utils.pxToNumber(resizingWidth) || imageWdith;
-            let targetHeight = utils.pxToNumber(resizingHeight) || imageHeight;
-
-            // In canvas.toBlob(callback, mimeType, qualityArgument)
-            // qualityArgument doesnt work
-            // so in case compressibleDiamensions are not present, we use ratio
-            if (file.type === 'image/png' && !compressibleDiamensions) {
-              targetWidth *= compressionRate;
-              targetHeight *= compressionRate;
-            }
-
-            canvas.width = targetWidth;
-            canvas.height = targetHeight;
-            const context = canvas.getContext('2d');
-            context.drawImage(image, 0, 0, targetWidth, targetHeight);
-            context.canvas.toBlob(
-              (newImageBlob) => {
-                const compressedFile = new File([newImageBlob], file.name, { type: file.type });
-                if (shouldCreateCustomParams) {
-                  logger.info('Channel: Creating params using onBeforeSendFileMessage', onBeforeSendFileMessage);
-                }
-                const params = shouldCreateCustomParams
-                  ? onBeforeSendFileMessage(compressedFile, quoteMessage)
-                  : createParamsDefault(compressedFile);
-                logger.info('Channel: Uploading file message start!', params);
-                currentGroupChannel
-                  .sendFileMessage(params)
-                  .onPending((pendingMessage) => {
-                    pubSub.publish(topics.SEND_MESSAGE_START, {
-                      /* pubSub is used instead of messagesDispatcher
-                        to avoid redundantly calling `messageActionTypes.SEND_MESSAGE_START` */
-                      message: {
-                        ...pendingMessage,
-                        url: URL.createObjectURL(compressedFile),
-                        // pending thumbnail message seems to be failed
-                        requestState: 'pending',
-                      },
-                      channel: currentGroupChannel,
-                      publishingModules: [PublishingModuleType.CHANNEL],
-                    });
-                    setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
-                  })
-                  .onFailed((err, failedMessage) => {
-                    logger.error('Channel: Sending file message failed!', { failedMessage, err });
-
-                    // TODO: v4 - remove logic that modifies the original object.
-                    //  It makes the code difficult to track, likely causing unpredictable side effects.
-                    // @ts-ignore eslint-disable-next-line no-param-reassign
-                    failedMessage.localUrl = URL.createObjectURL(compressedFile);
-                    // @ts-ignore eslint-disable-next-line no-param-reassign
-                    failedMessage.file = compressedFile;
-
-                    messagesDispatcher({
-                      type: messageActionTypes.SEND_MESSAGE_FAILURE,
-                      payload: failedMessage as SendableMessageType,
-                    });
-                    reject(err);
-                  })
-                  .onSucceeded((succeededMessage) => {
-                    logger.info('Channel: Sending file message success!', succeededMessage);
-                    messagesDispatcher({
-                      type: messageActionTypes.SEND_MESSAGE_SUCCESS,
-                      payload: succeededMessage as SendableMessageType,
-                    });
-                    resolve(succeededMessage as FileMessage);
-                  });
-              },
-              file.type,
-              compressionRate,
-            );
-          };
-        } catch (error) {
-          logger.error('Channel: Sending file message failed!', error);
-          reject(error);
-        }
-      } else {
-        // Not using image compression
-        if (shouldCreateCustomParams) {
-          logger.info('Channel: creating params using onBeforeSendFileMessage', onBeforeSendFileMessage);
-        }
-        const params = onBeforeSendFileMessage
-          ? onBeforeSendFileMessage(file, quoteMessage)
-          : createParamsDefault(file);
-        logger.info('Channel: Uploading file message start!', params);
-
-        currentGroupChannel
-          .sendFileMessage(params)
-          .onPending((pendingMsg) => {
-            pubSub.publish(topics.SEND_MESSAGE_START, {
-              /* pubSub is used instead of messagesDispatcher
-                to avoid redundantly calling `messageActionTypes.SEND_MESSAGE_START` */
-              message: {
-                ...pendingMsg,
-                // TODO: v4 - remove logic that modifies the original object.
-                //  It makes the code difficult to track, likely causing unpredictable side effects.
-                url: URL.createObjectURL(file),
-                // pending thumbnail message seems to be failed
-                requestState: 'pending',
-              },
-              channel: currentGroupChannel,
-              publishingModules: [PublishingModuleType.CHANNEL],
-            });
-            setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
-          })
-          .onFailed((error, message) => {
-            logger.error('Channel: Sending file message failed!', { message, error });
-
-            // TODO: v4 - remove logic that modifies the original object.
-            //  It makes the code difficult to track, likely causing unpredictable side effects.
-            // @ts-ignore eslint-disable-next-line no-param-reassign
-            message.localUrl = URL.createObjectURL(file);
-            // @ts-ignore eslint-disable-next-line no-param-reassign
-            message.file = file;
-
-            messagesDispatcher({
-              type: messageActionTypes.SEND_MESSAGE_FAILURE,
-              payload: message as SendableMessageType,
-            });
-            reject(error);
-          })
-          .onSucceeded((message) => {
-            logger.info('Channel: Sending message success!', message);
-            messagesDispatcher({
-              type: messageActionTypes.SEND_MESSAGE_SUCCESS,
-              payload: message as SendableMessageType,
-            });
-            resolve(message as FileMessage);
-          });
       }
+
+      // Send FileMessage
+      logger.info('Channel: Uploading file message start!', params);
+      currentGroupChannel
+        .sendFileMessage(params)
+        .onPending((pendingMessage) => {
+          pubSub.publish(topics.SEND_MESSAGE_START, {
+            /* pubSub is used instead of messagesDispatcher
+              to avoid redundantly calling `messageActionTypes.SEND_MESSAGE_START` */
+            message: {
+              ...pendingMessage,
+              url: URL.createObjectURL(compressedFile),
+              // pending thumbnail message seems to be failed
+              requestState: 'pending',
+            },
+            channel: currentGroupChannel,
+            publishingModules: [PublishingModuleType.CHANNEL],
+          });
+          setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
+        })
+        .onFailed((err, failedMessage) => {
+          logger.error('Channel: Sending file message failed!', { failedMessage, err });
+
+          // TODO: v4 - remove logic that modifies the original object.
+          //  It makes the code difficult to track, likely causing unpredictable side effects.
+          // @ts-ignore eslint-disable-next-line no-param-reassign
+          failedMessage.localUrl = URL.createObjectURL(compressedFile);
+          // @ts-ignore eslint-disable-next-line no-param-reassign
+          failedMessage.file = compressedFile;
+
+          messagesDispatcher({
+            type: messageActionTypes.SEND_MESSAGE_FAILURE,
+            payload: failedMessage as SendableMessageType,
+          });
+          reject(err);
+        })
+        .onSucceeded((succeededMessage) => {
+          logger.info('Channel: Sending file message success!', succeededMessage);
+          messagesDispatcher({
+            type: messageActionTypes.SEND_MESSAGE_SUCCESS,
+            payload: succeededMessage as SendableMessageType,
+          });
+          resolve(succeededMessage as FileMessage);
+        });
     }),
     [currentGroupChannel, onBeforeSendFileMessage, imageCompression],
   );

--- a/src/modules/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/modules/Thread/components/ThreadMessageInput/index.tsx
@@ -66,7 +66,7 @@ const ThreadMessageInput = (
     || (!(currentChannel?.myRole === Role.OPERATOR) && isChannelFrozen) || parentMessage === null;
 
   // MFM
-  const [handleUploadFiles] = useHandleUploadFiles({
+  const handleUploadFiles = useHandleUploadFiles({
     sendFileMessage,
     sendMultipleFilesMessage,
     quoteMessage: parentMessage,

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -1,6 +1,6 @@
-import { ImageCompressionOptions } from "../lib/Sendbird";
-import pxToNumber from "./pxToNumber";
-import { Logger } from "../lib/SendbirdState";
+import { ImageCompressionOptions } from '../lib/Sendbird';
+import pxToNumber from './pxToNumber';
+import { Logger } from '../lib/SendbirdState';
 
 interface CompressImageProps {
   imageFile: File;
@@ -58,7 +58,7 @@ const compressImage = ({
           }
         },
         imageFile.type,
-        compressionRate
+        compressionRate,
       );
     };
   });
@@ -116,13 +116,13 @@ export const compressImages = async ({
             imageFile,
           });
         }
-      })
+      }),
   );
 
   logger.info('useImageCompression: Finished compressing images', {
     compressedImages,
     notCompressedFiles,
-  })
+  });
   return {
     compressedImages,
     notCompressedFiles,

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -1,0 +1,130 @@
+import { ImageCompressionOptions } from "../lib/Sendbird";
+import pxToNumber from "./pxToNumber";
+import { Logger } from "../lib/SendbirdState";
+
+interface CompressImageProps {
+  imageFile: File;
+  compressionRate: number;
+  resizingWidth?: number;
+  resizingHeight?: number;
+}
+
+const compressImage = ({
+  imageFile,
+  compressionRate,
+  resizingWidth,
+  resizingHeight,
+}: CompressImageProps): Promise<File> => {
+  const image = document.createElement('img');
+  return new Promise((resolve, reject) => {
+    image.src = URL.createObjectURL(imageFile);
+    image.onerror = reject;
+    image.onload = () => {
+      URL.revokeObjectURL(image.src);
+      const canvas = document.createElement('canvas');
+
+      const originWidth = image.width;
+      const originHeight = image.height;
+      const widthRatio = originWidth / (resizingWidth || originWidth);
+      const heightRatio = originHeight / (resizingHeight || originHeight);
+
+      let targetResizingWidth = resizingWidth || originWidth;
+      let targetResizingHeight = resizingHeight || originHeight;
+
+      if (widthRatio > heightRatio) {
+        targetResizingHeight = originHeight / (resizingWidth ? widthRatio : 1);
+      } else if (heightRatio > widthRatio) {
+        targetResizingWidth = originWidth / (resizingHeight ? heightRatio : 1);
+      }
+
+      canvas.width = targetResizingWidth;
+      canvas.height = targetResizingHeight;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Failed to get canvas 2d context'));
+        return;
+      }
+
+      ctx.drawImage(image, 0, 0, targetResizingWidth, targetResizingHeight);
+
+      ctx.canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const file = new File([blob], imageFile.name, { type: imageFile.type });
+            resolve(file);
+          } else {
+            reject(new Error('Failed to compress image'));
+          }
+        },
+        imageFile.type,
+        compressionRate
+      );
+    };
+  });
+};
+
+export interface CompressImagesProps {
+  files: File[];
+  imageCompression: ImageCompressionOptions;
+  logger?: Logger;
+}
+export const compressImages = async ({
+  files,
+  logger,
+  imageCompression,
+}: CompressImagesProps) => {
+  const { compressionRate } = imageCompression;
+  const resizingWidth = pxToNumber(imageCompression.resizingWidth);
+  const resizingHeight = pxToNumber(imageCompression.resizingHeight);
+
+  if (!(Array.isArray(files) && files.length > 0)) {
+    logger.warning('useImageCompression: There is no file.', files);
+    return;
+  }
+  if (compressionRate < 0 || 1 < compressionRate) {
+    logger.warning('useImageCompression: The compressionRate is not acceptable.', compressionRate);
+    return;
+  }
+
+  const compressedImages: File[] = [];
+  const notCompressedFiles: File[] = [];
+
+  await Promise.all(
+    files
+      .filter((file, index) => {
+        if (file.type === 'image/jpg' || file.type === 'image/png' || file.type === 'image/jpeg') {
+          return true;
+        }
+        notCompressedFiles.push(file);
+        logger.warning('useImageCompression: The file type is not compressible.', { file, index });
+        return false;
+      })
+      .map(async (imageFile) => {
+        try {
+          const compressedImage = await compressImage({
+            imageFile,
+            compressionRate,
+            resizingWidth,
+            resizingHeight,
+          });
+          compressedImages.push(compressedImage);
+        } catch (err) {
+          notCompressedFiles.push(imageFile);
+          logger.warning('useImageCompression: Failed to compress image file', {
+            err,
+            imageFile,
+          });
+        }
+      })
+  );
+
+  logger.info('useImageCompression: Finished compressing images', {
+    compressedImages,
+    notCompressedFiles,
+  })
+  return {
+    compressedImages,
+    notCompressedFiles,
+  };
+};

--- a/src/utils/compressImages.ts
+++ b/src/utils/compressImages.ts
@@ -31,6 +31,7 @@ const compressImage = ({
       let targetResizingWidth = resizingWidth || originWidth;
       let targetResizingHeight = resizingHeight || originHeight;
 
+      // Use the more impactful value, so the original images' ratio won't be broken
       if (widthRatio > heightRatio) {
         targetResizingHeight = originHeight / (resizingWidth ? widthRatio : 1);
       } else if (heightRatio > widthRatio) {

--- a/src/utils/pxToNumber.ts
+++ b/src/utils/pxToNumber.ts
@@ -1,4 +1,4 @@
-export default (px: string | number): number => {
+export const pxToNumber = (px: string | number): number => {
   if (typeof px === 'number') {
     return px;
   }
@@ -10,3 +10,5 @@ export default (px: string | number): number => {
   }
   return NaN;
 };
+
+export default pxToNumber;


### PR DESCRIPTION
[CLNP-1320](https://sendbird.atlassian.net/browse/CLNP-1320)

## Outer
### Fixes
* Use the more impactful value between the `resizingWidth` and `resizingHeight`
  * So, the original images' ratio won't be broken
* Apply the ImageCompression to the Thread module
* Apply the ImageCompression for sending `file message` and `multiple files message`

## Internal
### Fixes
* Create a `compressImages` util function
* Compress the images in the `useHandleUploadFiles` hook
  * Do not compress the image inside of the `useSendFileMessageCallback` hook of the Channel module


[CLNP-1320]: https://sendbird.atlassian.net/browse/CLNP-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ