### PR TITLE
chore: Add script storybook:stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To read more: https://webpack.js.org/configuration/resolve/#resolvefallback
 3. Plop templates are found in [here](/plop-templates).
 
 ## Troubleshooting Guide
-- If you use node.js >= 17 and see `ERR_OSSL_EVP_UNSUPPORTED` error on any run cmd, try to set `export NODE_OPTIONS=--openssl-legacy-provider` in the terminal
+- If you use node.js >= 17 and see `ERR_OSSL_EVP_UNSUPPORTED` error on any run cmd, try to run `yarn storybook:stable` instead.
 
 
 ## Acknowledgments

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prepublishOnly": "yarn build",
     "predeploy": "yarn clean-release; yarn install; yarn build",
     "storybook": "start-storybook -p 6006",
+    "storybook:stable": "NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "lint": "yarn eslint; yarn eslint-ts",
     "lint:fix": "yarn eslint --fix; yarn eslint-ts --fix",


### PR DESCRIPTION
chore: Add script `storybook:stable` for using open SSL legacy provider
