### PR TITLE
fix: Complete GroupChannelList props interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@sendbird/chat": "^4.10.1",
-    "@sendbird/uikit-tools": "0.0.1-alpha.43",
+    "@sendbird/uikit-tools": "0.0.1-alpha.44",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "dompurify": "^3.0.1"

--- a/src/modules/App/stories/index.stories.js
+++ b/src/modules/App/stories/index.stories.js
@@ -6,6 +6,7 @@ import pkg from '../../../../package.json'
 import App from '../index';
 import Sendbird from '../../../lib/Sendbird';
 import ChannelList from '../../ChannelList';
+import GroupChannelList from '../../GroupChannelList';
 import Channel from '../../Channel';
 import ChannelSettings from '../../ChannelSettings';
 import MessageSearch from '../../MessageSearch';
@@ -362,12 +363,13 @@ export const user4 = () => fitPageSize(
   />
 );
 
-const UseSendbirdChannelList = (props) => {
+const SBChannelList = ({
+  setChannelUrl,
+}) => {
   const [queries] = useState({ channelListQuery: { customTypesFilter: ['apple'] } });
-  const { setChannelUrl } = props;
 
   return (
-    <ChannelList
+    <GroupChannelList
       onChannelSelect={(channel) => channel && setChannelUrl(channel?.url)}
       queries={queries}
       onBeforeCreateChannel={(selectedUserIds) => {
@@ -381,7 +383,6 @@ const UseSendbirdChannelList = (props) => {
     />
   );
 };
-const SBChannelList = withSendBird(UseSendbirdChannelList);
 const SBChannel = withSendBird((props) => {
   const {
     channelUrl,
@@ -427,8 +428,8 @@ const CustomApp = () => {
   return (
     <Sendbird
       appId={appId}
-      userId={array[4]}
-      nickname={array[4]}
+      userId={array[0]}
+      nickname={array[0]}
       theme="dark"
       showSearchIcon
       allowProfileEdit

--- a/src/modules/App/stories/index.stories.js
+++ b/src/modules/App/stories/index.stories.js
@@ -366,7 +366,7 @@ export const user4 = () => fitPageSize(
 const SBChannelList = ({
   setChannelUrl,
 }) => {
-  const [queries] = useState({ channelListQuery: { customTypesFilter: ['apple'] } });
+  const [query] = useState({ customTypesFilter: ['apple'] });
 
   const setCurrentChannel = (channel) => {
     if (channel) {
@@ -378,7 +378,7 @@ const SBChannelList = ({
     <GroupChannelList
       onChannelSelect={setCurrentChannel}
       onCreateChannel={setCurrentChannel}
-      queries={queries}
+      channelListQuery={query}
       onBeforeCreateChannel={(selectedUserIds) => {
         const params = {
           invitedUserIds: selectedUserIds,

--- a/src/modules/App/stories/index.stories.js
+++ b/src/modules/App/stories/index.stories.js
@@ -368,9 +368,16 @@ const SBChannelList = ({
 }) => {
   const [queries] = useState({ channelListQuery: { customTypesFilter: ['apple'] } });
 
+  const setCurrentChannel = (channel) => {
+    if (channel) {
+      setChannelUrl(channel.url);
+    }
+  };
+
   return (
     <GroupChannelList
-      onChannelSelect={(channel) => channel && setChannelUrl(channel?.url)}
+      onChannelSelect={setCurrentChannel}
+      onCreateChannel={setCurrentChannel}
       queries={queries}
       onBeforeCreateChannel={(selectedUserIds) => {
         const params = {

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -5,8 +5,15 @@ import {
   GroupChannel,
   GroupChannelCreateParams,
   GroupChannelHandler,
+  GroupChannelListOrder,
   GroupChannelListQuery as GroupChannelListQuerySb,
   GroupChannelUserIdsFilter,
+  HiddenChannelFilter,
+  MyMemberStateFilter,
+  PublicChannelFilter,
+  QueryType,
+  SuperChannelFilter,
+  UnreadChannelFilter,
 } from '@sendbird/chat/groupChannel';
 
 import { RenderUserProfileProps } from '../../../types';
@@ -37,26 +44,21 @@ export interface ApplicationUserListQueryInternal {
 export interface GroupChannelListQueryParamsInternal {
   limit?: number;
   includeEmpty?: boolean;
-  order?: 'latest_last_message' | 'chronological' | 'channel_name_alphabetical' | 'metadata_value_alphabetical';
+  order?: GroupChannelListOrder;
   userIdsExactFilter?: Array<string>;
   userIdsIncludeFilter?: Array<string>;
-  userIdsIncludeFilterQueryType?: 'AND' | 'OR';
+  userIdsIncludeFilterQueryType?: QueryType;
   nicknameContainsFilter?: string;
   channelNameContainsFilter?: string;
   customTypesFilter?: Array<string>;
   customTypeStartsWithFilter?: string;
   channelUrlsFilter?: Array<string>;
-  superChannelFilter?: 'all' | 'super' | 'nonsuper' | 'broadcast_only' | 'exclusive_only';
-  publicChannelFilter?: 'all' | 'public' | 'private';
+  superChannelFilter?: SuperChannelFilter;
+  publicChannelFilter?: PublicChannelFilter;
   metadataOrderKeyFilter?: string;
-  memberStateFilter?: 'all' | 'joined_only' | 'invited_only' | 'invited_by_friend' | 'invited_by_non_friend';
-  hiddenChannelFilter?:
-    | 'all'
-    | 'unhidden_only'
-    | 'hidden_only'
-    | 'hidden_allow_auto_unhide'
-    | 'hidden_prevent_auto_unhide';
-  unreadChannelFilter?: 'all' | 'unread_message';
+  memberStateFilter?: MyMemberStateFilter;
+  hiddenChannelFilter?: HiddenChannelFilter;
+  unreadChannelFilter?: UnreadChannelFilter;
   includeFrozen?: boolean;
   userIdsFilter?: GroupChannelUserIdsFilter;
 }

--- a/src/modules/ChannelList/utils.ts
+++ b/src/modules/ChannelList/utils.ts
@@ -1,6 +1,7 @@
 import {
   GroupChannel,
   GroupChannelHandler,
+  GroupChannelListOrder,
   GroupChannelListQuery,
   GroupChannelListQueryParams,
 } from '@sendbird/chat/groupChannel';
@@ -133,7 +134,7 @@ const createChannelListQuery = ({
   const params: GroupChannelListQueryParamsInternal = {
     includeEmpty: false,
     limit: 20, // The value of pagination limit could be set up to 100.
-    order: 'latest_last_message', // 'chronological', 'latest_last_message', 'channel_name_alphabetical', and 'metadata_value_alphabetical'
+    order: GroupChannelListOrder.LATEST_LAST_MESSAGE, // 'chronological', 'latest_last_message', 'channel_name_alphabetical', and 'metadata_value_alphabetical'
   };
 
   if (userFilledChannelListQuery) {

--- a/src/modules/ChannelList/utils.ts
+++ b/src/modules/ChannelList/utils.ts
@@ -134,7 +134,7 @@ const createChannelListQuery = ({
   const params: GroupChannelListQueryParamsInternal = {
     includeEmpty: false,
     limit: 20, // The value of pagination limit could be set up to 100.
-    order: GroupChannelListOrder.LATEST_LAST_MESSAGE, // 'chronological', 'latest_last_message', 'channel_name_alphabetical', and 'metadata_value_alphabetical'
+    order: GroupChannelListOrder.LATEST_LAST_MESSAGE,
   };
 
   if (userFilledChannelListQuery) {
@@ -149,7 +149,7 @@ const createChannelListQuery = ({
 /**
  * Setup event listener
  * create channel source query
- * addloading screen
+ * add loading screen
  */
 type SetupChannelListParams = {
   sdk: SdkStore['sdk'];

--- a/src/modules/GroupChannelList/components/AddGroupChannel/AddGroupChannelView.tsx
+++ b/src/modules/GroupChannelList/components/AddGroupChannel/AddGroupChannelView.tsx
@@ -12,6 +12,7 @@ type Props = {
   onChangeCreateChannelVisible: (value: boolean) => void;
   onBeforeCreateChannel?: CreateChannelProviderProps['onBeforeCreateChannel'];
   overrideInviteUser?: CreateChannelProviderProps['overrideInviteUser'];
+  onCreateChannel?: CreateChannelProviderProps['onCreateChannel'];
 };
 
 export const AddGroupChannelView = ({
@@ -19,6 +20,7 @@ export const AddGroupChannelView = ({
   onChangeCreateChannelVisible,
   onBeforeCreateChannel,
   overrideInviteUser,
+  onCreateChannel,
 }: Props) => {
   const { config } = useSendbirdStateContext();
 
@@ -40,7 +42,10 @@ export const AddGroupChannelView = ({
       {createChannelVisible && (
         <CreateChannel
           onCancel={() => onChangeCreateChannelVisible(false)}
-          onCreateChannel={() => onChangeCreateChannelVisible(false)}
+          onCreateChannel={(channel) => {
+            onCreateChannel?.(channel);
+            onChangeCreateChannelVisible(false);
+          }}
           onBeforeCreateChannel={onBeforeCreateChannel}
           overrideInviteUser={overrideInviteUser}
         />

--- a/src/modules/GroupChannelList/components/AddGroupChannel/index.tsx
+++ b/src/modules/GroupChannelList/components/AddGroupChannel/index.tsx
@@ -4,13 +4,17 @@ import { useGroupChannelListContext } from '../../context/GroupChannelListProvid
 
 export const AddGroupChannel = () => {
   const [createChannelVisible, setCreateChannelVisible] = useState(false);
-  const { onBeforeCreateChannel } = useGroupChannelListContext();
+  const {
+    onCreateChannel,
+    onBeforeCreateChannel,
+  } = useGroupChannelListContext();
 
   return (
     <AddGroupChannelView
       createChannelVisible={createChannelVisible}
       onChangeCreateChannelVisible={setCreateChannelVisible}
       onBeforeCreateChannel={onBeforeCreateChannel}
+      onCreateChannel={onCreateChannel}
     />
   );
 };

--- a/src/modules/GroupChannelList/components/GroupChannelListUI/index.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListUI/index.tsx
@@ -36,6 +36,7 @@ const GroupChannelListUI = (props: GroupChannelListUIProps) => {
   } = props;
 
   const {
+    onChannelSelect,
     onThemeChange,
     allowProfileEdit,
     groupChannels,
@@ -50,7 +51,6 @@ const GroupChannelListUI = (props: GroupChannelListUIProps) => {
   const renderListItem = (renderProps: { item: GroupChannel; index: number }) => {
     const { item: channel, index } = renderProps;
 
-    // todo: Refactor and move this inside channel - preview
     const onLeaveChannel: RenderChannelPreviewProps['onLeaveChannel'] = async (
       targetChannel,
       cb,
@@ -65,7 +65,7 @@ const GroupChannelListUI = (props: GroupChannelListUIProps) => {
     const onClick = () => {
       if (isOnline) {
         logger.info('ChannelList: Clicked on channel:', channel);
-        // TODO: onChannelSelect(channel);
+        onChannelSelect(channel);
       }
     };
 

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -44,6 +44,11 @@ interface GroupChannelListContextType {
 
   // Custom
   // Partial props - because we are doing null check before calling these functions
+  /**
+   * TODO: - channelListQuery
+   * Make a separated Params type for GroupChannelListProps.
+   * Because we don't need to keep the same exact input with ChannelList module.
+   */
   channelListQuery?: GroupChannelListQueryParamsInternal;
   onThemeChange?(theme: string): void;
   onClickCreateChannel?(params: OverrideInviteUserType): void;

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -2,13 +2,24 @@ import React, { useContext, useState } from 'react';
 
 import type { User } from '@sendbird/chat';
 import type { GroupChannel, GroupChannelCreateParams } from '@sendbird/chat/groupChannel';
-import { useGroupChanelList, useGroupChannelHandler } from '@sendbird/uikit-tools';
+import {
+  GroupChannelFilter,
+  GroupChannelListOrder,
+  QueryType,
+  SuperChannelFilter,
+  PublicChannelFilter,
+  MyMemberStateFilter,
+  HiddenChannelFilter,
+  UnreadChannelFilter,
+} from '@sendbird/chat/groupChannel';
 
 import { noop } from '../../../utils/utils';
 
-import { CHANNEL_TYPE } from '../../CreateChannel/types';
+import type { GroupChannelListQueryParamsInternal } from '../../ChannelList/context/ChannelListProvider';
+import type { CHANNEL_TYPE } from '../../CreateChannel/types';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
-import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
+import { UserProfileProvider, type UserProfileProviderProps } from '../../../lib/UserProfileContext';
+import { useGroupChannelList, useGroupChannelHandler } from '@sendbird/uikit-tools';
 
 type OverrideInviteUserType = {
   users: Array<string>;
@@ -33,15 +44,16 @@ interface GroupChannelListContextType {
 
   // Custom
   // Partial props - because we are doing null check before calling these functions
+  channelListQuery?: GroupChannelListQueryParamsInternal;
   onThemeChange?(theme: string): void;
   onClickCreateChannel?(params: OverrideInviteUserType): void;
   onBeforeCreateChannel?(users: Array<string>): GroupChannelCreateParams;
   onUpdatedUserProfile?(user: User): void;
 }
 
-export interface GroupChannelListProviderProps extends Partial<GroupChannelListContextType>, UserProfileProviderProps, React.PropsWithChildren {}
+export interface GroupChannelListProviderProps extends Partial<GroupChannelListContextType>, UserProfileProviderProps, React.PropsWithChildren { }
 
-export interface GroupChannelListProviderInterface extends GroupChannelListContextType, ReturnType<typeof useGroupChanelList> {
+export interface GroupChannelListProviderInterface extends GroupChannelListContextType, ReturnType<typeof useGroupChannelList> {
   typingChannelUrls: Array<string>;
 }
 
@@ -88,6 +100,7 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
     isMessageReceiptStatusEnabled = null,
 
     // Custom
+    channelListQuery,
     onThemeChange,
     onChannelSelect = noop,
     onCreateChannel,
@@ -109,9 +122,36 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
   } = config;
   const sdk = sdkStore?.sdk;
 
-  const channelListStore = useGroupChanelList(sdk, {
-    // TODO: Apply the filter props
-  });
+  const channelListStore = useGroupChannelList(
+    sdk,
+    !channelListQuery ? {} : {
+      collectionCreator: () => {
+        const filter = new GroupChannelFilter();
+        filter.includeEmpty = channelListQuery.includeEmpty ?? false;
+        filter.includeFrozen = channelListQuery.includeFrozen ?? false;
+        filter.setUserIdsFilter(
+          channelListQuery.userIdsExactFilter ?? channelListQuery.userIdsIncludeFilter ?? [],
+          channelListQuery.userIdsExactFilter ? false : true,
+          channelListQuery.userIdsIncludeFilterQueryType ?? QueryType.AND,
+        );
+        filter.nicknameContainsFilter = channelListQuery.nicknameContainsFilter ?? '';
+        filter.channelNameContainsFilter = channelListQuery.channelNameContainsFilter ?? '';
+        filter.customTypesFilter = channelListQuery.customTypesFilter ?? [];
+        filter.customTypeStartsWithFilter = channelListQuery.customTypeStartsWithFilter ?? '';
+        filter.channelUrlsFilter = channelListQuery.channelUrlsFilter ?? [];
+        filter.superChannelFilter = channelListQuery.superChannelFilter ?? SuperChannelFilter.ALL;
+        filter.publicChannelFilter = channelListQuery.publicChannelFilter ?? PublicChannelFilter.ALL;
+        filter.myMemberStateFilter = channelListQuery.memberStateFilter ?? MyMemberStateFilter.ALL;
+        filter.hiddenChannelFilter = channelListQuery.hiddenChannelFilter ?? HiddenChannelFilter.ALL;
+        filter.unreadChannelFilter = channelListQuery.unreadChannelFilter ?? UnreadChannelFilter.ALL;
+        return sdk.groupChannel.createGroupChannelCollection({
+          filter,
+          limit: channelListQuery.limit ?? 20,
+          order: channelListQuery.order ?? GroupChannelListOrder.LATEST_LAST_MESSAGE,
+        });
+      },
+    },
+  );
   const {
     refreshing,
     initialized,

--- a/src/modules/GroupChannelList/index.tsx
+++ b/src/modules/GroupChannelList/index.tsx
@@ -4,14 +4,14 @@ import {
   GroupChannelListProviderProps,
 } from './context/GroupChannelListProvider';
 
-import ChannelListUI, { GroupChannelListUIProps } from './components/GroupChannelListUI';
+import GroupChannelListUI, { GroupChannelListUIProps } from './components/GroupChannelListUI';
 
-interface GroupChannelListProps extends GroupChannelListProviderProps, GroupChannelListUIProps {}
+export interface GroupChannelListProps extends GroupChannelListProviderProps, GroupChannelListUIProps {}
 
-export const GroupChannelList: React.FC<GroupChannelListProps> = (props: GroupChannelListProps) => {
+export const GroupChannelList = (props: GroupChannelListProps) => {
   return (
     <GroupChannelListProvider {...props} >
-      <ChannelListUI {...props} />
+      <GroupChannelListUI {...props} />
     </GroupChannelListProvider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,7 +3853,7 @@ __metadata:
     "@rollup/plugin-replace": ^5.0.4
     "@rollup/plugin-typescript": ^11.1.5
     "@sendbird/chat": ^4.10.1
-    "@sendbird/uikit-tools": 0.0.1-alpha.43
+    "@sendbird/uikit-tools": 0.0.1-alpha.44
     "@storybook/addon-actions": ^6.5.10
     "@storybook/addon-docs": ^6.5.10
     "@storybook/addon-links": ^6.5.10
@@ -3918,13 +3918,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sendbird/uikit-tools@npm:0.0.1-alpha.43":
-  version: 0.0.1-alpha.43
-  resolution: "@sendbird/uikit-tools@npm:0.0.1-alpha.43"
+"@sendbird/uikit-tools@npm:0.0.1-alpha.44":
+  version: 0.0.1-alpha.44
+  resolution: "@sendbird/uikit-tools@npm:0.0.1-alpha.44"
   peerDependencies:
     "@sendbird/chat": ^4.9.2
     react: ">=16.8.6"
-  checksum: 7aa888a2888faf7295dbdfca91cf60e70e2933e52b3158a7b4b6de8b01f406bbf429ce83ee44133e636ce8e4f1157ee6c885f3ca802780fa22e6ac5e24bf563c
+  checksum: 9f2a6df9283060174a3e1b2e6421c5de99405484b31067d4dcd45d91a942cb11357aa3bd8379057f8f8d8fb8a9c3a9db82028ace2088f4ab8ad5a131f6d30765
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Fix
* Use uikit-tools 0.0.1-alpha.44
* Update the `GroupChannelListQueryParamsInternal` with the recent supporting types
* Call `onChannelSelect` in the GroupChannelList
* Add a `channelListQuery` to the GruopChannelList props
* Add the `onChannelCreate` props to the CreateGroupChannel component
* Use the `onChannelCreate` props to set the current channel in the Custom App of storybook sample