### PR TITLE
fix: Clear localMessages when initializing message list

### DIFF
--- a/src/modules/Channel/context/dux/reducers.ts
+++ b/src/modules/Channel/context/dux/reducers.ts
@@ -46,6 +46,7 @@ export default function channelReducer(
         hasMorePrev: false,
         hasMoreNext: false,
         allMessages: [],
+        localMessages: [],
       };
     })
     .with({ type: channelActions.FETCH_INITIAL_MESSAGES_START }, () => {
@@ -56,6 +57,7 @@ export default function channelReducer(
           ? m.sendingStatus !== SendingStatus.SUCCEEDED
           : true,
         ),
+        localMessages: [],
       };
     })
     .with({ type: channelActions.FETCH_INITIAL_MESSAGES_SUCCESS }, (action) => {
@@ -201,6 +203,8 @@ export default function channelReducer(
       return {
         ...state,
         currentGroupChannel: null,
+        allMessages: [],
+        localMessages: [],
         isInvalid: true,
       };
     })


### PR DESCRIPTION
### Issue
The failed or pending messages were not removed from the message list when changing the current channel.

### ChangeLog
#### Fix
* Clear pending and failed messages from the message list when changing the current channel