### PR TITLE
chore: remove filterMessageList from GroupChannel module

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -16,7 +16,7 @@ import type { GroupChannel, MessageFilterParams, MessageCollectionParams } from 
 import { MessageFilter } from '@sendbird/chat/groupChannel';
 import { useAsyncEffect, useAsyncLayoutEffect, useGroupChannelMessages, useIIFE, usePreservedCallback } from '@sendbird/uikit-tools';
 
-import type { CoreMessageType, SendableMessageType } from '../../../utils';
+import type { SendableMessageType } from '../../../utils';
 import { UserProfileProvider } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { ThreadReplySelectType } from './const';

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -64,7 +64,6 @@ export interface GroupChannelContextProps {
 
   // Custom
   messageListQueryParams?: MessageListQueryParamsType;
-  filterMessageList?(messages: CoreMessageType): boolean;
 
   // Handlers
   onBeforeSendUserMessage?: OnBeforeHandler<UserMessageCreateParams>;
@@ -155,7 +154,6 @@ const GroupChannelProvider = (props: GroupChannelContextProps) => {
 
     // Custom
     messageListQueryParams,
-    filterMessageList,
     // #Message
     onBeforeSendUserMessage,
     onBeforeSendFileMessage,
@@ -419,7 +417,6 @@ const GroupChannelProvider = (props: GroupChannelContextProps) => {
 
         // # Custom Props
         messageListQueryParams,
-        filterMessageList,
         // ## Message
         onBeforeSendUserMessage,
         onBeforeSendFileMessage,


### PR DESCRIPTION
- Remove `filterMessageList` from GroupChannel module

```tsx
// You can filter message like this.
const GroupChannelPage = () => {
  return (<GroupChannel
    renderMessage={({ message }) => {
      if(message.type === 'filtered') return <></>; // render empty component.

      return null; // render default component.
    }}
  />);
}

```