### PR TITLE
fix: do not disconnect and connect when the accessToken is changed

### DIFF
--- a/src/lib/hooks/useConnect/index.ts
+++ b/src/lib/hooks/useConnect/index.ts
@@ -46,7 +46,7 @@ export default function useConnect(triggerTypes: TriggerTypes, staticTypes: Stat
     }).catch(error => {
       logger?.error?.('SendbirdProvider | useConnect/useEffect', error);
     });
-  }, [userId, appId, accessToken]);
+  }, [userId, appId]);
   const reconnect = useCallback(async () => {
     logger?.info?.('SendbirdProvider | useConnect/reconnect/useCallback', { sdk });
 


### PR DESCRIPTION
## Description

1. When the `accessToken` is changed, `disconnect` and `connect` are called again.
2. If the customer controls the `accessToken`, the session_key refresh performed by the SDK is canceled(API request cancel) due to the `disconnect` triggered in (1).
3. Even if the `accessToken` has already expired, it is refreshed by the SDK(**SessionHandler**). Therefore, UIKit does not need to rely on this value to handle the connect logic.

ticket: [CLNP-2257]

[CLNP-2257]: https://sendbird.atlassian.net/browse/CLNP-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ