### PR TITLE
fix: channel view should show NO_CHANNEL placeholder after leaving all channels

### DIFF
--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -311,9 +311,16 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
 
   // Set current channel (by on_channel_selected event)
   useEffect(() => {
-    if (!sdk || !sdk.groupChannel || !currentChannel || !currentChannel?.url) {
+    if (!sdk || !sdk.groupChannel) {
       return;
     }
+
+    // When leaving a channel, tell consumers that the prior channel is no longer selected
+    if (!currentChannel?.url) {
+      onChannelSelect(null);
+      return;
+    }
+
     sdk.groupChannel.getChannel(currentChannel.url).then((groupChannel) => {
       if (groupChannel) {
         onChannelSelect(groupChannel);

--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -97,10 +97,11 @@ export default function channelListReducer(
         { type: P.union(channelListActions.LEAVE_CHANNEL_SUCCESS, channelListActions.ON_CHANNEL_DELETED) },
         (action) => {
           const channelUrl = action.payload;
+          const allChannels = state.allChannels.filter(({ url }) => url !== channelUrl);
           return {
             ...state,
-            currentChannel: channelUrl === state.currentChannel?.url ? state.allChannels[0] : state.currentChannel,
-            allChannels: state.allChannels.filter(({ url }) => url !== channelUrl),
+            currentChannel: channelUrl === state.currentChannel?.url ? allChannels[0] : state.currentChannel,
+            allChannels,
           };
         },
       )


### PR DESCRIPTION
- before change - after leaving your only channel, you still see a channel view with `No Title` that allows typing messages (but then fails to send):
![before](https://github.com/sendbird/sendbird-uikit-react/assets/2145098/3912fcf4-ff16-445c-bd90-e9333e9fc3b2)

- after change - you see the NO_CHANNEL placeholder, as expected:
![after](https://github.com/sendbird/sendbird-uikit-react/assets/2145098/34932e31-0ad2-4679-8dfe-75b8f5ca16c7)

# CLA Notes
- as noted on #893 , I've reached out to support asking how to move forward with a CLA