### PR TITLE
fix: Include metaArray to messages when reconnecting

### DIFF
--- a/src/hooks/VoicePlayer/useVoicePlayer.tsx
+++ b/src/hooks/VoicePlayer/useVoicePlayer.tsx
@@ -75,7 +75,7 @@ export const useVoicePlayer = ({
      * The unit of playbackTime and duration should be millisecond
      */
     playbackTime: (currentAudioUnit?.playbackTime || 0) * 1000,
-    duration: (currentAudioUnit?.duration || 0)  * 1000,
+    duration: (currentAudioUnit?.duration || 0) * 1000,
     playingStatus: currentAudioUnit.playingStatus,
   });
 };

--- a/src/hooks/VoicePlayer/useVoicePlayer.tsx
+++ b/src/hooks/VoicePlayer/useVoicePlayer.tsx
@@ -70,9 +70,12 @@ export const useVoicePlayer = ({
     play: playVoicePlayer,
     pause: pauseVoicePlayer,
     stop: stopVoicePlayer,
-    playbackTime: currentAudioUnit.playbackTime * 1000,
-    duration: currentAudioUnit.duration * 1000,
-    // the unit of playbackTime and duration should be millisecond
+    /**
+     * The reason why we multiply this by *1000 is,
+     * The unit of playbackTime and duration should be millisecond
+     */
+    playbackTime: (currentAudioUnit?.playbackTime || 0) * 1000,
+    duration: (currentAudioUnit?.duration || 0)  * 1000,
     playingStatus: currentAudioUnit.playingStatus,
   });
 };

--- a/src/lib/hooks/useOnlineStatus.ts
+++ b/src/lib/hooks/useOnlineStatus.ts
@@ -20,7 +20,6 @@ function useOnlineStatus(sdk: SendbirdChat, logger: LoggerInterface) {
         onReconnectStarted() {
           setIsOnline(false);
           logger.warning('onReconnectStarted', { isOnline });
-
         },
         onReconnectSucceeded() {
           setIsOnline(true);

--- a/src/modules/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/modules/Channel/context/hooks/useHandleReconnect.ts
@@ -54,6 +54,7 @@ function useHandleReconnect(
           prevResultSize: PREV_RESULT_SIZE,
           isInclusive: true,
           includeReactions: isReactionEnabled,
+          includeMetaArray: true,
           nextResultSize: NEXT_RESULT_SIZE,
         };
         if (replyType && replyType === 'QUOTE_REPLY') {


### PR DESCRIPTION
## Issue
[CLNP-1779](https://sendbird.atlassian.net/browse/CLNP-1779)

## Fix
* Include `metaArray` to the message list when fetching messages again by connecting
## ChangeLog
* Resolve `NaN` message on VoiceMessage after reconnection

[CLNP-1779]: https://sendbird.atlassian.net/browse/CLNP-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ