### PR TITLE
fix: ensure consistent scroll to bottom delay after message send in channel module

### DIFF
--- a/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
+++ b/src/modules/Channel/context/hooks/useHandleChannelEvents.ts
@@ -83,9 +83,7 @@ function useHandleChannelEvents({
             ) {
               // and !openContextMenu
               try {
-                setTimeout(() => {
-                  scrollIntoLast(0, scrollRef);
-                });
+                setTimeout(() => scrollIntoLast(0, scrollRef));
                 if (!disableMarkAsRead) {
                   markAsReadScheduler.push(currentGroupChannel);
                 }

--- a/src/modules/Channel/context/hooks/useHandleChannelPubsubEvents.ts
+++ b/src/modules/Channel/context/hooks/useHandleChannelPubsubEvents.ts
@@ -5,6 +5,7 @@ import * as channelActions from '../dux/actionTypes';
 import { PUBSUB_TOPICS, SBUGlobalPubSub } from '../../../../lib/pubSub/topics';
 import { shouldPubSubPublishToChannel } from '../../../internalInterfaces';
 import { ChannelActionTypes } from '../dux/actionTypes';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
 
 export interface UseHandlePubsubEventsParams {
   channelUrl: string;
@@ -26,12 +27,12 @@ export const useHandleChannelPubsubEvents = ({
     if (pubSub?.subscribe) {
       subscriber.set(PUBSUB_TOPICS.SEND_USER_MESSAGE, pubSub.subscribe(PUBSUB_TOPICS.SEND_USER_MESSAGE, (props) => {
         const { channel, message } = props;
-        scrollIntoLast(0, scrollRef);
         if (channelUrl === channel?.url) {
           dispatcher({
             type: channelActions.SEND_MESSAGE_SUCCESS,
             payload: message,
           });
+          setTimeout(() => scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_SEND);
         }
       }));
       subscriber.set(PUBSUB_TOPICS.SEND_MESSAGE_START, pubSub.subscribe(PUBSUB_TOPICS.SEND_MESSAGE_START, (props) => {
@@ -63,12 +64,12 @@ export const useHandleChannelPubsubEvents = ({
       }));
       subscriber.set(PUBSUB_TOPICS.SEND_FILE_MESSAGE, pubSub.subscribe(PUBSUB_TOPICS.SEND_FILE_MESSAGE, (props) => {
         const { channel, message } = props;
-        scrollIntoLast(0, scrollRef);
         if (channelUrl === channel?.url) {
           dispatcher({
             type: channelActions.SEND_MESSAGE_SUCCESS,
             payload: message,
           });
+          setTimeout(() => scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_SEND);
         }
       }));
       subscriber.set(PUBSUB_TOPICS.UPDATE_USER_MESSAGE, pubSub.subscribe(PUBSUB_TOPICS.UPDATE_USER_MESSAGE, (props) => {

--- a/src/modules/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/modules/Channel/context/hooks/useHandleReconnect.ts
@@ -9,8 +9,9 @@ import { Logger } from '../../../../lib/SendbirdState';
 import { MarkAsReadSchedulerType } from '../../../../lib/hooks/useMarkAsReadScheduler';
 import useReconnectOnIdle from './useReconnectOnIdle';
 import { ChannelActionTypes } from '../dux/actionTypes';
-import { CoreMessageType, isMultipleFilesMessage } from '../../../../utils';
+import { CoreMessageType } from '../../../../utils';
 import { SdkStore } from '../../../../lib/types';
+import { SCROLL_BOTTOM_DELAY_FOR_FETCH } from '../../../../utils/consts';
 
 interface DynamicParams {
   isOnline: boolean;
@@ -73,7 +74,6 @@ function useHandleReconnect(
           payload: null,
         });
 
-        let multipleFilesMessageCount = 0;
         sdk?.groupChannel?.getChannel(currentGroupChannel?.url)
           .then((groupChannel) => {
             const lastMessageTime = new Date().getTime();
@@ -90,15 +90,7 @@ function useHandleReconnect(
                     messages: messages as CoreMessageType[],
                   },
                 });
-                multipleFilesMessageCount = messages.filter((message) => isMultipleFilesMessage(message as CoreMessageType)).length;
-                setTimeout(
-                  () => utils.scrollIntoLast(0, scrollRef),
-                  /**
-                   * Rendering MFM takes long time so we need this.
-                   * But later we should find better solution.
-                   */
-                  Math.min(multipleFilesMessageCount * 100, 1000),
-                );
+                setTimeout(() => utils.scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_FETCH);
               })
               .catch((error) => {
                 logger.error('Channel: Fetching messages failed', error);

--- a/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendFileMessageCallback.ts
@@ -10,6 +10,7 @@ import { PublishingModuleType } from '../../../internalInterfaces';
 import { LoggerInterface } from '../../../../lib/Logger';
 import { SendableMessageType } from '../../../../utils';
 import { SendBirdState } from '../../../../lib/types';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
 
 type UseSendFileMessageCallbackOptions = {
   currentGroupChannel: null | GroupChannel;
@@ -55,7 +56,7 @@ export default function useSendFileMessageCallback(
             channel: currentGroupChannel,
             publishingModules: [PublishingModuleType.CHANNEL],
           });
-          setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
+          setTimeout(() => utils.scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_SEND);
         })
         .onFailed((err, failedMessage) => {
           logger.error('Channel: Sending file message failed!', { failedMessage, err });

--- a/src/modules/Channel/context/hooks/useSendMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendMessageCallback.ts
@@ -10,6 +10,7 @@ import topics, { SBUGlobalPubSub } from '../../../../lib/pubSub/topics';
 import { PublishingModuleType } from '../../../internalInterfaces';
 import { SendableMessageType } from '../../../../utils';
 import { LoggerInterface } from '../../../../lib/Logger';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
 
 type UseSendMessageCallbackOptions = {
   isMentionEnabled: boolean;
@@ -82,7 +83,7 @@ export default function useSendMessageCallback(
             channel: currentGroupChannel,
             publishingModules: [PublishingModuleType.CHANNEL],
           });
-          setTimeout(() => utils.scrollIntoLast(0, scrollRef));
+          setTimeout(() => utils.scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_SEND);
         })
         .onFailed((err, msg) => {
           logger.warning('Channel: Sending message failed!', { message: msg, error: err });

--- a/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
+++ b/src/modules/Channel/context/hooks/useSendMultipleFilesMessage.ts
@@ -14,6 +14,7 @@ import {
   shouldPubSubPublishToThread,
 } from '../../../internalInterfaces';
 import { scrollIntoLast as scrollIntoLastForThread } from '../../../Thread/context/utils';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
 
 export type OnBeforeSendMFMType = (
   files: Array<File>,
@@ -108,7 +109,6 @@ export const useSendMultipleFilesMessage = ({
               channel: currentChannel,
               publishingModules,
             });
-            // We need this delay because rendering MFM takes time due to large image files.
             setTimeout(() => {
               if (scrollRef && shouldPubSubPublishToChannel(publishingModules)) {
                 scrollIntoLastForChannel(0, scrollRef);
@@ -116,7 +116,7 @@ export const useSendMultipleFilesMessage = ({
               if (shouldPubSubPublishToThread(publishingModules)) {
                 scrollIntoLastForThread(0);
               }
-            }, 100);
+            }, SCROLL_BOTTOM_DELAY_FOR_SEND);
           })
           .onFailed((error, failedMessage: MultipleFilesMessage) => {
             logger.error('Channel: Sending MFM failed.', { error, failedMessage });
@@ -134,15 +134,6 @@ export const useSendMultipleFilesMessage = ({
               message: succeededMessage,
               publishingModules,
             });
-            // We need this delay because rendering MFM takes time due to large image files.
-            setTimeout(() => {
-              if (scrollRef && shouldPubSubPublishToChannel(publishingModules)) {
-                scrollIntoLastForChannel(0, scrollRef);
-              }
-              if (shouldPubSubPublishToThread(publishingModules)) {
-                scrollIntoLastForThread(0);
-              }
-            }, 100);
             resolve(succeededMessage);
           });
       } catch (error) {

--- a/src/modules/Channel/context/hooks/useSendVoiceMessageCallback.ts
+++ b/src/modules/Channel/context/hooks/useSendVoiceMessageCallback.ts
@@ -11,6 +11,7 @@ import {
   META_ARRAY_MESSAGE_TYPE_KEY,
   META_ARRAY_MESSAGE_TYPE_VALUE__VOICE,
   META_ARRAY_VOICE_DURATION_KEY,
+  SCROLL_BOTTOM_DELAY_FOR_SEND,
   VOICE_MESSAGE_FILE_NAME,
   VOICE_MESSAGE_MIME_TYPE,
 } from '../../../../utils/consts';
@@ -79,7 +80,7 @@ export const useSendVoiceMessageCallback = ({
           channel: currentGroupChannel,
           publishingModules: [PublishingModuleType.CHANNEL],
         });
-        setTimeout(() => utils.scrollIntoLast(0, scrollRef), 1000);
+        setTimeout(() => utils.scrollIntoLast(0, scrollRef), SCROLL_BOTTOM_DELAY_FOR_SEND);
       })
       .onFailed((err, failedMessage) => {
         logger.error('Channel: Sending voice message failed!', { failedMessage, err });

--- a/src/modules/Channel/context/utils.ts
+++ b/src/modules/Channel/context/utils.ts
@@ -40,7 +40,7 @@ export const scrollIntoLast = (
   }
   try {
     const scrollDOM = scrollRef?.current || document.querySelector('.sendbird-conversation__messages-padding');
-    scrollDOM.scrollTop = scrollRef.current.scrollHeight;
+    scrollDOM.scrollTop = scrollDOM.scrollHeight;
     setIsScrolled?.(true);
   } catch (error) {
     setTimeout(() => {

--- a/src/modules/Thread/context/hooks/useSendFileMessage.ts
+++ b/src/modules/Thread/context/hooks/useSendFileMessage.ts
@@ -8,6 +8,7 @@ import topics, { SBUGlobalPubSub } from '../../../../lib/pubSub/topics';
 import { scrollIntoLast } from '../utils';
 import { SendableMessageType } from '../../../../utils';
 import { PublishingModuleType } from './useSendMultipleFilesMessage';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
 
 interface DynamicProps {
   currentChannel: GroupChannel;
@@ -63,7 +64,7 @@ export default function useSendFileMessageCallback({
               },
             },
           });
-          setTimeout(() => scrollIntoLast(), 1000);
+          setTimeout(() => scrollIntoLast(), SCROLL_BOTTOM_DELAY_FOR_SEND);
         })
         .onFailed((error, message) => {
           (message as LocalFileMessage).localUrl = URL.createObjectURL(file);

--- a/src/modules/Thread/context/hooks/useSendVoiceMessageCallback.ts
+++ b/src/modules/Thread/context/hooks/useSendVoiceMessageCallback.ts
@@ -11,6 +11,7 @@ import {
   META_ARRAY_VOICE_DURATION_KEY,
   VOICE_MESSAGE_FILE_NAME,
   VOICE_MESSAGE_MIME_TYPE,
+  SCROLL_BOTTOM_DELAY_FOR_SEND,
 } from '../../../../utils/consts';
 import { SendableMessageType } from '../../../../utils';
 import { PublishingModuleType } from '../../../internalInterfaces';
@@ -80,7 +81,7 @@ export const useSendVoiceMessageCallback = ({
             },
           },
         });
-        setTimeout(() => scrollIntoLast(), 1000);
+        setTimeout(() => scrollIntoLast(), SCROLL_BOTTOM_DELAY_FOR_SEND);
       })
       .onFailed((error, message) => {
         (message as LocalFileMessage).localUrl = URL.createObjectURL(file);

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,5 +1,7 @@
 export const ONE_MiB = 1024 * 1024;
 export const SCROLL_BUFFER = 10;
+export const SCROLL_BOTTOM_DELAY_FOR_SEND = 100;
+export const SCROLL_BOTTOM_DELAY_FOR_FETCH = 100;
 
 // voice message record
 export const VOICE_RECORDER_CLICK_BUFFER_TIME = 250;


### PR DESCRIPTION
- Now that rendering of MFM messages is consistent, unnecessary delays have been removed.
- Adjusted message delay after message transmission to be consistent.
- Fixed the scroll-to-bottom functionality to work properly with messages sent in threads