### PR TITLE
fix: replay voice memos

### DIFF
--- a/src/hooks/VoicePlayer/dux/reducer.ts
+++ b/src/hooks/VoicePlayer/dux/reducer.ts
@@ -90,7 +90,10 @@ export default function voicePlayerReducer(
       const { groupKey } = action.payload as OnCurrentTimeUpdatePayload;
       const { currentTime, duration } = state.currentPlayer as HTMLAudioElement;
       const audioUnit = (state.audioStorage?.[groupKey] ? state.audioStorage[groupKey] : AudioUnitDefaultValue()) as AudioStorageUnit;
-      if (currentTime > 0 && duration > 0) {
+      // sometimes the final time update is fired AFTER the pause event when audio is finished
+      if (audioUnit.playbackTime === audioUnit.duration && audioUnit.playingStatus === VOICE_PLAYER_STATUS.PAUSED) {
+        audioUnit.playbackTime = 0;
+      } else if (currentTime > 0 && duration > 0) {
         audioUnit.playbackTime = currentTime;
         audioUnit.duration = duration;
       }


### PR DESCRIPTION
- I am unable to replay voice memos after listening to them once (Apple M2 MBP 16")
- When playback is complete, the progress bar overlay shows 00:00 and blocks replaying:
<img width="273" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/2145098/25e87058-43d6-46c3-9d18-39b08c7a686b">

- Here are logs from before my fix - notice that when the pause event is fired, currentTime doesn't equal duration yet, and instead a timeupdate event is fired immediately after: 
![before](https://github.com/sendbird/sendbird-uikit-react/assets/2145098/fad7ee6b-3c75-49d2-8ca6-a09081053edb)

- And after the fix - replay works:
![after-fix](https://github.com/sendbird/sendbird-uikit-react/assets/2145098/e625a4ec-0780-4b83-908a-47ac89b13053)

## CLA Notes
- I see the project isn't currently setup for external contributors
- I am emailing developer-advocates@sendbird.com now to hopefully setup a CLA