### PR TITLE
bug-fix: Fix a bug in ChannelList where activeChannelUrl is set but onChannelSelect fires with null after loading ChannelList

### DIFF
--- a/src/modules/ChannelList/dux/__tests__/reducers.spec.js
+++ b/src/modules/ChannelList/dux/__tests__/reducers.spec.js
@@ -16,10 +16,23 @@ describe('Channels-Reducers', () => {
     expect(nextState.currentChannel.url).toEqual(mockData.allChannels[0].url);
   });
 
-    // https://sendbird.atlassian.net/browse/UIKIT-2158
-    it('should check if ITNITAL_LOADING state is true', () => {
-      expect(initialState.loading).toEqual(true);
+  // if INIT_CHANNELS_SUCCESS comes back _after_ SET_CURRENT_CHANNEL via activeChannelUrl, don't wipe active channel
+  it('should not override current channel if disableAutoSelect channels on INIT_CHANNELS_SUCCESS', () => {
+    const nextState = reducers({
+      ...initialState,
+      currentChannel: mockData.allChannels[0],
+    }, {
+      type: actionTypes.INIT_CHANNELS_SUCCESS,
+      payload: { channelList: mockData.allChannels, disableAutoSelect: true },
     });
+
+    expect(nextState.currentChannel.url).toEqual(mockData.allChannels[0].url);
+  });
+
+  // https://sendbird.atlassian.net/browse/UIKIT-2158
+  it('should check if ITNITAL_LOADING state is true', () => {
+    expect(initialState.loading).toEqual(true);
+  });
 
   it('should handle create new channel using CREATE_CHANNEL', () => {
     const newChannel = mockData.allChannels[1];

--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -29,7 +29,7 @@ export default function channelListReducer(
           allChannels: channelList,
           disableAutoSelect,
           currentChannel:
-            !disableAutoSelect && channelList && channelList.length && channelList.length > 0 ? channelList[0] : null,
+            !disableAutoSelect && channelList && channelList.length && channelList.length > 0 ? channelList[0] : state.currentChannel,
         };
       })
       .with({ type: channelListActions.REFRESH_CHANNELS_SUCCESS }, (action) => {


### PR DESCRIPTION
Fixes: [CLNP-2162](https://sendbird.atlassian.net/browse/CLNP-2162)

The bug has been reported by an external user, @aldenquimby
original PR: https://github.com/sendbird/sendbird-uikit-react/pull/950
This PR duplicates above.

### Changelogs
- Fixed a bug in `ChannelList` where `activeChannelUrl` is set but `onChannelSelect` fires with null after loading `ChannelList`

[CLNP-2162]: https://sendbird.atlassian.net/browse/CLNP-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ