### PR TITLE
release v3.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog - v3
 
+## [v3.13.2] (Mar 14, 2024)
+
+### Features
+* Add a `renderHeader` props to the ChannelSettingsUIProps
+  ```
+  <ChannelSettingsUI
+    renderHeader={() => ...}
+  />
+  ```
+
+### Fixes
+* Deprecated the `onClick` prop in `UserListItem` and added `onUserAvatarClick`. The deprecated prop will be removed in the next major version
+* Added throttling in `mute/unmute` operation
+* Added throttling in `add/remove` operator operation
+* Fixed that the Chat SDK is not initialized more than once
+* Display the normal `FileMessage` for the `.mov` video
+* Show `X` button on the ModalHeader of mobile mode
+* Modify the incorrect stringSet on the BannedUsersModal
+  * `CHANNEL_SETTING__MUTED_MEMBERS__TITLE` to `CHANNEL_SETTING__BANNED_MEMBERS__TITLE`
+  * `CHANNEL_SETTING__MODERATION__BAN` to `CHANNEL_SETTING__MODERATION__UNBAN`
+  * also modified the dataSbId, `channel_setting_banned_user_context_menu_ban` to `channel_setting_banned_user_context_menu_unban`
+* Fixed a specific environment issue (Android emulator) - Resolved an issue in modals used in ChannelSettings such as MembersModal, MutedMembersModal, AddOperatorsModal, OperatorsModal, BannedUsersModal, where even when scrolling to the end, additional members were not fetched
+* Fixed a specific environment issue (Safari) - Similarly addressed an issue within lists inside modals, where overflow occurred instead of scrolling
+
 ## [v3.13.1] (Mar 08, 2024)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.13.2-rc.0",
+  "version": "3.13.2",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.13.1",
+  "version": "3.13.2-rc.0",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",

--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -60,6 +60,7 @@ export default {
   'ChannelSettings/components/ModerationPanel': 'src/modules/ChannelSettings/components/ModerationPanel/index.tsx',
   'ChannelSettings/components/ChannelProfile': 'src/modules/ChannelSettings/components/ChannelProfile/index.tsx',
   'ChannelSettings/components/ChannelSettingsUI': 'src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx',
+  'ChannelSettings/components/ChannelSettingsHeader': 'src/modules/ChannelSettings/components/ChannelSettingsUI/ChannelSettingsHeader.tsx',
   'ChannelSettings/components/EditDetailsModal': 'src/modules/ChannelSettings/components/EditDetailsModal/index.tsx',
   'ChannelSettings/components/LeaveChannel': 'src/modules/ChannelSettings/components/LeaveChannel/index.tsx',
   'ChannelSettings/components/UserListItem': 'src/modules/ChannelSettings/components/UserListItem/index.tsx',


### PR DESCRIPTION
## [v3.13.2] (Mar 14, 2024)

### Features
* Add a `renderHeader` props to the ChannelSettingsUIProps
  ```
  <ChannelSettingsUI
    renderHeader={() => ...}
  />
  ```

### Fixes
* Deprecated the `onClick` prop in `UserListItem` and added `onUserAvatarClick`. The deprecated prop will be removed in the next major version
* Added throttling in `mute/unmute` operation
* Added throttling in `add/remove` operator operation
* Fixed that the Chat SDK is not initialized more than once
* Display the normal `FileMessage` for the `.mov` video
* Show `X` button on the ModalHeader of mobile mode
* Modify the incorrect stringSet on the BannedUsersModal
  * `CHANNEL_SETTING__MUTED_MEMBERS__TITLE` to `CHANNEL_SETTING__BANNED_MEMBERS__TITLE`
  * `CHANNEL_SETTING__MODERATION__BAN` to `CHANNEL_SETTING__MODERATION__UNBAN`
  * also modified the dataSbId, `channel_setting_banned_user_context_menu_ban` to `channel_setting_banned_user_context_menu_unban`
* Fixed a specific environment issue (Android emulator) - Resolved an issue in modals used in ChannelSettings such as MembersModal, MutedMembersModal, AddOperatorsModal, OperatorsModal, BannedUsersModal, where even when scrolling to the end, additional members were not fetched
* Fixed a specific environment issue (Safari) - Similarly addressed an issue within lists inside modals, where overflow occurred instead of scrolling