### PR TITLE
bug-fix: activeChannelUrl should select channel in list

### DIFF
--- a/src/modules/ChannelList/dux/__tests__/reducers.spec.js
+++ b/src/modules/ChannelList/dux/__tests__/reducers.spec.js
@@ -16,6 +16,19 @@ describe('Channels-Reducers', () => {
     expect(nextState.currentChannel.url).toEqual(mockData.allChannels[0].url);
   });
 
+  // if INIT_CHANNELS_SUCCESS comes back _after_ SET_CURRENT_CHANNEL via activeChannelUrl, don't wipe active channel
+  it('should not override current channel if disableAutoSelect channels on INIT_CHANNELS_SUCCESS', () => {
+    const nextState = reducers({
+      ...initialState,
+      currentChannel: mockData.allChannels[0],
+    }, {
+      type: actionTypes.INIT_CHANNELS_SUCCESS,
+      payload: { channelList: mockData.allChannels, disableAutoSelect: true },
+    });
+
+    expect(nextState.currentChannel.url).toEqual(mockData.allChannels[0].url);
+  });
+
     // https://sendbird.atlassian.net/browse/UIKIT-2158
     it('should check if ITNITAL_LOADING state is true', () => {
       expect(initialState.loading).toEqual(true);

--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -27,7 +27,7 @@ export default function channelListReducer(
           allChannels: channelList,
           disableAutoSelect,
           currentChannel:
-            !disableAutoSelect && channelList && channelList.length && channelList.length > 0 ? channelList[0] : null,
+            !disableAutoSelect && channelList && channelList.length && channelList.length > 0 ? channelList[0] : state.currentChannel,
         };
       })
       .with({ type: channelListActions.FETCH_CHANNELS_SUCCESS }, (action) => {


### PR DESCRIPTION
## Steps to reproduce
- Load a channel list with a known activeChannelUrl, e.g.
```
        <ChannelList
          activeChannelUrl={'my channel url'}
          onChannelSelect={(channel) => {
            console.log('onChannelSelect', channel);
          }}
        />
```

## Expected
- active channel is selected
- `onChannelSelect` does NOT fire with `null`

## Actual
- active channel is not selected
- `onChannelSelect` fires with `null` b/c `INIT_CHANNELS_SUCCESS` finishes after `useActiveChannelUrl` hook
