### PR TITLE
fix: Enable the MessageInput if cache is enabled during disconnection

### DIFF
--- a/src/lib/hooks/useOnlineStatus.ts
+++ b/src/lib/hooks/useOnlineStatus.ts
@@ -76,7 +76,7 @@ function useOnlineStatus(sdk: SendbirdChat, logger: LoggerInterface) {
   // add offline-class to body
   useEffect(() => {
     const body = document.querySelector('body');
-    if (!isOnline) {
+    if (!isOnline && !sdk?.isCacheEnabled) {
       try {
         body.classList.add('sendbird__offline');
         logger.info('Added class sendbird__offline to body');
@@ -91,7 +91,7 @@ function useOnlineStatus(sdk: SendbirdChat, logger: LoggerInterface) {
         //
       }
     }
-  }, [isOnline]);
+  }, [isOnline, sdk?.isCacheEnabled]);
 
   return isOnline;
 }

--- a/src/modules/ChannelList/components/ChannelListUI/index.tsx
+++ b/src/modules/ChannelList/components/ChannelListUI/index.tsx
@@ -48,8 +48,9 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (
     onProfileEditSuccess,
   } = useChannelListContext();
 
-  const { config } = useSendbirdStateContext();
+  const { stores, config } = useSendbirdStateContext();
   const { logger, isOnline = false } = config;
+  const sdk = stores.sdkStore.sdk;
 
   const renderListItem = (props: { item: GroupChannel; index: number }) => {
     const { item: channel, index } = props;
@@ -74,7 +75,8 @@ const ChannelListUI: React.FC<ChannelListUIProps> = (
     };
 
     const onClickChannel = () => {
-      if (!isOnline) {
+      if (!isOnline && !sdk?.isCacheEnabled) {
+        logger.warning('ChannelList: Inactivated clicking channel item during offline.');
         return;
       }
       logger.info('ChannelList: Clicked on channel:', channel);

--- a/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
@@ -74,7 +74,7 @@ export const MessageInputWrapperView = React.forwardRef((
   } = props;
   const { stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
-  const { config } = useSendbirdStateContext();
+  const { stores, config } = useSendbirdStateContext();
   const {
     isOnline,
     isMentionEnabled,
@@ -83,6 +83,7 @@ export const MessageInputWrapperView = React.forwardRef((
     userMention,
     logger,
   } = config;
+  const sdk = stores.sdkStore.sdk;
   const { maxMentionCount, maxSuggestionCount } = userMention;
 
   const { isBroadcast } = currentChannel;
@@ -102,7 +103,7 @@ export const MessageInputWrapperView = React.forwardRef((
     || !currentChannel
     || isDisabledBecauseFrozen(currentChannel)
     || isDisabledBecauseMuted(currentChannel)
-    || !isOnline;
+    || (!isOnline && !sdk?.isCacheEnabled);
   const showSuggestedMentionList = !isMessageInputDisabled
     && isMentionEnabled
     && mentionNickname.length > 0

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -335,7 +335,7 @@ const GroupChannelProvider = (props: GroupChannelContextProps) => {
     setAnimatedMessageId(0);
     setIsScrollBottomReached(true);
 
-    if (messageDataSource.hasNext()) {
+    if (config.isOnline && messageDataSource.hasNext()) {
       await messageDataSource.resetWithStartingPoint(Number.MAX_SAFE_INTEGER);
       scrollPubSub.publish('scrollToBottom', null);
     } else {

--- a/src/modules/GroupChannelList/components/GroupChannelListUI/index.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListUI/index.tsx
@@ -45,8 +45,9 @@ const GroupChannelListUI = (props: GroupChannelListUIProps) => {
     onUpdatedUserProfile,
   } = useGroupChannelListContext();
 
-  const { config } = useSendbirdStateContext();
+  const { stores, config } = useSendbirdStateContext();
   const { logger, isOnline } = config;
+  const sdk = stores.sdkStore.sdk;
 
   const renderListItem = (renderProps: { item: GroupChannel; index: number }) => {
     const { item: channel, index } = renderProps;
@@ -63,9 +64,11 @@ const GroupChannelListUI = (props: GroupChannelListUIProps) => {
     };
 
     const onClick = () => {
-      if (isOnline) {
+      if (isOnline || sdk?.isCacheEnabled) {
         logger.info('ChannelList: Clicked on channel:', channel);
         onChannelSelect(channel);
+      } else {
+        logger.warning('ChannelList: Inactivated clicking channel item during offline.');
       }
     };
 


### PR DESCRIPTION
[CLNP-1958](https://sendbird.atlassian.net/browse/CLNP-1958)

### Issue
* `MessageInput` and `ChannelPreview` are disabled during disconnected status even if the local caching is enabled

### Fix
* Enable the `MessageInput` and `ChannelPreview` during disconnection if the local cache is enabled

[CLNP-1958]: https://sendbird.atlassian.net/browse/CLNP-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ