### PR TITLE
fix: Scroll issue in the member list of the Modal

### DIFF
--- a/src/modules/ChannelSettings/components/ModerationPanel/BannedUsersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/BannedUsersModal.tsx
@@ -13,6 +13,7 @@ import ContextMenu, { MenuItem, MenuItems } from '../../../../ui/ContextMenu';
 import { noop } from '../../../../utils/utils';
 import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { useLocalization } from '../../../../lib/LocalizationContext';
+import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 interface Props {
   onCancel(): void;
@@ -44,24 +45,21 @@ export default function BannedUsersModal({
       >
         <div
           className="sendbird-more-members__popup-scroll"
-          onScroll={(e) => {
-            const { hasNext } = memberQuery;
-            const target = e.target as HTMLTextAreaElement;
-            const fetchMore = (
-              target.clientHeight + target.scrollTop === target.scrollHeight
-            );
-
-            if (hasNext && fetchMore) {
-              memberQuery.next().then((o) => {
-                setMembers([
-                  ...members,
-                  ...o,
-                ]);
-              });
-            }
-          }}
+          onScroll={useOnScrollPositionChangeDetector({
+            onReachedBottom: async () => {
+              const { hasNext } = memberQuery;
+              if (hasNext) {
+                memberQuery.next().then((o) => {
+                  setMembers([
+                    ...members,
+                    ...o,
+                  ]);
+                });
+              }
+            },
+          })}
         >
-          { members.map((member) => (
+          {members.map((member) => (
             <UserListItem
               user={member}
               key={member.userId}

--- a/src/modules/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
@@ -13,6 +13,7 @@ import { noop } from '../../../../utils/utils';
 import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useLocalization } from '../../../../lib/LocalizationContext';
+import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 interface Props {
   onCancel(): void;
@@ -51,24 +52,21 @@ export default function MutedMembersModal({
       >
         <div
           className="sendbird-more-members__popup-scroll"
-          onScroll={(e) => {
-            const { hasNext } = memberQuery;
-            const target = e.target as HTMLTextAreaElement;
-            const fetchMore = (
-              target.clientHeight + target.scrollTop === target.scrollHeight
-            );
-
-            if (hasNext && fetchMore) {
-              memberQuery.next().then((o) => {
-                setMembers([
-                  ...members,
-                  ...o,
-                ]);
-              });
-            }
-          }}
+          onScroll={useOnScrollPositionChangeDetector({
+            onReachedBottom: async () => {
+              const { hasNext } = memberQuery;
+              if (hasNext) {
+                memberQuery.next().then((o) => {
+                  setMembers([
+                    ...members,
+                    ...o,
+                  ]);
+                });
+              }
+            },
+          })}
         >
-          { members.map((member) => (
+          {members.map((member) => (
             <UserListItem
               currentUser={currentUser}
               user={member}

--- a/src/modules/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
@@ -14,6 +14,7 @@ import ContextMenu, { MenuItem, MenuItems } from '../../../../ui/ContextMenu';
 import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
+import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 interface Props { onCancel?(): void }
 
@@ -45,22 +46,19 @@ export default function OperatorsModal({ onCancel }: Props): ReactElement {
       >
         <div
           className="sendbird-more-members__popup-scroll"
-          onScroll={(e) => {
-            const { hasNext } = operatorQuery;
-            const target = e.target as HTMLTextAreaElement;
-            const fetchMore = (
-              target.clientHeight + target.scrollTop === target.scrollHeight
-            );
-
-            if (hasNext && fetchMore) {
-              operatorQuery.next().then((o) => {
-                setOperators([
-                  ...operators,
-                  ...o,
-                ]);
-              });
-            }
-          }}
+          onScroll={useOnScrollPositionChangeDetector({
+            onReachedBottom: async () => {
+              const { hasNext } = operatorQuery;
+              if (hasNext) {
+                operatorQuery.next().then((o) => {
+                  setOperators([
+                    ...operators,
+                    ...o,
+                  ]);
+                });
+              }
+            },
+          })}
         >
           {operators.map((member) => (
             <UserListItem

--- a/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
@@ -65,11 +65,7 @@ export default function AdminPannel(): ReactElement {
             </Label>
           </>
         )}
-        renderContent={() => (
-          <>
-            <OperatorList />
-          </>
-        )}
+        renderContent={() => <OperatorList />}
       />
       <Accordion
         className="sendbird-channel-settings__members-list"
@@ -92,11 +88,7 @@ export default function AdminPannel(): ReactElement {
             <Badge count={kFormatter(channel?.memberCount)} />
           </>
         )}
-        renderContent={() => (
-          <>
-            <MemberList />
-          </>
-        )}
+        renderContent={() => <MemberList />}
       />
       {
         // No muted members in broadcast channel
@@ -121,11 +113,7 @@ export default function AdminPannel(): ReactElement {
                 </Label>
               </>
             )}
-            renderContent={() => (
-              <>
-                <MutedMemberList />
-              </>
-            )}
+            renderContent={() => <MutedMemberList />}
           />
         )
       }
@@ -149,11 +137,7 @@ export default function AdminPannel(): ReactElement {
             </Label>
           </>
         )}
-        renderContent={() => (
-          <>
-            <BannedUserList />
-          </>
-        )}
+        renderContent={() => <BannedUserList />}
       />
       {
         // cannot freeze broadcast channel

--- a/src/ui/MobileMenu/ReactedMembersBottomSheet.tsx
+++ b/src/ui/MobileMenu/ReactedMembersBottomSheet.tsx
@@ -94,7 +94,7 @@ export const ReactedMembersBottomSheet = ({
                   className="sendbird-message__bottomsheet__reactor-list__item"
                   user={member}
                   avatarSize="36px"
-                  onClick={onPressUserProfileCallBack}
+                  onUserAvatarClick={onPressUserProfileCallBack}
                 />
               ))
           }

--- a/src/ui/Modal/index.scss
+++ b/src/ui/Modal/index.scss
@@ -5,9 +5,6 @@
     width: 100vw;
     max-width: 100%;
     height: 100%;
-    @include mobile() {
-      height: stretch;
-    }
   }
 }
 

--- a/src/ui/UserListItem/index.tsx
+++ b/src/ui/UserListItem/index.tsx
@@ -27,7 +27,9 @@ export interface UserListItemProps {
   }): ReactElement;
   onChange?(e: ChangeEvent<HTMLInputElement>): void;
   avatarSize?: string;
+  /** @deprecated Please use the onUserAvatarClick instead */
   onClick?(): void,
+  onUserAvatarClick?(): void,
 }
 
 export default function UserListItem({
@@ -43,6 +45,7 @@ export default function UserListItem({
   onChange,
   avatarSize = '40px',
   onClick,
+  onUserAvatarClick,
 }: UserListItemProps): ReactElement {
   const uniqueKey = user.userId;
   const actionRef = React.useRef(null);
@@ -74,7 +77,7 @@ export default function UserListItem({
             onClick={() => {
               if (!disableUserProfile) {
                 toggleDropdown();
-                onClick?.();
+                (onUserAvatarClick ?? onClick)?.();
               }
             }}
           />


### PR DESCRIPTION
### ChangeLog & Fix
* Fixed a specific environment issue (Android emulator) - Resolved an issue in modals used in ChannelSettings such as MembersModal, MutedMembersModal, OperatorsModal, BannedUsersModal, where even when scrolling to the end, additional members were not fetched
* Fixed a specific environment issue (Safari) - Similarly addressed an issue within lists inside modals, where overflow occurred instead of scrolling
* Deprecated the `onClick` prop in `UserListItem` and added `onUserAvatarClick`. The deprecated prop will be removed in the next major version