### PR TITLE
feat: Apply lastMessage suggestedReplies disable chat input flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@sendbird/chat": "^4.10.8",
-    "@sendbird/uikit-tools": "0.0.1-alpha.58",
+    "@sendbird/uikit-tools": "0.0.1-alpha.61",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "dompurify": "^3.0.1"

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -383,6 +383,7 @@ const SendbirdSDK = ({
             threadReplySelectType: getCaseResolvedThreadReplySelectType(configs.groupChannel.channel.threadReplySelectType).lowerCase,
             typingIndicatorTypes: configs.groupChannel.channel.typingIndicatorTypes,
             enableFeedback: configs.groupChannel.channel.enableFeedback,
+            enableSuggestedReplies: configs.groupChannel.channel.enableSuggestedReplies,
           },
           openChannel: {
             enableOgtag:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,6 +105,7 @@ export interface SendBirdStateConfig {
     threadReplySelectType: SBUConfig['groupChannel']['channel']['threadReplySelectType'];
     typingIndicatorTypes: SBUConfig['groupChannel']['channel']['typingIndicatorTypes'];
     enableFeedback: SBUConfig['groupChannel']['channel']['enableFeedback'];
+    enableSuggestedReplies: SBUConfig['groupChannel']['channel']['enableSuggestedReplies'];
   },
   openChannel: {
     enableOgtag: SBUConfig['openChannel']['channel']['enableOgtag'];

--- a/src/lib/utils/uikitConfigMapper.ts
+++ b/src/lib/utils/uikitConfigMapper.ts
@@ -36,6 +36,7 @@ export function uikitConfigMapper({
       },
       typingIndicatorTypes: uikitOptions.groupChannel?.typingIndicatorTypes,
       enableFeedback: uikitOptions.groupChannel?.enableFeedback,
+      enableSuggestedReplies: uikitOptions.groupChannel?.enableSuggestedReplies,
     },
     groupChannelList: {
       enableTypingIndicator: uikitOptions.groupChannelList?.enableTypingIndicator ?? isTypingIndicatorEnabledOnChannelList,

--- a/src/modules/App/stories/integrated.stories.js
+++ b/src/modules/App/stories/integrated.stories.js
@@ -351,6 +351,7 @@ export const GroupChannel = () => {
                     // enableTypingIndicator: false,
                     typingIndicatorTypes: new Set([TypingIndicatorType.Bubble, TypingIndicatorType.Text]),
                     enableFeedback: true, // This enables feedback message feature.
+                    enableSuggestedReplies: true, // This enables suggested replies feature.
                   }
                 }}
                 imageCompression={{ compressionRate: sampleOptions.imageCompression ? 0.7 : 1 }}

--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -9,6 +9,9 @@ import { GroupChannelUIView } from '../../../GroupChannel/components/GroupChanne
 import ChannelHeader from '../ChannelHeader';
 import MessageList from '../MessageList';
 import MessageInputWrapper from '../MessageInputWrapper';
+import { getSuggestedReplies } from '../../../../utils';
+import type { UserMessage } from '@sendbird/chat/message';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface ChannelUIProps {
   isLoading?: boolean;
@@ -28,12 +31,27 @@ export interface ChannelUIProps {
 }
 
 const ChannelUI = (props: ChannelUIProps) => {
+  const { config } = useSendbirdStateContext();
   const context = useChannelContext();
   const {
     channelUrl,
     isInvalid,
     loading,
+    localMessages,
+    currentGroupChannel,
   } = context;
+
+  const lastMessage = currentGroupChannel?.lastMessage;
+  const isLastMessageSuggestedRepliesEnabled = config?.groupChannel?.enableSuggestedReplies
+    && lastMessage
+    && getSuggestedReplies(lastMessage).length > 0
+    && (
+      !localMessages
+      || localMessages.length === 0
+      || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
+    );
+  const disableMessageInput = isLastMessageSuggestedRepliesEnabled
+    && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 
   return (
     <GroupChannelUIView
@@ -44,7 +62,10 @@ const ChannelUI = (props: ChannelUIProps) => {
       isInvalid={isInvalid}
       renderChannelHeader={(props) => (<ChannelHeader {...props} />)}
       renderMessageList={(props) => (<MessageList {...props} />)}
-      renderMessageInput={() => (<MessageInputWrapper {...props} />)}
+      renderMessageInput={() => (
+        props.renderMessageInput?.()
+        ?? <MessageInputWrapper {...props} disabled={disableMessageInput} />
+      )}
     />
   );
 };

--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -9,9 +9,6 @@ import { GroupChannelUIView } from '../../../GroupChannel/components/GroupChanne
 import ChannelHeader from '../ChannelHeader';
 import MessageList from '../MessageList';
 import MessageInputWrapper from '../MessageInputWrapper';
-import { getSuggestedReplies } from '../../../../utils';
-import type { UserMessage } from '@sendbird/chat/message';
-import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface ChannelUIProps {
   isLoading?: boolean;
@@ -31,27 +28,12 @@ export interface ChannelUIProps {
 }
 
 const ChannelUI = (props: ChannelUIProps) => {
-  const { config } = useSendbirdStateContext();
   const context = useChannelContext();
   const {
     channelUrl,
     isInvalid,
     loading,
-    localMessages,
-    currentGroupChannel,
   } = context;
-
-  const lastMessage = currentGroupChannel?.lastMessage;
-  const isLastMessageSuggestedRepliesEnabled = config?.groupChannel?.enableSuggestedReplies
-    && lastMessage
-    && getSuggestedReplies(lastMessage).length > 0
-    && (
-      !localMessages
-      || localMessages.length === 0
-      || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
-    );
-  const disableMessageInput = isLastMessageSuggestedRepliesEnabled
-    && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 
   return (
     <GroupChannelUIView
@@ -64,7 +46,7 @@ const ChannelUI = (props: ChannelUIProps) => {
       renderMessageList={(props) => (<MessageList {...props} />)}
       renderMessageInput={() => (
         props.renderMessageInput?.()
-        ?? <MessageInputWrapper {...props} disabled={disableMessageInput} />
+        ?? <MessageInputWrapper {...props} />
       )}
     />
   );

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -51,10 +51,7 @@ const Message = (props: MessageProps): React.ReactElement => {
         config?.groupChannel?.enableSuggestedReplies
         && message.messageId === currentGroupChannel?.lastMessage?.messageId
         // the options should appear only when there's no failed or pending messages
-        && (
-          !localMessages
-          || localMessages.length === 0
-        )
+        && localMessages?.length === 0
         && getSuggestedReplies(message).length > 0
       }
       isReactionEnabled={isReactionEnabled}

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -49,9 +49,14 @@ const Message = (props: MessageProps): React.ReactElement => {
         !initialized || isDisabledBecauseFrozen(currentGroupChannel) || isDisabledBecauseMuted(currentGroupChannel) || !config.isOnline
       }
       shouldRenderSuggestedReplies={
-        message.messageId === currentGroupChannel?.lastMessage?.messageId
+        config?.groupChannel?.enableSuggestedReplies
+        && message.messageId === currentGroupChannel?.lastMessage?.messageId
         // the options should appear only when there's no failed or pending messages
-        && localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
+        && (
+          !localMessages
+          || localMessages.length === 0
+          || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
+        )
         && getSuggestedReplies(message).length > 0
       }
       isReactionEnabled={isReactionEnabled}

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { UserMessage } from '@sendbird/chat/message';
 
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useChannelContext } from '../../context/ChannelProvider';

--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -55,7 +55,6 @@ const Message = (props: MessageProps): React.ReactElement => {
         && (
           !localMessages
           || localMessages.length === 0
-          || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
         )
         && getSuggestedReplies(message).length > 0
       }

--- a/src/modules/Channel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/Channel/components/MessageInputWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { FileMessageCreateParams, UserMessage } from '@sendbird/chat/message';
+import type { FileMessageCreateParams } from '@sendbird/chat/message';
 
 import { getSuggestedReplies, SendableMessageType } from '../../../../utils';
 import MessageInputWrapperView from '../../../GroupChannel/components/MessageInputWrapper/MessageInputWrapperView';

--- a/src/modules/Channel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/Channel/components/MessageInputWrapper/index.tsx
@@ -29,12 +29,8 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
 
   const lastMessage = currentGroupChannel?.lastMessage;
   const isLastMessageSuggestedRepliesEnabled = config?.groupChannel?.enableSuggestedReplies
-    && lastMessage
     && getSuggestedReplies(lastMessage).length > 0
-    && (
-      !localMessages
-      || localMessages.length === 0
-    );
+    && localMessages?.length === 0;
   const disableMessageInput = props.disabled
     || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 

--- a/src/modules/Channel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/Channel/components/MessageInputWrapper/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import type { FileMessageCreateParams } from '@sendbird/chat/message';
+import type { FileMessageCreateParams, UserMessage } from '@sendbird/chat/message';
 
-import type { SendableMessageType } from '../../../../utils';
+import { getSuggestedReplies, SendableMessageType } from '../../../../utils';
 import MessageInputWrapperView from '../../../GroupChannel/components/MessageInputWrapper/MessageInputWrapperView';
 import { useChannelContext } from '../../context/ChannelProvider';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface MessageInputWrapperProps {
   value?: string;
@@ -15,18 +16,33 @@ export interface MessageInputWrapperProps {
 }
 
 export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
+  const { config } = useSendbirdStateContext();
   const context = useChannelContext();
   const {
     currentGroupChannel,
+    localMessages,
     sendMessage,
     sendFileMessage,
     sendVoiceMessage,
     sendMultipleFilesMessage,
   } = context;
 
+  const lastMessage = currentGroupChannel?.lastMessage;
+  const isLastMessageSuggestedRepliesEnabled = config?.groupChannel?.enableSuggestedReplies
+    && lastMessage
+    && getSuggestedReplies(lastMessage).length > 0
+    && (
+      !localMessages
+      || localMessages.length === 0
+      || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
+    );
+  const disableMessageInput = props.disabled
+    || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
+
   return (
     <MessageInputWrapperView
       {...props}
+      disabled={disableMessageInput}
       {...context}
       currentChannel={currentGroupChannel}
       quoteMessage={context.quoteMessage}

--- a/src/modules/Channel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/Channel/components/MessageInputWrapper/index.tsx
@@ -34,7 +34,6 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
     && (
       !localMessages
       || localMessages.length === 0
-      || localMessages.every((message) => (message as UserMessage).sendingStatus === 'succeeded')
     );
   const disableMessageInput = props.disabled
     || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];

--- a/src/modules/CreateChannel/components/InviteUsers/utils.ts
+++ b/src/modules/CreateChannel/components/InviteUsers/utils.ts
@@ -29,9 +29,7 @@ export const createDefaultUserListQuery = (
   { sdk, userFilledApplicationUserListQuery }: CreateDefaultUserListQueryType,
 ): ApplicationUserListQuery => {
   if (sdk?.createApplicationUserListQuery) {
-    const params = sdk?.createApplicationUserListQuery({
-      userIdsFilter: ['bot_test_0a780'],
-    });
+    const params = sdk?.createApplicationUserListQuery();
     if (userFilledApplicationUserListQuery) {
       Object.keys(userFilledApplicationUserListQuery).forEach((key) => {
         params[key] = userFilledApplicationUserListQuery[key];

--- a/src/modules/CreateChannel/components/InviteUsers/utils.ts
+++ b/src/modules/CreateChannel/components/InviteUsers/utils.ts
@@ -29,7 +29,9 @@ export const createDefaultUserListQuery = (
   { sdk, userFilledApplicationUserListQuery }: CreateDefaultUserListQueryType,
 ): ApplicationUserListQuery => {
   if (sdk?.createApplicationUserListQuery) {
-    const params = sdk?.createApplicationUserListQuery();
+    const params = sdk?.createApplicationUserListQuery({
+      userIdsFilter: ['bot_test_0a780'],
+    });
     if (userFilledApplicationUserListQuery) {
       Object.keys(userFilledApplicationUserListQuery).forEach((key) => {
         params[key] = userFilledApplicationUserListQuery[key];

--- a/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
@@ -8,9 +8,6 @@ import { useGroupChannelContext } from '../../context/GroupChannelProvider';
 import { GroupChannelUIView } from './GroupChannelUIView';
 import type { MessageContentProps } from '../../../../ui/MessageContent';
 import MessageInputWrapper from '../MessageInputWrapper';
-import { useIIFE } from '@sendbird/uikit-tools';
-import { getSuggestedReplies, isSendableMessage } from '../../../../utils';
-import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface GroupChannelUIProps {
   renderPlaceholderLoader?: () => React.ReactElement;
@@ -30,25 +27,12 @@ export interface GroupChannelUIProps {
 }
 
 export const GroupChannelUI = (props: GroupChannelUIProps) => {
-  const { config } = useSendbirdStateContext();
   const context = useGroupChannelContext();
   const {
     currentChannel,
     channelUrl,
     loading,
-    messages,
   } = context;
-
-  const lastMessage = messages[messages.length - 1];
-  const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
-    if (!config?.groupChannel?.enableSuggestedReplies) return false;
-    if (getSuggestedReplies(lastMessage).length === 0) return false;
-    if (lastMessage && isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
-
-    return true;
-  });
-  const disableMessageInput = isLastMessageSuggestedRepliesEnabled
-    && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 
   return (
     <GroupChannelUIView
@@ -59,7 +43,7 @@ export const GroupChannelUI = (props: GroupChannelUIProps) => {
       isInvalid={channelUrl && !currentChannel}
       renderMessageInput={() => (
         props.renderMessageInput?.()
-        ?? <MessageInputWrapper {...props} disabled={disableMessageInput} />
+        ?? <MessageInputWrapper {...props} />
       )}
     />
   );

--- a/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
@@ -7,6 +7,10 @@ import { RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../..
 import { useGroupChannelContext } from '../../context/GroupChannelProvider';
 import { GroupChannelUIView } from './GroupChannelUIView';
 import type { MessageContentProps } from '../../../../ui/MessageContent';
+import MessageInputWrapper from '../MessageInputWrapper';
+import { useIIFE } from '@sendbird/uikit-tools';
+import { getSuggestedReplies, isSendableMessage } from '../../../../utils';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface GroupChannelUIProps {
   renderPlaceholderLoader?: () => React.ReactElement;
@@ -26,12 +30,25 @@ export interface GroupChannelUIProps {
 }
 
 export const GroupChannelUI = (props: GroupChannelUIProps) => {
+  const { config } = useSendbirdStateContext();
   const context = useGroupChannelContext();
   const {
     currentChannel,
     channelUrl,
     loading,
+    messages,
   } = context;
+
+  const lastMessage = messages[messages.length - 1];
+  const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
+    if (!config?.groupChannel?.enableSuggestedReplies) return false;
+    if (getSuggestedReplies(lastMessage).length === 0) return false;
+    if (lastMessage && isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
+
+    return true;
+  });
+  const disableMessageInput = isLastMessageSuggestedRepliesEnabled
+    && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 
   return (
     <GroupChannelUIView
@@ -40,6 +57,10 @@ export const GroupChannelUI = (props: GroupChannelUIProps) => {
       requestedChannelUrl={channelUrl}
       loading={loading}
       isInvalid={channelUrl && !currentChannel}
+      renderMessageInput={() => (
+        props.renderMessageInput?.()
+        ?? <MessageInputWrapper {...props} disabled={disableMessageInput} />
+      )}
     />
   );
 };

--- a/src/modules/GroupChannel/components/Message/index.tsx
+++ b/src/modules/GroupChannel/components/Message/index.tsx
@@ -38,6 +38,7 @@ export const Message = (props: MessageProps): React.ReactElement => {
   const initialized = !loading && Boolean(currentChannel);
 
   const shouldRenderSuggestedReplies = useIIFE(() => {
+    if (!config?.groupChannel?.enableSuggestedReplies) return false;
     if (message.messageId !== currentChannel?.lastMessage?.messageId) return false;
     if (getSuggestedReplies(message).length === 0) return false;
     const lastMessage = messages[messages.length - 1];

--- a/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
@@ -72,6 +72,7 @@ export const MessageInputWrapperView = React.forwardRef((
     renderVoiceMessageIcon,
     renderSendMessageIcon,
     acceptableMimeTypes,
+    disabled,
   } = props;
   const { stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
@@ -104,7 +105,8 @@ export const MessageInputWrapperView = React.forwardRef((
     || !currentChannel
     || isDisabledBecauseFrozen(currentChannel)
     || isDisabledBecauseMuted(currentChannel)
-    || (!isOnline && !sdk?.isCacheEnabled);
+    || (!isOnline && !sdk?.isCacheEnabled)
+    || disabled;
   const showSuggestedMentionList = !isMessageInputDisabled
     && isMentionEnabled
     && mentionNickname.length > 0
@@ -209,7 +211,7 @@ export const MessageInputWrapperView = React.forwardRef((
           setMentionedUsers={setMentionedUsers}
           placeholder={
             (quoteMessage && stringSet.MESSAGE_INPUT__QUOTE_REPLY__PLACE_HOLDER)
-            || (isDisabledBecauseFrozen(currentChannel) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED)
+            || ((disabled || isDisabledBecauseFrozen(currentChannel)) && stringSet.MESSAGE_INPUT__PLACE_HOLDER__DISABLED)
             || (isDisabledBecauseMuted(currentChannel)
               && (isMobile ? stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED_SHORT : stringSet.MESSAGE_INPUT__PLACE_HOLDER__MUTED))
           }

--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
@@ -18,15 +18,17 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
   const context = useGroupChannelContext();
   const {
     messages,
+    currentChannel,
   } = context;
-  const lastMessage = messages[messages.length - 1];
   const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
     if (!config?.groupChannel?.enableSuggestedReplies) return false;
     if (getSuggestedReplies(lastMessage).length === 0) return false;
-    if (isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
+    const lastMessageInContext = messages[messages.length - 1];
+    if (isSendableMessage(lastMessageInContext) && lastMessageInContext.sendingStatus !== 'succeeded') return false;
 
     return true;
   });
+  const lastMessage = currentChannel?.lastMessage;
   const disableMessageInput = props.disabled
     || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 

--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import MessageInputWrapperView from './MessageInputWrapperView';
 import { useGroupChannelContext } from '../../context/GroupChannelProvider';
+import { useIIFE } from '@sendbird/uikit-tools';
+import { getSuggestedReplies, isSendableMessage } from '../../../../utils';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface MessageInputWrapperProps {
   value?: string;
@@ -11,10 +14,26 @@ export interface MessageInputWrapperProps {
 }
 
 export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
+  const { config } = useSendbirdStateContext();
   const context = useGroupChannelContext();
+  const {
+    messages,
+  } = context;
+  const lastMessage = messages[messages.length - 1];
+  const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
+    if (!config?.groupChannel?.enableSuggestedReplies) return false;
+    if (getSuggestedReplies(lastMessage).length === 0) return false;
+    if (lastMessage && isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
+
+    return true;
+  });
+  const disableMessageInput = props.disabled
+    || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
+
   return (
     <MessageInputWrapperView
       {...props}
+      disabled={disableMessageInput}
       {...context}
     />
   );

--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
@@ -23,7 +23,7 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
   const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
     if (!config?.groupChannel?.enableSuggestedReplies) return false;
     if (getSuggestedReplies(lastMessage).length === 0) return false;
-    if (lastMessage && isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
+    if (isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
 
     return true;
   });

--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
@@ -20,6 +20,7 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
     messages,
     currentChannel,
   } = context;
+  const lastMessage = currentChannel?.lastMessage;
   const isLastMessageSuggestedRepliesEnabled = useIIFE(() => {
     if (!config?.groupChannel?.enableSuggestedReplies) return false;
     if (getSuggestedReplies(lastMessage).length === 0) return false;
@@ -28,7 +29,6 @@ export const MessageInputWrapper = (props: MessageInputWrapperProps) => {
 
     return true;
   });
-  const lastMessage = currentChannel?.lastMessage;
   const disableMessageInput = props.disabled
     || isLastMessageSuggestedRepliesEnabled && !!lastMessage.extendedMessagePayload?.['disable_chat_input'];
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,7 +13,7 @@ import {
 import { OpenChannel, SendbirdOpenChat } from '@sendbird/chat/openChannel';
 
 import { getOutgoingMessageState, OutgoingMessageStates } from './exports/getOutgoingMessageState';
-import { Nullable, EveryMessage } from '../types';
+import { Nullable } from '../types';
 import { match } from 'ts-pattern';
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
@@ -409,7 +409,7 @@ export const getUseReaction = (store: UIKitStore, channel: GroupChannel | OpenCh
   return store?.config?.isReactionEnabled;
 };
 
-export function getSuggestedReplies(message?: EveryMessage): string[] {
+export function getSuggestedReplies(message?: BaseMessage): string[] {
   if (Array.isArray(message?.extendedMessagePayload?.suggested_replies)) {
     return message.extendedMessagePayload.suggested_replies;
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,7 +2679,7 @@ __metadata:
     "@rollup/plugin-replace": ^5.0.4
     "@rollup/plugin-typescript": ^11.1.5
     "@sendbird/chat": ^4.10.8
-    "@sendbird/uikit-tools": 0.0.1-alpha.58
+    "@sendbird/uikit-tools": 0.0.1-alpha.61
     "@storybook/addon-actions": ^6.5.10
     "@storybook/addon-docs": ^6.5.10
     "@storybook/addon-links": ^6.5.10
@@ -2744,13 +2744,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sendbird/uikit-tools@npm:0.0.1-alpha.58":
-  version: 0.0.1-alpha.58
-  resolution: "@sendbird/uikit-tools@npm:0.0.1-alpha.58"
+"@sendbird/uikit-tools@npm:0.0.1-alpha.61":
+  version: 0.0.1-alpha.61
+  resolution: "@sendbird/uikit-tools@npm:0.0.1-alpha.61"
   peerDependencies:
     "@sendbird/chat": ^4.10.5
     react: ">=16.8.6"
-  checksum: 2b8d8bcb1f24c902f39c81dd6563c8864b0b99da149c62d4751205e9a8816c232c9eea2ebc87c6d848a9b64378ea56014451fadf7b3f1c4c93e40fd2b38c2ac3
+  checksum: c5790169a9615bd085d5571ec1240145d3b5c3de407e9b174fd23837ac499493303f64f824b8275eddb03813ce1e580d6f15fa57219619e1104566d1a181b7fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes: [AC-1106](https://sendbird.atlassian.net/browse/AC-1106)

### Changelogs
- Added `enableSuggestedReplies` global option
  - How to use?
  ```tsx
  <App
    appId={appId}
    userId={userId}
    uikitOptions={{
      groupChannel: {
        // Below turns on the suggested replies feature. Default value is false.
        enableSuggestedReplies: true,
      }
    }}
  />
  ```
- `MessageInput` is now being disabled if `channel.lastMessage.extendedMessagePayload['disable_chat_input']` is true

[AC-1106]: https://sendbird.atlassian.net/browse/AC-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ