### PR TITLE
fix: Display the normal file message for the mov video

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,7 +31,7 @@ export const SUPPORTED_MIMES = {
     'video/ogg',
     'video/webm',
     'video/mp4',
-    'video/quicktime', // .mov
+    // 'video/quicktime', // NOTE: Do not support ThumbnailMessage for the .mov video
   ],
   AUDIO: [
     'audio/aac',
@@ -54,6 +54,7 @@ export const SUPPORTED_MIMES = {
     'text/calendar',
     'text/javascript',
     'text/xml',
+    'video/quicktime', // NOTE: Assume this video is a normal file, not video
   ],
   APPLICATION: [
     'application/x-abiword',


### PR DESCRIPTION
[CLNP-2528](https://sendbird.atlassian.net/browse/CLNP-2528)

### ChangeLog & Fix
* Display the normal `FileMessage` for the `.mov` video

[CLNP-2528]: https://sendbird.atlassian.net/browse/CLNP-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ