### PR TITLE
Add message.message to message tokenize hook deps array

### DIFF
--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -149,7 +149,7 @@ const Message = (props: MessageUIProps): React.ReactElement => {
   }, [showEdit, message?.reactions?.length]);
   useDidMountEffect(() => {
     handleScroll?.(true);
-  }, [message?.updatedAt]);
+  }, [message?.updatedAt, (message as UserMessage)?.message]);
 
   useLayoutEffect(() => {
     let animationTimeout = null;

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -91,7 +91,7 @@ export default function ParentMessageInfoItem({
     return tokenizeMessage({
       messageText: (message as UserMessage)?.message,
     });
-  }, [message?.updatedAt]);
+  }, [message?.updatedAt, (message as UserMessage)?.message]);
 
   // Thumbnail mesage
   const [isImageRendered, setImageRendered] = useState(false);

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -58,7 +58,7 @@ export default function OGMessageItemBody({
     return tokenizeMessage({
       messageText: message?.message,
     });
-  }, [message?.updatedAt]);
+  }, [message?.updatedAt, message?.message]);
   return (
     <div className={getClassName([
       className,

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -96,7 +96,7 @@ export default function OpenchannelOGMessage({
     return tokenizeMessage({
       messageText: message.message,
     });
-  }, [message?.updatedAt]);
+  }, [message?.updatedAt, message?.message]);
 
   // place conxt menu top depending clientHeight of message component
   useEffect(() => {

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -40,7 +40,7 @@ export default function TextMessageItemBody({
     return tokenizeMessage({
       messageText: message?.message,
     });
-  }, [message?.updatedAt]);
+  }, [message?.updatedAt, message?.message]);
   return (
     <Label
       type={LabelTypography.BODY_1}


### PR DESCRIPTION
> This change is originally made by @ishubham21 at https://github.com/sendbird/sendbird-uikit-react/pull/916. Please refer to this PR for more detailed background.

`message.updateAt` won't be updated if the message is coming from a bot especially in streaming. Its value gets just `0`. I added one more field `message.message` to the dependency array so we can make sure the hook is being executed again. 

