### PR TITLE
fix: when open-in-channel pressed, scrolling to message should work properly

### DIFF
--- a/src/modules/App/DesktopLayout.tsx
+++ b/src/modules/App/DesktopLayout.tsx
@@ -169,7 +169,8 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
               setStartingPoint?.(message?.createdAt);
             }
             setTimeout(() => {
-              setHighlightedMessage(message?.messageId);
+              setStartingPoint?.(null);
+              setHighlightedMessage?.(message?.messageId);
             }, 500);
           }}
         />

--- a/src/ui/Avatar/index.tsx
+++ b/src/ui/Avatar/index.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, RefObject } from 'react';
 import ImageRenderer from '../ImageRenderer';
 import './index.scss';
-import { uuidv4 } from '../../utils/uuid';
 import AvatarDefault from './AvatarDefault';
 
 const imageRendererClassName = 'sendbird-avatar-img';
@@ -114,14 +113,14 @@ export const AvatarInner = ({
       <div className="sendbird-avatar--inner__four-child">
         {
           src.slice(0, 4)
-            .map((i) => (
+            .map((url, index) => (
               <ImageRenderer
                 className={imageRendererClassName}
-                url={i}
+                url={url}
                 height={height}
                 width={width}
                 alt={alt}
-                key={uuidv4()}
+                key={`${url}-${index}`}
                 defaultComponent={defaultComponent}
               />
             ))

--- a/src/ui/ThreadReplies/index.tsx
+++ b/src/ui/ThreadReplies/index.tsx
@@ -6,7 +6,6 @@ import Avatar from '../Avatar';
 import Icon, { IconTypes, IconColors } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../../ui/Label';
 import { useLocalization } from '../../lib/LocalizationContext';
-import uuidv4 from '../../utils/uuid';
 
 export interface ThreadRepliesProps {
   className?: string;
@@ -41,7 +40,7 @@ export default function ThreadReplies({
         {mostRepliedUsers.slice(0, 4).map((user) => {
           return (
             <Avatar
-              key={uuidv4()}
+              key={user.userId}
               className="sendbird-ui-thread-replies__user-profiles__avatar"
               src={user?.profileUrl}
               alt="user profile"


### PR DESCRIPTION
fix: when open-in-channel pressed, scrolling to message should work properly
fix: remove uuid in key (to avoid re-mount of image components)

- ticket: [CLNP-2122]

[CLNP-2122]: https://sendbird.atlassian.net/browse/CLNP-2122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ