### PR TITLE
fix: message render structure

### DIFF
--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -9,6 +9,10 @@ import MessageInputWrapper from '../MessageInputWrapper';
 
 export interface ChannelUIProps extends GroupChannelUIBasicProps {
   isLoading?: boolean;
+  /**
+   * Customizes all child components of the message component.
+   * */
+  renderMessage?: GroupChannelUIBasicProps['renderMessage'];
 }
 
 const ChannelUI = (props: ChannelUIProps) => {

--- a/src/modules/Channel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/Channel/components/MessageInputWrapper/index.tsx
@@ -4,14 +4,15 @@ import { getSuggestedReplies } from '../../../../utils';
 import MessageInputWrapperView from '../../../GroupChannel/components/MessageInputWrapper/MessageInputWrapperView';
 import { useChannelContext } from '../../context/ChannelProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
+import { GroupChannelUIBasicProps } from '../../../GroupChannel/components/GroupChannelUI/GroupChannelUIView';
 
 export interface MessageInputWrapperProps {
   value?: string;
   disabled?: boolean;
-  renderFileUploadIcon?: () => React.ReactElement;
-  renderVoiceMessageIcon?: () => React.ReactElement;
-  renderSendMessageIcon?: () => React.ReactElement;
   acceptableMimeTypes?: string[];
+  renderFileUploadIcon?: GroupChannelUIBasicProps['renderFileUploadIcon'];
+  renderVoiceMessageIcon?: GroupChannelUIBasicProps['renderVoiceMessageIcon'];
+  renderSendMessageIcon?: GroupChannelUIBasicProps['renderSendMessageIcon'];
 }
 
 export const MessageInputWrapper = (props: MessageInputWrapperProps) => {

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -23,13 +23,19 @@ import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScroll
 
 import { getMessagePartsInfo } from '../../../GroupChannel/components/MessageList/getMessagePartsInfo';
 import { GroupChannelMessageListProps } from '../../../GroupChannel/components/MessageList';
+import { GroupChannelUIBasicProps } from '../../../GroupChannel/components/GroupChannelUI/GroupChannelUIView';
 
 const SCROLL_BOTTOM_PADDING = 50;
 
-export type MessageListProps = GroupChannelMessageListProps;
+export interface MessageListProps extends GroupChannelMessageListProps {
+  /**
+   * Customizes all child components of the message component.
+   * */
+  renderMessage?: GroupChannelUIBasicProps['renderMessage'];
+}
 export const MessageList = ({
   className = '',
-  renderMessage = (props) => <Message {...props} />,
+  renderMessage,
   renderMessageContent,
   renderCustomSeparator,
   renderPlaceholderLoader = () => <PlaceHolder type={PlaceHolderTypes.LOADING} />,
@@ -189,15 +195,17 @@ export const MessageList = ({
               const isByMe = (m as UserMessage)?.sender?.userId === store?.config?.userId;
               return (
                 <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
-                  {renderMessage({
-                    handleScroll: moveScroll,
-                    message: m as EveryMessage,
-                    hasSeparator,
-                    chainTop,
-                    chainBottom,
-                    renderMessageContent,
-                    renderCustomSeparator,
-                  })}
+                  <Message
+                    handleScroll={moveScroll}
+                    message={m as EveryMessage}
+                    hasSeparator={hasSeparator}
+                    chainTop={chainTop}
+                    chainBottom={chainBottom}
+                    renderMessageContent={renderMessageContent}
+                    renderCustomSeparator={renderCustomSeparator}
+                    // backward compatibility
+                    renderMessage={renderMessage}
+                  />
                 </MessageProvider>
               );
             })}
@@ -213,14 +221,16 @@ export const MessageList = ({
               const isByMe = (m as UserMessage)?.sender?.userId === store?.config?.userId;
               return (
                 <MessageProvider message={m} key={m?.messageId} isByMe={isByMe}>
-                  {renderMessage({
-                    handleScroll: moveScroll,
-                    message: m as EveryMessage,
-                    chainTop,
-                    chainBottom,
-                    renderMessageContent,
-                    renderCustomSeparator,
-                  })}
+                  <Message
+                    handleScroll={moveScroll}
+                    message={m as EveryMessage}
+                    chainTop={chainTop}
+                    chainBottom={chainBottom}
+                    renderMessageContent={renderMessageContent}
+                    renderCustomSeparator={renderCustomSeparator}
+                    // backward compatibility
+                    renderMessage={renderMessage}
+                  />
                 </MessageProvider>
               );
             })}

--- a/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
@@ -15,24 +15,66 @@ import type { MessageContentProps } from '../../../../ui/MessageContent';
 
 export interface GroupChannelUIBasicProps {
   // Components
+  /**
+   * A function that customizes the rendering of a loading placeholder component.
+   */
   renderPlaceholderLoader?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a invalid placeholder component.
+   */
   renderPlaceholderInvalid?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of an empty placeholder component when there are no messages in the channel.
+   */
   renderPlaceholderEmpty?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a header component.
+   */
   renderChannelHeader?: (props: GroupChannelHeaderProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a message list component.
+   */
   renderMessageList?: (props: GroupChannelMessageListProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a message input component.
+   */
   renderMessageInput?: () => React.ReactElement;
 
   // Sub components
   //  MessageList
+  /**
+   * A function that customizes the rendering of each message component in the message list component.
+   */
   renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of the content portion of each message component.
+   */
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a separator component between messages.
+   */
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a frozen notification component when the channel is frozen.
+   */
   renderFrozenNotification?: () => React.ReactElement;
 
-  //  MessageInput
+  // MessageInput
+  /**
+   * A function that customizes the rendering of the file upload icon in the message input component.
+   */
   renderFileUploadIcon?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of the voice message icon in the message input component.
+   */
   renderVoiceMessageIcon?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of the send message icon in the message input component.
+   */
   renderSendMessageIcon?: () => React.ReactElement;
+  /**
+   * A function that customizes the rendering of the typing indicator component.
+   */
   renderTypingIndicator?: () => React.ReactElement;
 }
 

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -389,7 +389,7 @@ const MessageView = (props: MessageViewProps) => {
         isAnimated ? 'sendbird-msg-hoc__animated' : '',
         isHighlighted ? 'sendbird-msg-hoc__highlighted' : '',
       ])}
-      style={{ marginBottom: '2px' }}
+      style={children || renderMessage ? undefined : { marginBottom: '2px' }}
       data-sb-message-id={message.messageId}
       data-sb-created-at={message.createdAt}
       ref={messageScrollRef}

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -28,11 +28,27 @@ export interface MessageProps {
   chainBottom?: boolean;
   handleScroll?: (isBottomMessageAffected?: boolean) => void;
 
-  // for extending
-  renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
+  /**
+   * Customizes all child components of the message.
+   * */
+  children?: React.ReactNode;
+  /**
+   * A function that customizes the rendering of the content portion of message component.
+   */
   renderMessageContent?: (props: MessageContentProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of a separator between messages.
+   */
   renderCustomSeparator?: (props: RenderCustomSeparatorProps) => React.ReactElement;
+  /**
+   * A function that customizes the rendering of the edit input portion of the message component.
+   * */
   renderEditInput?: () => React.ReactElement;
+  /**
+   * @deprecated Please use `children` instead
+   * @description Customizes all child components of the message.
+   * */
+  renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
 }
 
 export interface MessageViewProps extends MessageProps {
@@ -78,6 +94,7 @@ const MessageView = (props: MessageViewProps) => {
     // MessageProps
     message,
     renderMessage,
+    children,
     renderMessageContent = (props) => <MessageContent {...props} />,
     renderCustomSeparator,
     renderEditInput,
@@ -227,40 +244,54 @@ const MessageView = (props: MessageViewProps) => {
   }, [animatedMessageId, messageScrollRef.current, message.messageId]);
 
   const renderedCustomSeparator = useMemo(() => renderCustomSeparator?.({ message }) ?? null, [message, renderCustomSeparator]);
-  const renderedMessage = useMemo(() => renderMessage?.(props), [message, renderMessage]);
 
-  if (renderedMessage) {
+  const renderChildren = () => {
+    if (children) {
+      return children;
+    }
+
+    if (renderMessage) {
+      return renderMessage({ ...props, renderMessage: undefined });
+    }
+
     return (
-      <div
-        // do not delete this data attribute, used for scroll to given message
-        // and also for testing
-        data-sb-message-id={message.messageId}
-        data-sb-created-at={message.createdAt}
-        ref={messageScrollRef}
-        className={getClassName([
-          'sendbird-msg-hoc sendbird-msg--scroll-ref',
-          isAnimated ? 'sendbird-msg-hoc__animated' : '',
-          isHighlighted ? 'sendbird-msg-hoc__highlighted' : '',
-        ])}
-      >
-        {/* date-separator */}
+      <>
+        {/* Message */}
+        {renderMessageContent({
+          className: 'sendbird-message-hoc__message-content',
+          userId,
+          scrollToMessage,
+          channel,
+          message,
+          disabled: !isOnline,
+          chainTop,
+          chainBottom,
+          isReactionEnabled,
+          replyType,
+          threadReplySelectType,
+          nicknamesMap,
+          emojiContainer,
+          showEdit: setShowEdit,
+          showRemove: setShowRemove,
+          showFileViewer: setShowFileViewer,
+          resendMessage,
+          deleteMessage,
+          toggleReaction,
+          setQuoteMessage,
+          onReplyInThread: onReplyInThreadClick,
+          onQuoteMessageClick: onQuoteMessageClick,
+          onMessageHeightChange: handleScroll,
+        })}
         {
-          // TODO: Add message instance as a function parameter
-          hasSeparator
-            && (renderedCustomSeparator || (
-              <DateSeparator>
-                <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
-                  {format(message.createdAt, stringSet.DATE_FORMAT__MESSAGE_LIST__DATE_SEPARATOR, {
-                    locale: dateLocale,
-                  })}
-                </Label>
-              </DateSeparator>
-            ))
+          /** Suggested Replies */
+          shouldRenderSuggestedReplies && <SuggestedReplies replyOptions={getSuggestedReplies(message)} onSendMessage={sendUserMessage} />
         }
-        {renderedMessage}
-      </div>
+        {/* Modal */}
+        {showRemove && renderRemoveMessageModal({ message, onCancel: () => setShowRemove(false) })}
+        {showFileViewer && renderFileViewer({ message: message as FileMessage, onCancel: () => setShowFileViewer(false) })}
+      </>
     );
-  }
+  };
 
   if (showEdit && message?.isUserMessage?.()) {
     return (
@@ -373,39 +404,7 @@ const MessageView = (props: MessageViewProps) => {
             </Label>
           </DateSeparator>
         ))}
-      {/* Message */}
-      {renderMessageContent({
-        className: 'sendbird-message-hoc__message-content',
-        userId,
-        scrollToMessage,
-        channel,
-        message,
-        disabled: !isOnline,
-        chainTop,
-        chainBottom,
-        isReactionEnabled,
-        replyType,
-        threadReplySelectType,
-        nicknamesMap,
-        emojiContainer,
-        showEdit: setShowEdit,
-        showRemove: setShowRemove,
-        showFileViewer: setShowFileViewer,
-        resendMessage,
-        deleteMessage,
-        toggleReaction,
-        setQuoteMessage,
-        onReplyInThread: onReplyInThreadClick,
-        onQuoteMessageClick: onQuoteMessageClick,
-        onMessageHeightChange: handleScroll,
-      })}
-      {
-        /** Suggested Replies */
-        shouldRenderSuggestedReplies && <SuggestedReplies replyOptions={getSuggestedReplies(message)} onSendMessage={sendUserMessage} />
-      }
-      {/* Modal */}
-      {showRemove && renderRemoveMessageModal({ message, onCancel: () => setShowRemove(false) })}
-      {showFileViewer && renderFileViewer({ message: message as FileMessage, onCancel: () => setShowFileViewer(false) })}
+      {renderChildren()}
     </div>
   );
 };

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -251,7 +251,8 @@ const MessageView = (props: MessageViewProps) => {
     }
 
     if (renderMessage) {
-      return renderMessage({ ...props, renderMessage: undefined });
+      const messageProps = { ...props, renderMessage: undefined };
+      return renderMessage(messageProps);
     }
 
     return (

--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.tsx
@@ -4,13 +4,15 @@ import { useGroupChannelContext } from '../../context/GroupChannelProvider';
 import { useIIFE } from '@sendbird/uikit-tools';
 import { getSuggestedReplies, isSendableMessage } from '../../../../utils';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
+import { GroupChannelUIBasicProps } from '../GroupChannelUI/GroupChannelUIView';
 
 export interface MessageInputWrapperProps {
   value?: string;
   disabled?: boolean;
-  renderFileUploadIcon?: () => React.ReactElement;
-  renderVoiceMessageIcon?: () => React.ReactElement;
-  renderSendMessageIcon?: () => React.ReactElement;
+  acceptableMimeTypes?: string[];
+  renderFileUploadIcon?: GroupChannelUIBasicProps['renderFileUploadIcon'];
+  renderVoiceMessageIcon?: GroupChannelUIBasicProps['renderVoiceMessageIcon'];
+  renderSendMessageIcon?: GroupChannelUIBasicProps['renderSendMessageIcon'];
 }
 
 export const MessageInputWrapper = (props: MessageInputWrapperProps) => {

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import type { Member } from '@sendbird/chat/groupChannel';
 import { useGroupChannelHandler } from '@sendbird/uikit-tools';
 
-import type { CoreMessageType } from '../../../../utils';
+import { CoreMessageType, isSendableMessage } from '../../../../utils';
 import { EveryMessage, TypingIndicatorType } from '../../../../types';
 
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
@@ -160,7 +160,7 @@ export const MessageList = ({
                 currentMessage: message as CoreMessageType,
                 currentChannel,
               });
-              const isOutgoingMessage = message.isUserMessage() && message.sender.userId === store.config.userId;
+              const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
               return (
                 <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
                   {renderMessage({

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -23,11 +23,29 @@ import { GroupChannelUIBasicProps } from '../GroupChannelUI/GroupChannelUIView';
 
 export interface GroupChannelMessageListProps {
   className?: string;
+  /**
+   * A function that customizes the rendering of each message component in the message list component.
+   */
   renderMessage?: GroupChannelUIBasicProps['renderMessage'];
+  /**
+   * A function that customizes the rendering of the content portion of each message component.
+   */
   renderMessageContent?: GroupChannelUIBasicProps['renderMessageContent'];
+  /**
+   * A function that customizes the rendering of a separator component between messages.
+   */
   renderCustomSeparator?: GroupChannelUIBasicProps['renderCustomSeparator'];
+  /**
+   * A function that customizes the rendering of a loading placeholder component.
+   */
   renderPlaceholderLoader?: GroupChannelUIBasicProps['renderPlaceholderLoader'];
+  /**
+   * A function that customizes the rendering of an empty placeholder component when there are no messages in the channel.
+   */
   renderPlaceholderEmpty?: GroupChannelUIBasicProps['renderPlaceholderEmpty'];
+  /**
+   * A function that customizes the rendering of a frozen notification component when the channel is frozen.
+   */
   renderFrozenNotification?: GroupChannelUIBasicProps['renderFrozenNotification'];
 }
 


### PR DESCRIPTION
- Resolved an infinite loop issue occurring when using the `GroupChannel/components/Message`, `Channel/components/Message` in the `renderMessage` method of the `GroupChannel`,`Channel` module.
- The `renderMessage` method of the `GroupChannel` module no longer nests messages under the `Message` component. If a container element for the `Message` component is needed, use it as follows:
  ```tsx
   import { GroupChannel } from '@sendbird/uikit-react/GroupChannel';
   import { Message } from '@sendbird/uikit-react/GroupChannel/components/Message';
    const GroupChannelPage = () => {
      return (
        <GroupChannel
          renderMessage={(props) => {
            return (
              <Message message={props.message}>
                <div>{props.message.messageId}</div>
              </Message>
            )
          }}
        />
      )
    })
  ```
- The `renderMessage` prop of the `Channel/components/Message` and `GroupChannel/components/Message` components has been deprecated. Instead, use `children` prop to customize message sub-elements.
  ```tsx
  <Message message={props.message}>
    <div>{props.message.messageId}</div>
  </Message>
  ```
- Added detailed comments for customizing-related props in `GroupChannel` module.