### PR TITLE
fix: loading status should be handled in message list

### DIFF
--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -13,7 +13,7 @@ export interface ChannelUIProps extends GroupChannelUIBasicProps {
 
 const ChannelUI = (props: ChannelUIProps) => {
   const context = useChannelContext();
-  const { channelUrl, isInvalid, loading } = context;
+  const { channelUrl, isInvalid } = context;
 
   // Inject components to presentation layer
   const {
@@ -26,7 +26,7 @@ const ChannelUI = (props: ChannelUIProps) => {
     <GroupChannelUIView
       {...props}
       {...context}
-      loading={props?.isLoading ?? loading}
+      isLoading={props?.isLoading}
       isInvalid={isInvalid}
       channelUrl={channelUrl}
       renderChannelHeader={renderChannelHeader}

--- a/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
@@ -37,7 +37,7 @@ export interface GroupChannelUIBasicProps {
 }
 
 export interface GroupChannelUIViewProps extends GroupChannelUIBasicProps {
-  loading: boolean;
+  isLoading?: boolean;
   isInvalid: boolean;
   channelUrl: string;
   renderChannelHeader: GroupChannelUIBasicProps['renderChannelHeader'];
@@ -47,7 +47,7 @@ export interface GroupChannelUIViewProps extends GroupChannelUIBasicProps {
 
 export const GroupChannelUIView = (props: GroupChannelUIViewProps) => {
   const {
-    loading,
+    isLoading,
     isInvalid,
     channelUrl,
     renderChannelHeader,
@@ -62,7 +62,9 @@ export const GroupChannelUIView = (props: GroupChannelUIViewProps) => {
   const sdkError = stores?.sdkStore?.error;
   const { logger, isOnline } = config;
 
-  if (loading) {
+  // Note: This is not a loading status of the message list.
+  //  It is just for custom props from the Channel module and is not used in the GroupChannel module. (We should remove this in v4)
+  if (isLoading) {
     return <div className="sendbird-conversation">{renderPlaceholderLoader?.() || <PlaceHolder type={PlaceHolderTypes.LOADING} />}</div>;
   }
 

--- a/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/index.tsx
@@ -11,7 +11,7 @@ export interface GroupChannelUIProps extends GroupChannelUIBasicProps {}
 
 export const GroupChannelUI = (props: GroupChannelUIProps) => {
   const context = useGroupChannelContext();
-  const { currentChannel, channelUrl, loading } = context;
+  const { channelUrl, fetchChannelError } = context;
 
   // Inject components to presentation layer
   const {
@@ -24,8 +24,7 @@ export const GroupChannelUI = (props: GroupChannelUIProps) => {
     <GroupChannelUIView
       {...props}
       {...context}
-      loading={loading}
-      isInvalid={channelUrl && !currentChannel}
+      isInvalid={fetchChannelError !== null}
       channelUrl={channelUrl}
       renderChannelHeader={renderChannelHeader}
       renderMessageList={renderMessageList}


### PR DESCRIPTION
## Description

https://github.com/sendbird/sendbird-uikit-react/blob/v3.10.0/src/modules/Channel/components/ChannelUI/index.tsx#L59-L67
Upon reviewing the `v3.10.0` code, I noticed that the actual loading of the message list is handled in the **MessageList** component, while the loading state displayed in the `ChannelUI` relies solely on a prop called `isLoading`.

During the migration process in this area, a mistake was made. I left a note indicating the purpose of this, as I'm unsure of its intended use.

Additionally, due to the change in `isLoading` being optional, the condition for `isInvalid` became invalid in the GroupChannel module. Therefore, I added a separate fetch error to the context.


ticket: [CLNP-2259]