### PR TITLE
refactor: move --sendbird-vh css variable setting logic to comp

### DIFF
--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -40,7 +40,8 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (
     setStartingPoint,
     threadTargetMessage,
     setThreadTargetMessage,
-    highlightedMessage, setHighlightedMessage,
+    highlightedMessage,
+    setHighlightedMessage,
   } = props;
   const [panel, setPanel] = useState(PANELS.CHANNEL_LIST);
 

--- a/src/modules/CreateChannel/components/InviteUsers/index.tsx
+++ b/src/modules/CreateChannel/components/InviteUsers/index.tsx
@@ -54,7 +54,7 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
   const titleText = stringSet.MODAL__CREATE_CHANNEL__TITLE;
   const submitText = stringSet.BUTTON__CREATE;
   const { isMobile } = useMediaQueryContext();
-  const [appHeight, setAppHeight] = useState<number>(window.innerHeight);
+  const [scrollableAreaHeight, setScrollableAreaHeight] = useState<number>(window.innerHeight);
 
   const userQueryCreator = userListQuery ? userListQuery() : createDefaultUserListQuery({ sdk });
 
@@ -71,12 +71,12 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
 
   // To fix navbar break in mobile we set dynamic height to the scrollable area
   useEffect(() => {
-    const appHeight = () => {
-      setAppHeight(window.innerHeight);
+    const scrollableAreaHeight = () => {
+      setScrollableAreaHeight(window.innerHeight);
     };
-    window.addEventListener('resize', appHeight);
+    window.addEventListener('resize', scrollableAreaHeight);
     return () => {
-      window.removeEventListener('resize', appHeight);
+      window.removeEventListener('resize', scrollableAreaHeight);
     };
   }, []);
 
@@ -135,7 +135,7 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
         </Label>
         <div
           className="sendbird-create-channel--scroll"
-          style={isMobile ? { height: `calc(${appHeight}px - 200px)` } : {}}
+          style={isMobile ? { height: `calc(${scrollableAreaHeight}px - 200px)` } : {}}
           onScroll={(e) => {
             if (!usersDataSource) return;
             const eventTarget = e.target as HTMLDivElement;

--- a/src/modules/CreateChannel/components/InviteUsers/index.tsx
+++ b/src/modules/CreateChannel/components/InviteUsers/index.tsx
@@ -6,7 +6,7 @@ import './invite-users.scss';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import { useCreateChannelContext } from '../../context/CreateChannelProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-
+import { useMediaQueryContext } from '../../../../lib/MediaQueryContext';
 import Modal from '../../../../ui/Modal';
 import Label, {
   LabelColors,
@@ -27,15 +27,6 @@ export interface InviteUsersProps {
   onCancel?: () => void;
   userListQuery?(): UserListQuery;
 }
-
-const appHeight = () => {
-  try {
-    const doc = document.documentElement;
-    doc.style.setProperty('--sendbird-vh', (window.innerHeight * 0.01) + 'px');
-  } catch {
-    //
-  }
-};
 
 const BUFFER = 50;
 
@@ -62,6 +53,8 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
   const selectedCount = Object.keys(selectedUsers).length;
   const titleText = stringSet.MODAL__CREATE_CHANNEL__TITLE;
   const submitText = stringSet.BUTTON__CREATE;
+  const { isMobile } = useMediaQueryContext();
+  const [appHeight, setAppHeight] = useState<number>(window.innerHeight);
 
   const userQueryCreator = userListQuery ? userListQuery() : createDefaultUserListQuery({ sdk });
 
@@ -76,11 +69,11 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
     }
   }, []);
 
-  // https://stackoverflow.com/a/70302463
-  // https://css-tricks.com/the-trick-to-viewport-units-on-mobile/#css-custom-properties-the-trick-to-correct-sizing
-  // to fix navbar break in mobile
+  // To fix navbar break in mobile we set dynamic height to the scrollable area
   useEffect(() => {
-    appHeight();
+    const appHeight = () => {
+      setAppHeight(window.innerHeight);
+    };
     window.addEventListener('resize', appHeight);
     return () => {
       window.removeEventListener('resize', appHeight);
@@ -142,6 +135,7 @@ const InviteUsers: React.FC<InviteUsersProps> = ({
         </Label>
         <div
           className="sendbird-create-channel--scroll"
+          style={isMobile ? { height: `calc(${appHeight}px - 200px)` } : {}}
           onScroll={(e) => {
             if (!usersDataSource) return;
             const eventTarget = e.target as HTMLDivElement;

--- a/src/modules/CreateChannel/components/InviteUsers/invite-users.scss
+++ b/src/modules/CreateChannel/components/InviteUsers/invite-users.scss
@@ -9,8 +9,4 @@
   height: 360px;
   overflow-x: hidden;
   overflow-y: scroll;
-  @include mobile() {
-    // Try to use `--sendbird-vh` for refer window.innerHeight
-    height: calc(calc(var(--sendbird-vh, 1vh) * 100) - 200px);
-  }
 }


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-1806

We have been calculating the height value of the modules/InviteUsers modal using the --sendbird-vh CSS variable in the following manner: [GitHub Link](https://github.com/sendbird/sendbird-uikit-react/blob/main/src/modules/CreateChannel/components/InviteUsers/invite-users.scss#L13).

I believe this approach was taken to adjust the dynamic scrollable area height, especially in mobile view. However, it hampers code readability as we need to search for the keyword to locate where it is defined.

Therefore, I propose relocating this logic to the InviteUsers component and consolidating all related logic within a single file.



Confirmed that it's working as before on mobile window size change. 
![record](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/445d672d-9b7e-41c4-ad40-cd8647e847eb)
