### PR TITLE
fix: Use PropsWithChildren<unknown> instead PropsWithChildren

### DIFF
--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -8,7 +8,7 @@ export type OpenGlobalModalProps = {
   modalProps: ModalProps;
   childElement: (props: { closeModal: () => void }) => ReactElement;
 };
-export type GlobalModalProviderProps = React.PropsWithChildren;
+export type GlobalModalProviderProps = React.PropsWithChildren<unknown>;
 export interface GlobalModalContextInterface {
   openModal: (props: OpenGlobalModalProps) => void;
 }

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -79,7 +79,7 @@ export interface SendbirdConfig {
   isREMUnitEnabled?: boolean;
 }
 
-export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.PropsWithChildren {
+export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.PropsWithChildren<unknown> {
   appId: string;
   userId: string;
   accessToken?: string;


### PR DESCRIPTION
### Issue
* [Can't use `PropsWithChildren` because of type error](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60641)
  * Not assignable to type error, property 'children' doesn't exist on type `PropsWithChildren`
* [Can't use `PropsWithChildren<{}>` because of lint error](https://stackoverflow.com/questions/65548388/react-propswithchildren-with-no-props-other-than-children)

### Fix
* Use Use `PropsWithChildren<unknown>` instead `PropsWithChildren`

### ChangeLog
* Fix a type error from SendbirdProvider
  * Not assignable to type error, property 'children' doesn't exist on type `PropsWithChildren`