### PR TITLE
fix(CLNP-1973): thread input should be disabled when it goes offline

### DIFF
--- a/src/modules/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/modules/Thread/components/ThreadMessageInput/index.tsx
@@ -33,7 +33,7 @@ const ThreadMessageInput = (
     renderVoiceMessageIcon,
     renderSendMessageIcon,
   } = props;
-  const propsDisabled = props.disabled;
+
   const { config } = useSendbirdStateContext();
   const { stringSet } = useLocalization();
   const {
@@ -56,12 +56,14 @@ const ThreadMessageInput = (
     allThreadMessages,
   } = threadContext;
   const messageInputRef = useRef();
+
   const isMultipleFilesMessageEnabled = (
     threadContext.isMultipleFilesMessageEnabled
     ?? config.isMultipleFilesMessageEnabled
   );
 
-  const disabled = propsDisabled
+  const threadInputDisabled = props.disabled
+    || !isOnline
     || isMuted
     || (!(currentChannel?.myRole === Role.OPERATOR) && isChannelFrozen) || parentMessage === null;
 
@@ -159,7 +161,7 @@ const ThreadMessageInput = (
             <MessageInput
               className="sendbird-thread-message-input__message-input"
               messageFieldId="sendbird-message-input-text-field--thread"
-              disabled={disabled}
+              disabled={threadInputDisabled}
               channel={currentChannel}
               setMentionedUsers={setMentionedUsers}
               channelUrl={currentChannel?.url}

--- a/src/modules/Thread/index.tsx
+++ b/src/modules/Thread/index.tsx
@@ -10,7 +10,7 @@ export interface ThreadProps extends ThreadProviderProps, ThreadUIProps {
   className?: string;
 }
 
-const Thread: React.FC<ThreadProps> = (props: ThreadProps) => {
+const Thread = (props: ThreadProps) => {
   const {
     // props
     className,


### PR DESCRIPTION
We don't currently support local caching for threads, so it should be disabled when it goes offline.

ticket: [CLNP-1973]

[CLNP-1973]: https://sendbird.atlassian.net/browse/CLNP-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ