### PR TITLE
fix: Fit the OGMessage Thumbnail Image to the minimal width length

### DIFF
--- a/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -21,11 +21,11 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
     >
       <div
         class="sendbird-og-message-item-body__og-thumbnail__image sendbird-image-renderer"
-        style="width: 100%; min-width: min(400px, 400px); max-width: 400px;"
+        style="width: 100%; min-width: min(400px, 100%); max-width: 400px;"
       >
         <div
           class="sendbird-image-renderer__image"
-          style="width: 100%; min-width: min(400px, 400px); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url();"
+          style="width: 100%; min-width: min(400px, 100%); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url();"
         />
         <img
           alt=""

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -87,6 +87,10 @@ export default function OGMessageItemBody({
         onClick={openOGUrl}
       >
         <ImageRenderer
+          className="sendbird-og-message-item-body__og-thumbnail__image"
+          url={message?.ogMetaData?.defaultImage?.url || ''}
+          alt={message?.ogMetaData?.defaultImage?.alt}
+          width="100%"
           onLoad={onMessageHeightChange}
           onError={() => {
             try {
@@ -95,10 +99,6 @@ export default function OGMessageItemBody({
               // do nothing
             }
           }}
-          className="sendbird-og-message-item-body__og-thumbnail__image"
-          url={message?.ogMetaData?.defaultImage?.url || ''}
-          alt={message?.ogMetaData?.defaultImage?.alt}
-          // TODO: Change fixing width and height lengths
           defaultComponent={(
             <div className="sendbird-og-message-item-body__og-thumbnail__place-holder">
               <Icon


### PR DESCRIPTION
Before & After
<img width="315" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/0975440f-77fa-4d8b-8390-f6ef36eef17a"><img width="314" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/6475ff6a-645c-4e45-9659-d208da493aa0">

### Fix
* Add width:100% to the ImageRenderer of OGMessage

### ChangeLog
* Fit the OGMessage Thumbnail Image to the minimal width length