### PR TITLE
fix: avoid max_safe_integer to scroll to bottom behavior

### DIFF
--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -291,7 +291,7 @@ const MessageList: React.FC<MessageListProps> = ({
               time={unreadSince}
               lastReadAt={unreadSinceDate}
               onClick={() => {
-                if (scrollRef?.current) scrollRef.current.scrollTop = Number.MAX_SAFE_INTEGER;
+                if (scrollRef?.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
                 if (!disableMarkAsRead && !!currentGroupChannel) {
                   markAsReadScheduler.push(currentGroupChannel);
                   messagesDispatcher({

--- a/src/modules/Channel/context/utils.ts
+++ b/src/modules/Channel/context/utils.ts
@@ -40,7 +40,7 @@ export const scrollIntoLast = (
   }
   try {
     const scrollDOM = scrollRef?.current || document.querySelector('.sendbird-conversation__messages-padding');
-    scrollDOM.scrollTop = Number.MAX_SAFE_INTEGER;
+    scrollDOM.scrollTop = scrollRef.current.scrollHeight;
     setIsScrolled?.(true);
   } catch (error) {
     setTimeout(() => {


### PR DESCRIPTION
## Before
https://github.com/sendbird/sendbird-uikit-react/assets/26326015/1f31230f-6c64-4893-9872-19c7676c95ec

## After
https://github.com/sendbird/sendbird-uikit-react/assets/26326015/f3f89752-0d9d-474d-a655-5fc46ee51c5f

ticket: [CLNP-2050]

[CLNP-2050]: https://sendbird.atlassian.net/browse/CLNP-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ