### PR TITLE
bug-fix: Group channel user left or banned event should not be ignored

### DIFF
--- a/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
+++ b/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
@@ -196,12 +196,13 @@ function useHandleChannelEvents({
             });
           }
         },
-        onUserBanned: (channel, user) => {
-          if (compareIds(channel?.url, channelUrl) && user?.userId === sdk?.currentUser?.userId) {
+        onUserBanned: (channel: GroupChannel, user) => {
+          if (compareIds(channel?.url, channelUrl)) {
             logger.info('Channel | useHandleChannelEvents: onUserBanned', { channel, user });
+            const isByMe = user?.userId === sdk?.currentUser?.userId;
             messagesDispatcher({
               type: messageActions.SET_CURRENT_CHANNEL,
-              payload: null,
+              payload: isByMe ? null : channel,
             });
           }
         },
@@ -217,12 +218,11 @@ function useHandleChannelEvents({
         onUserLeft: (channel, user) => {
           if (compareIds(channel?.url, channelUrl)) {
             logger.info('Channel | useHandleChannelEvents: onUserLeft', { channel, user });
-            if (user?.userId === currentUserId) {
-              messagesDispatcher({
-                type: messageActions.SET_CURRENT_CHANNEL,
-                payload: null,
-              });
-            }
+            const isByMe = user?.userId === sdk?.currentUser?.userId;
+            messagesDispatcher({
+              type: messageActions.SET_CURRENT_CHANNEL,
+              payload: isByMe ? null : channel,
+            });
           }
         },
         onTypingStatusUpdated: (channel) => {


### PR DESCRIPTION
Fixes: [<TICKET_ID>](https://sendbird.atlassian.net/browse/<TICKET_ID>)

### Changelogs
- Fixed a bug where  `currentGroupChannel` of `useChannelContext()` not being updated when non-current user has left or been banned while `ChannelList` is not being used