### PR TITLE
fix: URL_REG subdomain / top-level domain

### DIFF
--- a/src/utils/__tests__/utils.spec.ts
+++ b/src/utils/__tests__/utils.spec.ts
@@ -175,6 +175,10 @@ describe('isURL', () => {
       // with the hash property
       'https://example.com/path/to/page.html?query=string#hash',
       'https://docs.google.com/document/d/19IccwdTIwNPJ_rGtsbi2Ft8dshaH4WiCXD5pder97VE/edit#heading=h.pve9ikkfqqzz',
+      // A subdomain has a hyphen
+      'https://send-bird.slack.com/archives/C065N4UQ77W/p1699931368643169?thread_ts=1699925671l395019&cid-Co65N4UQ77W',
+      // with long top-level domain
+      'https://send.bird.business/archives/C065N4UQ77W/p1699931368643169?thread_ts=1699925671l395019&cid-Co65N4UQ77W',
     ];
     validURLs.forEach((url) => {
       expect(isUrl(url)).toBe(true);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -424,7 +424,7 @@ export const isMessageSentByMe = (
   !!(userId && message?.sender?.userId && userId === message.sender.userId)
 );
 
-const URL_REG = /^((http|https):\/\/)?([a-z\d]+\.)+[a-z]{2,6}(\:[0-9]{1,5})?(\/[-a-zA-Z\d%_.~+&=]*)*(\?[;&a-zA-Z\d%_.~+=-]*)?(#\S*)?$/;
+const URL_REG = /^((http|https):\/\/)?([a-z\d-]+\.)+[a-z]{2,}(\:[0-9]{1,5})?(\/[-a-zA-Z\d%_.~+&=]*)*(\?[;&a-zA-Z\d%_.~+=-]*)?(#\S*)?$/;
 export const isUrl = (text: string): boolean => URL_REG.test(text);
 
 const MENTION_TAG_REG = /\@\{.*?\}/i;


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/SBISSUE-14740

```
 // A subdomain has a hyphen
'https://send-bird.slack.com/archives/C065N4UQ77W/p1699931368643169?thread_ts=1699925671l395019&cid-Co65N4UQ77W',

// with long top-level domain
'https://send.bird.business/archives/C065N4UQ77W/p1699931368643169?thread_ts=1699925671l395019&cid-Co65N4UQ77W',
```
^ these like domain couldn't be checked by the URL_REG, so I modified it a bit. 