### PR TITLE
bug-fix: Added and applied useOnScrollReachedEndDetector() in MessageList to mark new messages as read when scroll reaches bottom.

### DIFF
--- a/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
-import { useOnScrollReachedEndDetector, UseOnScrollReachedEndDetectorProps } from '../index';
+import { useOnScrollPositionChangeDetector, UseOnScrollReachedEndDetectorProps } from '../index';
 import { SCROLL_BUFFER } from '../../../utils/consts';
 
 jest.useFakeTimers();
@@ -23,6 +23,7 @@ const prepareMockParams = ({
     scrollRef,
     onReachedTop: jest.fn(),
     onReachedBottom: jest.fn(),
+    onInBetween: jest.fn(),
   };
 };
 
@@ -34,7 +35,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -42,6 +43,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).toHaveBeenCalledTimes(1);
     expect(params.onReachedBottom).not.toHaveBeenCalled();
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedTop() when scrollTop < SCROLL_BUFFER', () => {
     const params = prepareMockParams({
@@ -50,7 +52,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -58,6 +60,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).toHaveBeenCalledTimes(1);
     expect(params.onReachedBottom).not.toHaveBeenCalled();
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedTop() when scrollTop is 0', () => {
     const params = prepareMockParams({
@@ -66,7 +69,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -74,6 +77,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).toHaveBeenCalledTimes(1);
     expect(params.onReachedBottom).not.toHaveBeenCalled();
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is SCROLL_BUFFER', () => {
     const params = prepareMockParams({
@@ -82,7 +86,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -90,6 +94,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).not.toHaveBeenCalled();
     expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) < SCROLL_BUFFER', () => {
     const params = prepareMockParams({
@@ -98,7 +103,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -106,6 +111,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).not.toHaveBeenCalled();
     expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is 0', () => {
     const params = prepareMockParams({
@@ -114,7 +120,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -122,6 +128,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).not.toHaveBeenCalled();
     expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+    expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scroll position has not reached either ends', () => {
     const params = prepareMockParams({
@@ -130,7 +137,7 @@ describe('useOnScrollReachedEndDetector', () => {
       scrollHeight: 200,
     });
 
-    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
     onScrollReachedEndDetector();
 
@@ -138,5 +145,7 @@ describe('useOnScrollReachedEndDetector', () => {
 
     expect(params.onReachedTop).not.toHaveBeenCalled();
     expect(params.onReachedBottom).not.toHaveBeenCalled();
+    expect(params.onInBetween).toHaveBeenCalledTimes(1);
+
   });
 });

--- a/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
@@ -7,37 +7,39 @@ jest.useFakeTimers();
 
 const SAFE_DELAY = 550;
 
-const prepareMockParams = ({
-  scrollTop = 0,
-  scrollHeight = 0,
-  clientHeight = 0,
-}): UseOnScrollReachedEndDetectorProps => {
-  const scrollRef = {
-    current: {
-      scrollTop,
-      scrollHeight,
-      clientHeight,
-    },
-  } as React.RefObject<HTMLDivElement>;
+const prepareMockParams = (): UseOnScrollReachedEndDetectorProps => {
   return {
-    scrollRef,
     onReachedTop: jest.fn(),
     onReachedBottom: jest.fn(),
     onInBetween: jest.fn(),
   };
 };
 
+const getMockScrollEvent = ({
+  scrollTop = 0,
+  scrollHeight = 0,
+  clientHeight = 0,
+}): React.UIEvent<HTMLDivElement> => {
+  return {
+    target: {
+      scrollTop,
+      scrollHeight,
+      clientHeight,
+    },
+  } as unknown as React.UIEvent<HTMLDivElement>;
+};
+
 describe('useOnScrollReachedEndDetector', () => {
   it('should call onReachedTop() when scrollTop is SCROLL_BUFFER', () => {
-    const params = prepareMockParams({
-      scrollTop: SCROLL_BUFFER,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: SCROLL_BUFFER,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -46,15 +48,15 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedTop() when scrollTop < SCROLL_BUFFER', () => {
-    const params = prepareMockParams({
-      scrollTop: 5,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 5,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -63,15 +65,15 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedTop() when scrollTop is 0', () => {
-    const params = prepareMockParams({
-      scrollTop: 0,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 0,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -80,15 +82,15 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is SCROLL_BUFFER', () => {
-    const params = prepareMockParams({
-      scrollTop: 90,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 90,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -97,15 +99,15 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) < SCROLL_BUFFER', () => {
-    const params = prepareMockParams({
-      scrollTop: 95,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 95,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -114,15 +116,15 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is 0', () => {
-    const params = prepareMockParams({
-      scrollTop: 100,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 100,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
@@ -131,21 +133,20 @@ describe('useOnScrollReachedEndDetector', () => {
     expect(params.onInBetween).not.toHaveBeenCalled();
   });
   it('should call onReachedBottom() when scroll position has not reached either ends', () => {
-    const params = prepareMockParams({
-      scrollTop: 50,
-      clientHeight: 100,
-      scrollHeight: 200,
-    });
+    const params = prepareMockParams();
 
     const { result } = renderHook(() => useOnScrollPositionChangeDetector(params));
     const onScrollReachedEndDetector = result.current;
-    onScrollReachedEndDetector();
+    onScrollReachedEndDetector(getMockScrollEvent({
+      scrollTop: 50,
+      clientHeight: 100,
+      scrollHeight: 200,
+    }));
 
     jest.advanceTimersByTime(SAFE_DELAY);
 
     expect(params.onReachedTop).not.toHaveBeenCalled();
     expect(params.onReachedBottom).not.toHaveBeenCalled();
     expect(params.onInBetween).toHaveBeenCalledTimes(1);
-
   });
 });

--- a/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/__tests__/useHandleOnScrollCallback.spec.ts
@@ -1,0 +1,142 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useOnScrollReachedEndDetector, UseOnScrollReachedEndDetectorProps } from '../index';
+import { SCROLL_BUFFER } from '../../../utils/consts';
+
+jest.useFakeTimers();
+
+const SAFE_DELAY = 550;
+
+const prepareMockParams = ({
+  scrollTop = 0,
+  scrollHeight = 0,
+  clientHeight = 0,
+}): UseOnScrollReachedEndDetectorProps => {
+  const scrollRef = {
+    current: {
+      scrollTop,
+      scrollHeight,
+      clientHeight,
+    },
+  } as React.RefObject<HTMLDivElement>;
+  return {
+    scrollRef,
+    onReachedTop: jest.fn(),
+    onReachedBottom: jest.fn(),
+  };
+};
+
+describe('useOnScrollReachedEndDetector', () => {
+  it('should call onReachedTop() when scrollTop is SCROLL_BUFFER', () => {
+    const params = prepareMockParams({
+      scrollTop: SCROLL_BUFFER,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).toHaveBeenCalledTimes(1);
+    expect(params.onReachedBottom).not.toHaveBeenCalled();
+  });
+  it('should call onReachedTop() when scrollTop < SCROLL_BUFFER', () => {
+    const params = prepareMockParams({
+      scrollTop: 5,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).toHaveBeenCalledTimes(1);
+    expect(params.onReachedBottom).not.toHaveBeenCalled();
+  });
+  it('should call onReachedTop() when scrollTop is 0', () => {
+    const params = prepareMockParams({
+      scrollTop: 0,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).toHaveBeenCalledTimes(1);
+    expect(params.onReachedBottom).not.toHaveBeenCalled();
+  });
+  it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is SCROLL_BUFFER', () => {
+    const params = prepareMockParams({
+      scrollTop: 90,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).not.toHaveBeenCalled();
+    expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+  });
+  it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) < SCROLL_BUFFER', () => {
+    const params = prepareMockParams({
+      scrollTop: 95,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).not.toHaveBeenCalled();
+    expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+  });
+  it('should call onReachedBottom() when scrollHeight - (clientHeight + scrollTop) is 0', () => {
+    const params = prepareMockParams({
+      scrollTop: 100,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).not.toHaveBeenCalled();
+    expect(params.onReachedBottom).toHaveBeenCalledTimes(1);
+  });
+  it('should call onReachedBottom() when scroll position has not reached either ends', () => {
+    const params = prepareMockParams({
+      scrollTop: 50,
+      clientHeight: 100,
+      scrollHeight: 200,
+    });
+
+    const { result } = renderHook(() => useOnScrollReachedEndDetector(params));
+    const onScrollReachedEndDetector = result.current;
+    onScrollReachedEndDetector();
+
+    jest.advanceTimersByTime(SAFE_DELAY);
+
+    expect(params.onReachedTop).not.toHaveBeenCalled();
+    expect(params.onReachedBottom).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -7,28 +7,27 @@ import { usePreservedCallback } from '@sendbird/uikit-tools';
 const BUFFER_DELAY = 500;
 
 export interface UseOnScrollReachedEndDetectorProps {
-  scrollRef: React.RefObject<HTMLDivElement>;
   onReachedTop?: () => void;
   onReachedBottom?: () => void;
   onInBetween?: () => void;
 }
 
-export function useOnScrollPositionChangeDetector(props: UseOnScrollReachedEndDetectorProps): () => void {
+export function useOnScrollPositionChangeDetector(
+  props: UseOnScrollReachedEndDetectorProps,
+): (event: React.UIEvent<HTMLDivElement, UIEvent>) => void {
   const {
-    scrollRef,
     onReachedTop,
     onReachedBottom,
     onInBetween,
   } = props;
 
-  const cb = usePreservedCallback(() => {
-    const current = scrollRef?.current;
-    if (current) {
+  const cb = usePreservedCallback((event: React.UIEvent<HTMLDivElement, UIEvent>) => {
+    if (event?.target) {
       const {
         scrollTop,
         scrollHeight,
         clientHeight,
-      } = current;
+      } = event.target as HTMLDivElement;
       if (isAboutSame(scrollTop, 0, SCROLL_BUFFER)) {
         onReachedTop();
       } else if (isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER)) {

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -1,4 +1,4 @@
-import React  from 'react';
+import React from 'react';
 import { SCROLL_BUFFER } from '../../utils/consts';
 import { isAboutSame } from '../../modules/Channel/context/utils';
 import { useDebounce } from '../useDebounce';

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -1,0 +1,38 @@
+import React, { useCallback } from 'react';
+import { SCROLL_BUFFER } from '../../utils/consts';
+import { isAboutSame } from '../../modules/Channel/context/utils';
+import { useDebounce } from '../useDebounce';
+
+const BUFFER_DELAY = 500;
+
+export interface UseOnScrollReachedEndDetectorProps {
+  scrollRef: React.RefObject<HTMLDivElement>;
+  onReachedTop?: () => void;
+  onReachedBottom?: () => void;
+}
+
+export function useOnScrollReachedEndDetector(props: UseOnScrollReachedEndDetectorProps): () => void {
+  const {
+    scrollRef,
+    onReachedTop,
+    onReachedBottom,
+  } = props;
+
+  const cb = useCallback(() => {
+    const current = scrollRef?.current;
+    if (current) {
+      const {
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+      } = current;
+      if (isAboutSame(scrollTop, 0, SCROLL_BUFFER)) {
+        onReachedTop();
+      } else if (isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER)) {
+        onReachedBottom();
+      }
+    }
+  }, [scrollRef, onReachedTop, onReachedBottom]);
+
+  return useDebounce(cb, BUFFER_DELAY);
+}

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -9,13 +9,15 @@ export interface UseOnScrollReachedEndDetectorProps {
   scrollRef: React.RefObject<HTMLDivElement>;
   onReachedTop?: () => void;
   onReachedBottom?: () => void;
+  onInBetween?: () => void;
 }
 
-export function useOnScrollReachedEndDetector(props: UseOnScrollReachedEndDetectorProps): () => void {
+export function useOnScrollPositionChangeDetector(props: UseOnScrollReachedEndDetectorProps): () => void {
   const {
     scrollRef,
     onReachedTop,
     onReachedBottom,
+    onInBetween,
   } = props;
 
   const cb = useCallback(() => {
@@ -30,9 +32,11 @@ export function useOnScrollReachedEndDetector(props: UseOnScrollReachedEndDetect
         onReachedTop();
       } else if (isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER)) {
         onReachedBottom();
+      } else {
+        onInBetween();
       }
     }
-  }, [scrollRef, onReachedTop, onReachedBottom]);
+  }, [scrollRef, onReachedTop, onReachedBottom, onInBetween]);
 
   return useDebounce(cb, BUFFER_DELAY);
 }

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React  from 'react';
 import { SCROLL_BUFFER } from '../../utils/consts';
 import { isAboutSame } from '../../modules/Channel/context/utils';
 import { useDebounce } from '../useDebounce';
+import { usePreservedCallback } from '@sendbird/uikit-tools';
 
 const BUFFER_DELAY = 500;
 
@@ -20,7 +21,6 @@ export function useOnScrollPositionChangeDetector(props: UseOnScrollReachedEndDe
     onInBetween,
   } = props;
 
-// import { usePreservedCallback } from "@sendbird/uikit-tools";
   const cb = usePreservedCallback(() => {
     const current = scrollRef?.current;
     if (current) {

--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -20,7 +20,8 @@ export function useOnScrollPositionChangeDetector(props: UseOnScrollReachedEndDe
     onInBetween,
   } = props;
 
-  const cb = useCallback(() => {
+// import { usePreservedCallback } from "@sendbird/uikit-tools";
+  const cb = usePreservedCallback(() => {
     const current = scrollRef?.current;
     if (current) {
       const {
@@ -36,7 +37,7 @@ export function useOnScrollPositionChangeDetector(props: UseOnScrollReachedEndDe
         onInBetween();
       }
     }
-  }, [scrollRef, onReachedTop, onReachedBottom, onInBetween]);
+  });
 
   return useDebounce(cb, BUFFER_DELAY);
 }

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -142,7 +142,7 @@ const Message = ({
 
   useLayoutEffect(() => {
     // Keep the scrollBottom value after fetching new message list
-    handleScroll?.();
+    handleScroll?.(true);
   }, []);
   /**
    * Move the messsage list scroll

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -20,6 +20,7 @@ import { useSetScrollToBottom } from './hooks/useSetScrollToBottom';
 import { useScrollBehavior } from './hooks/useScrollBehavior';
 import * as utils from '../../context/utils';
 import TypingIndicatorBubble from '../../../../ui/TypingIndicatorBubble';
+import { useOnScrollReachedEndDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 const SCROLL_BOTTOM_PADDING = 50;
 
@@ -154,6 +155,23 @@ const MessageList: React.FC<MessageListProps> = ({
     scrollRef,
   });
 
+  const onScrollReachedEndDetector = useOnScrollReachedEndDetector({
+    scrollRef,
+    onReachedBottom: () => {
+      if (
+        !disableMarkAsRead
+        && !!currentGroupChannel
+        && !hasMoreNext
+      ) {
+        messagesDispatcher({
+          type: messageActionTypes.MARK_AS_READ,
+          payload: { channel: currentGroupChannel },
+        });
+        markAsReadScheduler.push(currentGroupChannel);
+      }
+    },
+  });
+
   const { scrollToBottomHandler, scrollBottom } = useSetScrollToBottom({ loading });
 
   if (loading) {
@@ -182,6 +200,7 @@ const MessageList: React.FC<MessageListProps> = ({
             onScroll={(e) => {
               handleOnScroll();
               scrollToBottomHandler(e);
+              onScrollReachedEndDetector();
             }}
           >
             {

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -301,9 +301,7 @@ const MessageList: React.FC<MessageListProps> = ({
               time={unreadSince}
               lastReadAt={unreadSinceDate}
               onClick={() => {
-                if (scrollRef?.current?.scrollTop) {
-                  scrollRef.current.scrollTop = (scrollRef?.current?.scrollHeight ?? 0) - (scrollRef?.current?.offsetHeight ?? 0);
-                }
+                if (scrollRef?.current) scrollRef.current.scrollTop = Number.MAX_SAFE_INTEGER;
                 if (!disableMarkAsRead && !!currentGroupChannel) {
                   markAsReadScheduler.push(currentGroupChannel);
                   messagesDispatcher({

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -158,7 +158,6 @@ const MessageList: React.FC<MessageListProps> = ({
   });
 
   const onScrollReachedEndDetector = useOnScrollPositionChangeDetector({
-    scrollRef,
     onReachedBottom: () => {
       /**
        * Note that this event is already being called in onScroll() above. However, it is only being called when
@@ -171,6 +170,7 @@ const MessageList: React.FC<MessageListProps> = ({
         });
         markAsReadScheduler.push(currentGroupChannel);
       }
+      console.log('## reached bottom: ', );
       setIsScrollBottom(true);
     },
     onReachedTop: () => {
@@ -209,7 +209,7 @@ const MessageList: React.FC<MessageListProps> = ({
             onScroll={(e) => {
               handleOnScroll();
               scrollToBottomHandler(e);
-              onScrollReachedEndDetector();
+              onScrollReachedEndDetector(e);
             }}
           >
             {

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -170,7 +170,6 @@ const MessageList: React.FC<MessageListProps> = ({
         });
         markAsReadScheduler.push(currentGroupChannel);
       }
-      console.log('## reached bottom: ', );
       setIsScrollBottom(true);
     },
     onReachedTop: () => {

--- a/src/modules/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/modules/ChannelList/components/ChannelPreview/index.tsx
@@ -46,7 +46,6 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
   const {
     isTypingIndicatorEnabled = false,
     isMessageReceiptStatusEnabled = false,
-    currentChannel,
   } = useChannelListContext();
   const { dateLocale, stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();

--- a/src/modules/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/modules/ChannelList/components/ChannelPreview/index.tsx
@@ -46,6 +46,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
   const {
     isTypingIndicatorEnabled = false,
     isMessageReceiptStatusEnabled = false,
+    currentChannel,
   } = useChannelListContext();
   const { dateLocale, stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
@@ -186,7 +187,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
               }
             </Label>
             {
-              !channel?.isEphemeral && (
+              !isActive && !channel?.isEphemeral && (
                 <div className="sendbird-channel-preview__content__lower__unread-message-count">
                   {
                     (isMentionEnabled && channel?.unreadMentionCount > 0)
@@ -227,7 +228,12 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
         https://github.com/facebook/react/issues/11387#issuecomment-340019419
       */}
       {
-        showMobileLeave && isMobile && (
+        /**
+         * Do not show unread count for focused channel. This is because of the limitation where
+         * isScrollBottom and hasNext states needs to be added globally but they are from channel context
+         * so channel list cannot see them with the current architecture.
+         */
+        (channel.url !== currentChannel?.url) && showMobileLeave && isMobile && (
           <Modal
             className="sendbird-channel-preview__leave--mobile"
             titleText={channelName}

--- a/src/modules/ChannelList/components/ChannelPreview/index.tsx
+++ b/src/modules/ChannelList/components/ChannelPreview/index.tsx
@@ -187,6 +187,11 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
               }
             </Label>
             {
+              /**
+               * Do not show unread count for focused channel. This is because of the limitation where
+               * isScrollBottom and hasNext states needs to be added globally but they are from channel context
+               * so channel list cannot see them with the current architecture.
+               */
               !isActive && !channel?.isEphemeral && (
                 <div className="sendbird-channel-preview__content__lower__unread-message-count">
                   {
@@ -228,12 +233,7 @@ const ChannelPreview: React.FC<ChannelPreviewInterface> = ({
         https://github.com/facebook/react/issues/11387#issuecomment-340019419
       */}
       {
-        /**
-         * Do not show unread count for focused channel. This is because of the limitation where
-         * isScrollBottom and hasNext states needs to be added globally but they are from channel context
-         * so channel list cannot see them with the current architecture.
-         */
-        (channel.url !== currentChannel?.url) && showMobileLeave && isMobile && (
+        showMobileLeave && isMobile && (
           <Modal
             className="sendbird-channel-preview__leave--mobile"
             titleText={channelName}

--- a/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -21,11 +21,11 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
     >
       <div
         class="sendbird-og-message-item-body__og-thumbnail__image sendbird-image-renderer"
-        style="width: 100%; min-width: min(400px, 400px); max-width: 400px;"
+        style="width: 100%; min-width: min(400px, 100%); max-width: 400px;"
       >
         <div
           class="sendbird-image-renderer__image"
-          style="width: 100%; min-width: min(400px, 400px); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url();"
+          style="width: 100%; min-width: min(400px, 100%); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url();"
         />
         <img
           alt=""

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -87,6 +87,10 @@ export default function OGMessageItemBody({
         onClick={openOGUrl}
       >
         <ImageRenderer
+          className="sendbird-og-message-item-body__og-thumbnail__image"
+          url={message?.ogMetaData?.defaultImage?.url || ''}
+          alt={message?.ogMetaData?.defaultImage?.alt}
+          width="100%"
           onLoad={onMessageHeightChange}
           onError={() => {
             try {
@@ -95,10 +99,6 @@ export default function OGMessageItemBody({
               // do nothing
             }
           }}
-          className="sendbird-og-message-item-body__og-thumbnail__image"
-          url={message?.ogMetaData?.defaultImage?.url || ''}
-          alt={message?.ogMetaData?.defaultImage?.alt}
-          // TODO: Change fixing width and height lengths
           defaultComponent={(
             <div className="sendbird-og-message-item-body__og-thumbnail__place-holder">
               <Icon


### PR DESCRIPTION
Fixes: [CLNP-1524](https://sendbird.atlassian.net/browse/CLNP-1524)

### Changelog
- Added and applied `useOnScrollReachedEndDetector()` in `MessageList` to mark new messages as read when scroll reaches bottom
- Channel list no longer displays unread message count for focused channel

The second change was due to limitation where isScrollBottom and hasNext states needs to be added globally but they are from channel context so channel list cannot see them with the current architecture.

[CLNP-1524]: https://sendbird.atlassian.net/browse/CLNP-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ