### PR TITLE
fix: update currentUserId properly in channel list initialize step

### DIFF
--- a/src/modules/ChannelList/dux/actionTypes.ts
+++ b/src/modules/ChannelList/dux/actionTypes.ts
@@ -45,7 +45,9 @@ type CHANNEL_LIST_PAYLOAD_TYPES = {
 
   [FETCH_CHANNELS_SUCCESS]: GroupChannel[];
   [FETCH_CHANNELS_FAILURE]: null;
-  [INIT_CHANNELS_START]: null;
+  [INIT_CHANNELS_START]: {
+    currentUserId: string;
+  };
   [INIT_CHANNELS_SUCCESS]: {
     channelList: GroupChannel[];
     disableAutoSelect: boolean;
@@ -68,7 +70,6 @@ type CHANNEL_LIST_PAYLOAD_TYPES = {
   [CHANNEL_REPLACED_TO_TOP]: GroupChannel;
   [CHANNEL_LIST_PARAMS_UPDATED]: {
     channelListQuery: GroupChannelListQuery;
-    currentUserId: string | undefined;
   };
 };
 

--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -11,7 +11,11 @@ export default function channelListReducer(
 ): ChannelListInitialStateType {
   return (
     match(action)
-      .with({ type: channelListActions.INIT_CHANNELS_START }, () => ({ ...state, loading: true }))
+      .with({ type: channelListActions.INIT_CHANNELS_START }, ({ payload }) => ({
+        ...state,
+        loading: true,
+        currentUserId: payload.currentUserId,
+      }))
       .with({ type: channelListActions.RESET_CHANNEL_LIST }, () => initialState)
       .with({ type: channelListActions.INIT_CHANNELS_SUCCESS }, (action) => {
         const { channelList, disableAutoSelect } = action.payload;
@@ -289,13 +293,10 @@ export default function channelListReducer(
           allChannels: [action.payload, ...state.allChannels.filter((channel) => channel?.url !== action.payload.url)],
         };
       })
-      .with({ type: channelListActions.CHANNEL_LIST_PARAMS_UPDATED }, (action) => {
-        return {
-          ...state,
-          currentUserId: action.payload.currentUserId,
-          channelListQuery: action.payload.channelListQuery,
-        };
-      })
+      .with({ type: channelListActions.CHANNEL_LIST_PARAMS_UPDATED }, (action) => ({
+        ...state,
+        channelListQuery: action.payload.channelListQuery,
+      }))
       .otherwise(() => state)
   );
 }

--- a/src/modules/ChannelList/utils.ts
+++ b/src/modules/ChannelList/utils.ts
@@ -194,6 +194,9 @@ function setupChannelList({
 
   channelListDispatcher({
     type: channelActions.INIT_CHANNELS_START,
+    payload: {
+      currentUserId: sdk?.currentUser?.userId ?? '',
+    }
   });
 
   if (userFilledChannelListQuery) {
@@ -202,7 +205,6 @@ function setupChannelList({
       type: channelActions.CHANNEL_LIST_PARAMS_UPDATED,
       payload: {
         channelListQuery,
-        currentUserId: sdk && sdk.currentUser && sdk.currentUser.userId,
       },
     });
   }
@@ -225,7 +227,10 @@ function setupChannelList({
         }
         channelListDispatcher({
           type: channelActions.INIT_CHANNELS_SUCCESS,
-          payload: { channelList: sortedChannelList, disableAutoSelect },
+          payload: {
+            channelList: sortedChannelList,
+            disableAutoSelect,
+          },
         });
         const canSetMarkAsDelivered = sdk?.appInfo?.premiumFeatureList?.find((feature) => feature === DELIVERY_RECEIPT);
 


### PR DESCRIPTION
- Fix group channel doesn't move to the top in a channel list even though latest_last_message is the default order.
- ticket: [CLNP-1697]

[CLNP-1697]: https://sendbird.atlassian.net/browse/CLNP-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ