### PR TITLE
chore: Put back message content props

### DIFF
--- a/src/ui/MessageContent/MessageProfile/index.tsx
+++ b/src/ui/MessageContent/MessageProfile/index.tsx
@@ -7,10 +7,10 @@ import UserProfile from '../../UserProfile';
 import MessageItemMenu from '../../MessageItemMenu';
 import { ThreadReplySelectType } from '../../../modules/Channel/context/const';
 import MessageItemReactionMenu from '../../MessageItemReactionMenu';
-import { MessageContentInternalProps } from '../index';
+import { MessageContentProps } from '../index';
 import { UserProfileContext } from '../../../lib/UserProfileContext';
 
-export interface MessageProfileProps extends MessageContentInternalProps {
+export interface MessageProfileProps extends MessageContentProps {
   setSupposedHover?: Dispatch<SetStateAction<boolean>>;
   isMobile?: boolean;
   isReactionEnabledInChannel?: boolean;

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -39,16 +39,7 @@ import MessageProfile, { MessageProfileProps } from './MessageProfile';
 import MessageBody, { MessageBodyProps } from './MessageBody';
 import MessageHeader, { MessageHeaderProps } from './MessageHeader';
 
-export interface MessageContentProps extends MessageContentInternalProps {
-  renderSenderProfile?: (props: MessageProfileProps) => ReactNode;
-  renderMessageBody?: (props: MessageBodyProps) => ReactNode;
-  renderMessageHeader?: (props: MessageHeaderProps) => ReactNode;
-}
-
-/**
- * @internal
- */
-export interface MessageContentInternalProps {
+export interface MessageContentProps {
   className?: string | Array<string>;
   userId: string;
   channel: Nullable<GroupChannel>;
@@ -73,6 +64,11 @@ export interface MessageContentInternalProps {
   onReplyInThread?: (props: { message: SendableMessageType }) => void;
   onQuoteMessageClick?: (props: { message: SendableMessageType }) => void;
   onMessageHeightChange?: () => void;
+
+  // For injecting customizable sub-components
+  renderSenderProfile?: (props: MessageProfileProps) => ReactNode;
+  renderMessageBody?: (props: MessageBodyProps) => ReactNode;
+  renderMessageHeader?: (props: MessageHeaderProps) => ReactNode;
 }
 
 export default function MessageContent(props: MessageContentProps): ReactElement {


### PR DESCRIPTION
MessageContentInternalProps should not be made interal for backward compatibility.