### PR TITLE
fix: Add missing props renderMessageContent

### DIFF
--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -1,8 +1,9 @@
 import './channel-ui.scss';
 
 import React from 'react';
-import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
+import type { MessageContentProps } from '../../../../ui/MessageContent';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useChannelContext } from '../../context/ChannelProvider';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import ConnectionStatus from '../../../../ui/ConnectionStatus';
@@ -19,6 +20,7 @@ export interface ChannelUIProps {
   renderPlaceholderEmpty?: () => React.ReactElement;
   renderChannelHeader?: () => React.ReactElement;
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderFileUploadIcon?: () => React.ReactElement;
   renderVoiceMessageIcon?: () => React.ReactElement;
@@ -35,6 +37,7 @@ const ChannelUI: React.FC<ChannelUIProps> = ({
   renderPlaceholderEmpty,
   renderChannelHeader,
   renderMessage,
+  renderMessageContent,
   renderMessageInput,
   renderTypingIndicator,
   renderCustomSeparator,
@@ -108,6 +111,7 @@ const ChannelUI: React.FC<ChannelUIProps> = ({
       <MessageList
         className="sendbird-conversation__message-list"
         renderMessage={renderMessage}
+        renderMessageContent={renderMessageContent}
         renderPlaceholderEmpty={renderPlaceholderEmpty}
         renderCustomSeparator={renderCustomSeparator}
         renderPlaceholderLoader={renderPlaceholderLoader}

--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -11,7 +11,7 @@ import ChannelHeader from '../ChannelHeader';
 import MessageList from '../MessageList';
 import TypingIndicator from '../TypingIndicator';
 import MessageInputWrapper from '../MessageInput';
-import { RenderCustomSeparatorProps, RenderMessageProps, TypingIndicatorType } from '../../../../types';
+import { RenderCustomSeparatorProps, RenderMessageParamsType, TypingIndicatorType } from '../../../../types';
 
 export interface ChannelUIProps {
   isLoading?: boolean;
@@ -19,7 +19,7 @@ export interface ChannelUIProps {
   renderPlaceholderInvalid?: () => React.ReactElement;
   renderPlaceholderEmpty?: () => React.ReactElement;
   renderChannelHeader?: () => React.ReactElement;
-  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderMessageInput?: () => React.ReactElement;
   renderFileUploadIcon?: () => React.ReactElement;

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -26,19 +26,20 @@ import MessageContent, { type MessageContentProps } from '../../../../ui/Message
 import FileViewer from '../FileViewer';
 import RemoveMessageModal from '../RemoveMessageModal';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
-import { EveryMessage, RenderCustomSeparatorProps, RenderMessageProps } from '../../../../types';
+import { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../../types';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import { useDirtyGetMentions } from '../../../Message/hooks/useDirtyGetMentions';
 import SuggestedReplies from '../SuggestedReplies';
+import { omitObjectProperties } from '../../../../utils/omitObjectProperty';
 
-type MessageUIProps = {
+export interface MessageUIProps {
   message: EveryMessage;
   hasSeparator?: boolean;
   chainTop?: boolean;
   chainBottom?: boolean;
   handleScroll?: (isBottomMessageAffected?: boolean) => void;
   // for extending
-  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
   renderEditInput?: () => React.ReactElement;
@@ -193,20 +194,10 @@ const Message = (props: MessageUIProps): React.ReactElement => {
       clearTimeout(messageAnimatedTimeout);
     };
   }, [animatedMessageId, messageScrollRef.current, message.messageId, onMessageAnimated]);
-  const renderedMessage = useMemo(() => {
-    return renderMessage?.({
-      message,
-      chainTop,
-      chainBottom,
-    });
-  }, [message, renderMessage]);
-  const renderedCustomSeparator = useMemo(() => {
-    if (renderCustomSeparator) {
-      return renderCustomSeparator?.({ message: message });
-    }
-    return null;
-  }, [message, renderCustomSeparator]);
-
+  
+  // Operate `renderMessage` props
+  const renderedCustomSeparator = useMemo(() => renderCustomSeparator?.({ message: message }) ?? null, [message, renderCustomSeparator]);
+  const renderedMessage = useMemo(() => renderMessage?.(omitObjectProperties(props, ['renderMessage'])), [message, renderMessage]);
   if (renderedMessage) {
     return (
       <div

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -22,7 +22,7 @@ import { MAX_USER_MENTION_COUNT, MAX_USER_SUGGESTION_COUNT } from '../../context
 import DateSeparator from '../../../../ui/DateSeparator';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import MessageInput from '../../../../ui/MessageInput';
-import MessageContent from '../../../../ui/MessageContent';
+import MessageContent, { type MessageContentProps } from '../../../../ui/MessageContent';
 import FileViewer from '../FileViewer';
 import RemoveMessageModal from '../RemoveMessageModal';
 import { MessageInputKeys } from '../../../../ui/MessageInput/const';
@@ -39,9 +39,9 @@ type MessageUIProps = {
   handleScroll?: (isBottomMessageAffected?: boolean) => void;
   // for extending
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
   renderEditInput?: () => React.ReactElement;
-  renderMessageContent?: () => React.ReactElement;
 };
 
 // todo: Refactor this component, is too complex now

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -43,7 +43,7 @@ export interface MessageUIProps {
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
   renderEditInput?: () => React.ReactElement;
-};
+}
 
 // todo: Refactor this component, is too complex now
 const Message = (props: MessageUIProps): React.ReactElement => {
@@ -194,7 +194,7 @@ const Message = (props: MessageUIProps): React.ReactElement => {
       clearTimeout(messageAnimatedTimeout);
     };
   }, [animatedMessageId, messageScrollRef.current, message.messageId, onMessageAnimated]);
-  
+
   // Operate `renderMessage` props
   const renderedCustomSeparator = useMemo(() => renderCustomSeparator?.({ message: message }) ?? null, [message, renderCustomSeparator]);
   const renderedMessage = useMemo(() => renderMessage?.(omitObjectProperties(props, ['renderMessage'])), [message, renderMessage]);

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -349,7 +349,7 @@ const Message = (props: MessageUIProps): React.ReactElement => {
       }
       {/* Message */}
       {renderMessageContent({
-        className: "sendbird-message-hoc__message-content",
+        className: 'sendbird-message-hoc__message-content',
         userId,
         scrollToMessage,
         channel: currentGroupChannel,
@@ -379,7 +379,7 @@ const Message = (props: MessageUIProps): React.ReactElement => {
         && localMessages.every(message => (message as UserMessage).sendingStatus === 'succeeded')
         && getSuggestedReplies(message).length > 0 && (
           <SuggestedReplies replyOptions={getSuggestedReplies(message)} onSendMessage={sendMessage} />
-        )}
+      )}
       {/* Modal */}
       {
         showRemove && (

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -45,17 +45,18 @@ type MessageUIProps = {
 };
 
 // todo: Refactor this component, is too complex now
-const Message = ({
-  message,
-  hasSeparator,
-  chainTop,
-  chainBottom,
-  handleScroll,
-  renderCustomSeparator,
-  renderEditInput,
-  renderMessage,
-  renderMessageContent,
-}: MessageUIProps): React.ReactElement => {
+const Message = (props: MessageUIProps): React.ReactElement => {
+  const {
+    message,
+    hasSeparator,
+    chainTop,
+    chainBottom,
+    handleScroll,
+    renderCustomSeparator,
+    renderEditInput,
+    renderMessage,
+    renderMessageContent = (props) => (<MessageContent {...props} />),
+  } = props;
   const { dateLocale, stringSet } = useLocalization();
   const globalStore = useSendbirdStateContext();
 
@@ -69,6 +70,7 @@ const Message = ({
   const maxUserMentionCount = userMention?.maxMentionCount || MAX_USER_MENTION_COUNT;
   const maxUserSuggestionCount = userMention?.maxSuggestionCount || MAX_USER_SUGGESTION_COUNT;
 
+  const context = useChannelContext();
   const {
     initialized,
     currentGroupChannel,
@@ -94,7 +96,7 @@ const Message = ({
     onMessageHighlighted,
     sendMessage,
     localMessages,
-  } = useChannelContext();
+  } = context;
   const [showEdit, setShowEdit] = useState(false);
   const [showRemove, setShowRemove] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
@@ -346,42 +348,38 @@ const Message = ({
         ))
       }
       {/* Message */}
-      {
-        renderMessageContent?.() || (
-          <MessageContent
-            className="sendbird-message-hoc__message-content"
-            userId={userId}
-            scrollToMessage={scrollToMessage}
-            channel={currentGroupChannel}
-            message={message}
-            disabled={!isOnline}
-            chainTop={chainTop}
-            chainBottom={chainBottom}
-            isReactionEnabled={isReactionEnabled}
-            replyType={replyType}
-            threadReplySelectType={threadReplySelectType}
-            nicknamesMap={nicknamesMap}
-            emojiContainer={emojiContainer}
-            showEdit={setShowEdit}
-            showRemove={setShowRemove}
-            showFileViewer={setShowFileViewer}
-            resendMessage={resendMessage}
-            deleteMessage={deleteMessage}
-            toggleReaction={toggleReaction}
-            setQuoteMessage={setQuoteMessage}
-            onReplyInThread={onReplyInThread}
-            onQuoteMessageClick={onQuoteMessageClick}
-            onMessageHeightChange={handleScroll}
-          />
-        )
-      }
+      {renderMessageContent({
+        className: "sendbird-message-hoc__message-content",
+        userId,
+        scrollToMessage,
+        channel: currentGroupChannel,
+        message,
+        disabled: !isOnline,
+        chainTop,
+        chainBottom,
+        isReactionEnabled,
+        replyType,
+        threadReplySelectType,
+        nicknamesMap,
+        emojiContainer,
+        showEdit: setShowEdit,
+        showRemove: setShowRemove,
+        showFileViewer: setShowFileViewer,
+        resendMessage,
+        deleteMessage,
+        toggleReaction,
+        setQuoteMessage,
+        onReplyInThread,
+        onQuoteMessageClick: onQuoteMessageClick,
+        onMessageHeightChange: handleScroll,
+      })}
       {/** Suggested Replies */}
       {message.messageId === currentGroupChannel?.lastMessage?.messageId
         // the options should appear only when there's no failed or pending messages
         && localMessages.every(message => (message as UserMessage).sendingStatus === 'succeeded')
         && getSuggestedReplies(message).length > 0 && (
           <SuggestedReplies replyOptions={getSuggestedReplies(message)} onSendMessage={sendMessage} />
-      )}
+        )}
       {/* Modal */}
       {
         showRemove && (

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -250,6 +250,7 @@ const MessageList: React.FC<MessageListProps> = ({
                     <Message
                       handleScroll={moveScroll}
                       renderMessage={renderMessage}
+                      renderMessageContent={renderMessageContent}
                       message={m as EveryMessage}
                       chainTop={chainTop}
                       chainBottom={chainBottom}

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -1,7 +1,9 @@
 import './message-list.scss';
 
 import React, { useState } from 'react';
+import type { UserMessage } from '@sendbird/chat/message';
 
+import type { MessageContentProps } from '../../../../ui/MessageContent';
 import { useChannelContext } from '../../context/ChannelProvider';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import Icon, { IconColors, IconTypes } from '../../../../ui/Icon';
@@ -13,7 +15,6 @@ import UnreadCount from '../UnreadCount';
 import FrozenNotification from '../FrozenNotification';
 import { SCROLL_BUFFER } from '../../../../utils/consts';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-import { UserMessage } from '@sendbird/chat/message';
 import { MessageProvider } from '../../../Message/context/MessageProvider';
 import { useHandleOnScrollCallback } from '../../../../hooks/useHandleOnScrollCallback';
 import { useSetScrollToBottom } from './hooks/useSetScrollToBottom';
@@ -26,6 +27,7 @@ const SCROLL_BOTTOM_PADDING = 50;
 export interface MessageListProps {
   className?: string;
   renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderPlaceholderEmpty?: () => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
   renderPlaceholderLoader?: () => React.ReactElement;
@@ -35,6 +37,7 @@ export interface MessageListProps {
 const MessageList: React.FC<MessageListProps> = ({
   className = '',
   renderMessage,
+  renderMessageContent,
   renderPlaceholderEmpty,
   renderCustomSeparator,
   renderPlaceholderLoader,
@@ -217,6 +220,7 @@ const MessageList: React.FC<MessageListProps> = ({
                     <Message
                       handleScroll={moveScroll}
                       renderMessage={renderMessage}
+                      renderMessageContent={renderMessageContent}
                       message={m as EveryMessage}
                       hasSeparator={hasSeparator}
                       chainTop={chainTop}

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -8,7 +8,7 @@ import { useChannelContext } from '../../context/ChannelProvider';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import Icon, { IconColors, IconTypes } from '../../../../ui/Icon';
 import Message from '../Message';
-import { EveryMessage, RenderCustomSeparatorProps, RenderMessageProps, TypingIndicatorType } from '../../../../types';
+import { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType, TypingIndicatorType } from '../../../../types';
 import { isAboutSame } from '../../context/utils';
 import { getMessagePartsInfo } from './getMessagePartsInfo';
 import UnreadCount from '../UnreadCount';
@@ -26,7 +26,7 @@ const SCROLL_BOTTOM_PADDING = 50;
 
 export interface MessageListProps {
   className?: string;
-  renderMessage?: (props: RenderMessageProps) => React.ReactElement;
+  renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
   renderPlaceholderEmpty?: () => React.ReactElement;
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;

--- a/src/modules/Channel/index.tsx
+++ b/src/modules/Channel/index.tsx
@@ -49,6 +49,7 @@ const Channel: React.FC<ChannelProps> = (props: ChannelProps) => {
         renderPlaceholderEmpty={props?.renderPlaceholderEmpty}
         renderChannelHeader={props?.renderChannelHeader}
         renderMessage={props?.renderMessage}
+        renderMessageContent={props?.renderMessageContent}
         renderMessageInput={props?.renderMessageInput}
         renderTypingIndicator={props?.renderTypingIndicator}
         renderCustomSeparator={props?.renderCustomSeparator}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import type {
   UserMessage,
 } from '@sendbird/chat/message';
 import { CoreMessageType } from './utils';
+import { MessageUIProps } from './modules/Channel/components/Message';
 
 export type ReplyType = 'NONE' | 'QUOTE_REPLY' | 'THREAD';
 export type Nullable<T> = T | null;
@@ -54,11 +55,14 @@ export interface ClientMessage {
   _sender: User;
 }
 
+// This is used for OpenChannel.renderMessage
 export interface RenderMessageProps {
   message: CoreMessageType;
   chainTop: boolean;
   chainBottom: boolean;
 }
+// This is used for GroupChannel.renderMessage
+export type RenderMessageParamsType = Omit<MessageUIProps, 'renderMessage'>;
 
 export interface RenderCustomSeparatorProps {
   message: CoreMessageType;

--- a/src/utils/__tests__/omitObjectProperties.spec.ts
+++ b/src/utils/__tests__/omitObjectProperties.spec.ts
@@ -1,0 +1,38 @@
+import { omitObjectProperties } from "../omitObjectProperty";
+
+const mockObject = {
+  a: 'a',
+  b: 'b',
+  c: 'c',
+  one: 1,
+  two: 2,
+  null: null,
+  undefined: undefined,
+};
+
+describe('Global-utils/omitObjectProperties', () => {
+  it('should omit the existing properties from object', () => {
+    expect(omitObjectProperties(mockObject, ['a', 'two', 'null', 'undefined']))
+      .toEqual({
+        b: 'b',
+        c: 'c',
+        one: 1,
+      });
+  });
+
+  it('should not omit not-existing properties', () => {
+    expect(omitObjectProperties(mockObject, ['d', 'three', 'NaN']))
+      .toEqual(mockObject);
+  });
+
+  it('should not affect to the original object', () => {
+    const clone = { ...mockObject };
+    expect(omitObjectProperties(mockObject, ['a', 'two', 'null', 'undefined']))
+      .toEqual({
+        b: 'b',
+        c: 'c',
+        one: 1,
+      });
+    expect(mockObject).toEqual(clone);
+  });
+});

--- a/src/utils/__tests__/omitObjectProperties.spec.ts
+++ b/src/utils/__tests__/omitObjectProperties.spec.ts
@@ -1,4 +1,4 @@
-import { omitObjectProperties } from "../omitObjectProperty";
+import { omitObjectProperties } from '../omitObjectProperty';
 
 const mockObject = {
   a: 'a',

--- a/src/utils/omitObjectProperty.ts
+++ b/src/utils/omitObjectProperty.ts
@@ -1,0 +1,6 @@
+export function omitObjectProperties<O extends Record<string, any>> (obj: O, properties: string[]) {
+  properties.forEach((propertyName) => {
+    if (Object.hasOwn(obj, propertyName)) delete obj[propertyName]
+  });
+  return obj;
+};

--- a/src/utils/omitObjectProperty.ts
+++ b/src/utils/omitObjectProperty.ts
@@ -1,6 +1,6 @@
-export function omitObjectProperties<O extends Record<string, any>> (obj: O, properties: string[]) {
+export function omitObjectProperties<O extends Record<string, any>>(obj: O, properties: string[]) {
   properties.forEach((propertyName) => {
-    if (Object.hasOwn(obj, propertyName)) delete obj[propertyName]
+    if (Object.hasOwn(obj, propertyName)) delete obj[propertyName];
   });
   return obj;
-};
+}


### PR DESCRIPTION
### Issue
The `renderMessage` and the `renderMessageContent` props are diffrent.
Customers can easily customize the `renderMessageContent` after we provide several sub-components of the `MessageContent` component.

### Change Log
* Add missing props `renderMessageContent` in Channel

### Fix
* Add missing props `renderMessageContent` in Channel
* Create a util function, `omitObjectProperties`

#### How to customize MessageContent in Channel?
1. Customize with `renderMessage`
```tsx
<Channel
  renderMessage={(props) => (
    <Message
      {...props}
      renderMessageContent={(props) => (
        <MessageContent {...props} />
      )}
    />
  )}
/>
```

2. **[More Simple Way]** Customize with `renderMessageContent`
```tsx
<Channel
  renderMessageContent={(props) => (
    <MessageContent {...props} />
  )}
/>
```