### PR TITLE
feature: Add an interface for confirming file download

### DIFF
--- a/src/modules/GroupChannel/components/FileViewer/FileViewerView.tsx
+++ b/src/modules/GroupChannel/components/FileViewer/FileViewerView.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 
 import { FileViewerProps } from '.';
@@ -15,12 +15,14 @@ import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 type DeleteMessageTypeLegacy = (message: CoreMessageType) => Promise<void>;
 export interface FileViewerViewProps extends FileViewerProps {
   deleteMessage: ((message: SendableMessageType) => Promise<void>) | DeleteMessageTypeLegacy;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export const FileViewerView = ({
   message,
   onCancel,
   deleteMessage,
+  onDownloadClick,
 }: FileViewerViewProps) => {
   const { sender, type, url, name = '', threadInfo } = message;
   const { profileUrl, nickname, userId } = sender;
@@ -38,6 +40,7 @@ export const FileViewerView = ({
       onDelete={() => deleteMessage(message).then(() => onCancel())}
       isByMe={config.userId === userId}
       disableDelete={threadInfo?.replyCount > 0}
+      onDownloadClick={onDownloadClick}
     />,
     document.getElementById(MODAL_ROOT),
   );
@@ -56,6 +59,7 @@ export interface FileViewerUIProps {
   onCancel: () => void;
   onDelete: () => void;
   disableDelete: boolean;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export const FileViewerComponent = ({
@@ -71,6 +75,7 @@ export const FileViewerComponent = ({
   onCancel,
   onDelete,
   disableDelete,
+  onDownloadClick,
 }: FileViewerUIProps) => (
   <div className="sendbird-fileviewer">
     <div className="sendbird-fileviewer__header">
@@ -88,7 +93,13 @@ export const FileViewerComponent = ({
       <div className="sendbird-fileviewer__header__right">
         {isSupportedFileView(type) && (
           <div className="sendbird-fileviewer__header__right__actions">
-            <a className="sendbird-fileviewer__header__right__actions__download" rel="noopener noreferrer" href={url} target="_blank">
+            <a
+              className="sendbird-fileviewer__header__right__actions__download"
+              rel="noopener noreferrer"
+              href={url}
+              target="_blank"
+              onClick={onDownloadClick}
+            >
               <Icon type={IconTypes.DOWNLOAD} fillColor={IconColors.ON_BACKGROUND_1} height="24px" width="24px" />
             </a>
             {onDelete && isByMe && (

--- a/src/modules/GroupChannel/components/FileViewer/index.tsx
+++ b/src/modules/GroupChannel/components/FileViewer/index.tsx
@@ -3,6 +3,7 @@ import type { FileMessage } from '@sendbird/chat/message';
 
 import { FileViewerView } from './FileViewerView';
 import { useGroupChannelContext } from '../../context/GroupChannelProvider';
+import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 
 export interface FileViewerProps {
   onCancel: () => void;
@@ -10,8 +11,29 @@ export interface FileViewerProps {
 }
 
 export const FileViewer = (props: FileViewerProps) => {
-  const { deleteMessage } = useGroupChannelContext();
-  return <FileViewerView {...props} deleteMessage={deleteMessage} />;
+  const { deleteMessage, onBeforeDownloadFileMessage } = useGroupChannelContext();
+  const { config } = useSendbirdStateContext();
+  const { logger } = config;
+  return (
+    <FileViewerView
+      {...props}
+      deleteMessage={deleteMessage}
+      onDownloadClick={async (e) => {
+        if (!onBeforeDownloadFileMessage) {
+          return null;
+        }
+        try {
+          const allowDownload = await onBeforeDownloadFileMessage({ message: props.message });
+          if (!allowDownload) {
+            e.preventDefault();
+            logger.info?.('FileViewer: Not allowed to download.');
+          }
+        } catch (err) {
+          logger.error?.('FileViewer: Error occurred while determining download continuation:', err);
+        }
+      }}
+    />
+  );
 };
 
 export default FileViewer;

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -81,7 +81,7 @@ export interface MessageViewProps extends MessageProps {
   renderFileViewer: (props: { message: FileMessage; onCancel: () => void }) => React.ReactElement;
   renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void }) => React.ReactElement;
   /**
-   * You can't use this prop in the (legacy) Channel component.
+   * You can't use this prop in the Channel component (legacy).
    * Accepting this prop only for the GroupChannel.
   */
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -20,6 +20,7 @@ import MessageContent, { MessageContentProps } from '../../../../ui/MessageConte
 
 import SuggestedReplies, { SuggestedRepliesProps } from '../SuggestedReplies';
 import SuggestedMentionListView from '../SuggestedMentionList/SuggestedMentionListView';
+import type { OnBeforeDownloadFileMessageType } from '../../context/GroupChannelProvider';
 
 export interface MessageProps {
   message: EveryMessage;
@@ -27,7 +28,6 @@ export interface MessageProps {
   chainTop?: boolean;
   chainBottom?: boolean;
   handleScroll?: (isBottomMessageAffected?: boolean) => void;
-
   /**
    * Customizes all child components of the message.
    * */
@@ -80,6 +80,11 @@ export interface MessageViewProps extends MessageProps {
 
   renderFileViewer: (props: { message: FileMessage; onCancel: () => void }) => React.ReactElement;
   renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void }) => React.ReactElement;
+  /**
+   * You can't use this prop in the (legacy) Channel component.
+   * Accepting this prop only for the GroupChannel.
+  */
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 
   animatedMessageId: number;
   setAnimatedMessageId: React.Dispatch<React.SetStateAction<number>>;
@@ -127,6 +132,7 @@ const MessageView = (props: MessageViewProps) => {
     setQuoteMessage,
     onQuoteMessageClick,
     onReplyInThreadClick,
+    onBeforeDownloadFileMessage,
 
     sendUserMessage,
     updateUserMessage,
@@ -261,6 +267,7 @@ const MessageView = (props: MessageViewProps) => {
           onReplyInThread: onReplyInThreadClick,
           onQuoteMessageClick: onQuoteMessageClick,
           onMessageHeightChange: handleScroll,
+          onBeforeDownloadFileMessage,
         })}
         { /* Suggested Replies */ }
         {

--- a/src/modules/GroupChannel/components/Message/index.tsx
+++ b/src/modules/GroupChannel/components/Message/index.tsx
@@ -27,6 +27,7 @@ export const Message = (props: MessageProps): React.ReactElement => {
     onQuoteMessageClick,
     onReplyInThreadClick,
     onMessageAnimated,
+    onBeforeDownloadFileMessage,
     messages,
     updateUserMessage,
     sendUserMessage,
@@ -82,6 +83,7 @@ export const Message = (props: MessageProps): React.ReactElement => {
       renderFileViewer={(props) => <FileViewer {...props} />}
       renderRemoveMessageModal={(props) => <RemoveMessageModal {...props} />}
       usedInLegacy={false}
+      onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
     />
   );
 };

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -7,6 +7,7 @@ import {
   UserMessageCreateParams,
   UserMessageUpdateParams,
   type FileMessage,
+  type MultipleFilesMessage,
 } from '@sendbird/chat/message';
 import type { GroupChannel, MessageCollectionParams, MessageFilterParams } from '@sendbird/chat/groupChannel';
 import { MessageFilter } from '@sendbird/chat/groupChannel';
@@ -31,7 +32,7 @@ type OnBeforeHandler<T> = (params: T) => T | Promise<T>;
 type MessageListQueryParamsType = Omit<MessageCollectionParams, 'filter'> & MessageFilterParams;
 type MessageActions = ReturnType<typeof useMessageActions>;
 type MessageListDataSourceWithoutActions = Omit<ReturnType<typeof useGroupChannelMessages>, keyof MessageActions | `_dangerous_${string}`>;
-export type OnBeforeDownloadFileMessageType = (params: { message: FileMessage }) => Promise<boolean>;
+export type OnBeforeDownloadFileMessageType = (params: { message: FileMessage | MultipleFilesMessage, index?: number }) => Promise<boolean>;
 
 interface ContextBaseType {
   // Required

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -6,6 +6,7 @@ import {
   ReplyType as ChatReplyType,
   UserMessageCreateParams,
   UserMessageUpdateParams,
+  type FileMessage,
 } from '@sendbird/chat/message';
 import type { GroupChannel, MessageCollectionParams, MessageFilterParams } from '@sendbird/chat/groupChannel';
 import { MessageFilter } from '@sendbird/chat/groupChannel';
@@ -30,6 +31,7 @@ type OnBeforeHandler<T> = (params: T) => T | Promise<T>;
 type MessageListQueryParamsType = Omit<MessageCollectionParams, 'filter'> & MessageFilterParams;
 type MessageActions = ReturnType<typeof useMessageActions>;
 type MessageListDataSourceWithoutActions = Omit<ReturnType<typeof useGroupChannelMessages>, keyof MessageActions | `_dangerous_${string}`>;
+export type OnBeforeDownloadFileMessageType = (params: { message: FileMessage }) => Promise<boolean>;
 
 interface ContextBaseType {
   // Required
@@ -61,6 +63,7 @@ interface ContextBaseType {
   onBeforeSendVoiceMessage?: OnBeforeHandler<FileMessageCreateParams>;
   onBeforeSendMultipleFilesMessage?: OnBeforeHandler<MultipleFilesMessageCreateParams>;
   onBeforeUpdateUserMessage?: OnBeforeHandler<UserMessageUpdateParams>;
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 
   // Click
   onBackClick?(): void;
@@ -123,6 +126,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
     onBeforeSendVoiceMessage,
     onBeforeSendMultipleFilesMessage,
     onBeforeUpdateUserMessage,
+    onBeforeDownloadFileMessage,
     onMessageAnimated,
     onBackClick,
     onChatHeaderActionClick,
@@ -389,6 +393,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
         onBeforeSendVoiceMessage,
         onBeforeSendMultipleFilesMessage,
         onBeforeUpdateUserMessage,
+        onBeforeDownloadFileMessage,
         // ## Focusing
         onMessageAnimated,
         // ## Click

--- a/src/modules/GroupChannel/index.tsx
+++ b/src/modules/GroupChannel/index.tsx
@@ -6,7 +6,13 @@ import GroupChannelUI, { GroupChannelUIProps } from './components/GroupChannelUI
 export interface GroupChannelProps extends GroupChannelProviderProps, GroupChannelUIProps {}
 export const GroupChannel = (props: GroupChannelProps) => {
   return (
-    <GroupChannelProvider {...props}>
+    <GroupChannelProvider {...props}
+      onBeforeDownloadFileMessage={async ({ message }) => {
+        console.log('후니, 파일사이즈', message.size);
+        const confirmed = window.confirm('파일을 다운로드 하시겠습니까?');
+        return confirmed;
+      }}
+    >
       <GroupChannelUI {...props} />
     </GroupChannelProvider>
   );

--- a/src/modules/GroupChannel/index.tsx
+++ b/src/modules/GroupChannel/index.tsx
@@ -3,16 +3,10 @@ import React from 'react';
 import { GroupChannelProvider, GroupChannelProviderProps } from './context/GroupChannelProvider';
 import GroupChannelUI, { GroupChannelUIProps } from './components/GroupChannelUI';
 
-export interface GroupChannelProps extends GroupChannelProviderProps, GroupChannelUIProps {}
+export interface GroupChannelProps extends GroupChannelProviderProps, GroupChannelUIProps { }
 export const GroupChannel = (props: GroupChannelProps) => {
   return (
-    <GroupChannelProvider {...props}
-      onBeforeDownloadFileMessage={async ({ message }) => {
-        console.log('후니, 파일사이즈', message.size);
-        const confirmed = window.confirm('파일을 다운로드 하시겠습니까?');
-        return confirmed;
-      }}
-    >
+    <GroupChannelProvider {...props}>
       <GroupChannelUI {...props} />
     </GroupChannelProvider>
   );

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -111,10 +111,10 @@ export default function ParentMessageInfoItem({
           if (allowDownload) {
             downloadFileWithUrl();
           } else {
-            logger?.info?.('FileMessageItemBody: Not allowed to download.');
+            logger?.info?.('ParentMessageInfoItem: Not allowed to download.');
           }
         } catch (err) {
-          logger?.error?.('FileMessageItemBody: Error occurred while determining download continuation:', err);
+          logger?.error?.('ParentMessageInfoItem: Error occurred while determining download continuation:', err);
         }
       }
     }

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -49,7 +49,7 @@ export default function ParentMessageInfoItem({
   className,
   message,
   showFileViewer,
-  onBeforeDownloadFileMessage,
+  onBeforeDownloadFileMessage = null,
 }: ParentMessageInfoItemProps): ReactElement {
   const { stores, config, eventHandlers } = useSendbirdStateContext?.() || {};
   const { logger } = config;
@@ -97,6 +97,7 @@ export default function ParentMessageInfoItem({
     });
   }, [message?.updatedAt, (message as UserMessage)?.message]);
 
+  // Only for the FileMessageItemBody
   const downloadFileWithUrl = () => {
     if (message.messageType === 'file') {
       window.open((message as FileMessage)?.url);
@@ -200,6 +201,7 @@ export default function ParentMessageInfoItem({
         </div>
       )} */}
       {
+        // Instead of the FileMessageItemBody component
         (getUIKitMessageType((message as FileMessage)) === getUIKitMessageTypes().FILE) && (
           <div className="sendbird-parent-message-info-item__file-message">
             <div className="sendbird-parent-message-info-item__file-message__file-icon">
@@ -242,6 +244,7 @@ export default function ParentMessageInfoItem({
             isReactionEnabled={isReactionEnabled}
             threadMessageKindKey={threadMessageKindKey}
             statefulFileInfoList={statefulFileInfoList}
+            onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
           />
         )
       }

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -59,6 +59,7 @@ export default function ParentMessageInfo({
     onHeaderActionClick,
     isMuted,
     isChannelFrozen,
+    onBeforeDownloadFileMessage,
   } = useThreadContext();
   const { isMobile } = useMediaQueryContext();
 
@@ -280,6 +281,7 @@ export default function ParentMessageInfo({
         <ParentMessageInfoItem
           message={parentMessage}
           showFileViewer={setShowFileViewer}
+          onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
         />
       </div>
       {/* context menu */}

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -119,6 +119,21 @@ export default function ParentMessageInfo({
     }));
   }, [mentionedUserIds]);
 
+  const handleOnDownloadClick = async (e) => {
+    if (!onBeforeDownloadFileMessage) {
+      return null;
+    }
+    try {
+      const allowDownload = await onBeforeDownloadFileMessage({ message: parentMessage as FileMessage });
+      if (!allowDownload) {
+        e.preventDefault();
+        logger?.info?.('ParentMessageInfo: Not allowed to download.');
+      }
+    } catch (err) {
+      logger?.error?.('ParentMessageInfo: Error occurred while determining download continuation:', err);
+    }
+  };
+
   // User Profile
   const avatarRef = useRef(null);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
@@ -331,6 +346,7 @@ export default function ParentMessageInfo({
                 setShowFileViewer(false);
               });
           }}
+          onDownloadClick={handleOnDownloadClick}
         />
       )}
       {showMobileMenu && (
@@ -356,6 +372,7 @@ export default function ParentMessageInfo({
           showRemove={setShowRemove}
           toggleReaction={toggleReaction}
           isOpenedFromThread
+          onDownloadClick={handleOnDownloadClick}
         />
       )}
     </div>

--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -94,7 +94,7 @@ export default function ThreadListItemContent({
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const [supposedHover, setSupposedHover] = useState(false);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
-  const { deleteMessage } = useThreadContext();
+  const { deleteMessage, onBeforeDownloadFileMessage } = useThreadContext();
   const avatarRef = useRef(null);
 
   const isByMe = (userId === (message as SendableMessageType)?.sender?.userId)
@@ -270,6 +270,7 @@ export default function ThreadListItemContent({
               isByMe={isByMe}
               isReactionEnabled={isReactionEnabledInChannel}
               truncateLimit={isByMe ? 18 : 14}
+              onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
             />
           )}
           {

--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -91,6 +91,7 @@ export default function ThreadListItemContent({
   const { isMobile } = useMediaQueryContext();
   const { dateLocale } = useLocalization();
   const { config, eventHandlers } = useSendbirdStateContext?.() || {};
+  const { logger } = config;
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const [supposedHover, setSupposedHover] = useState(false);
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
@@ -392,6 +393,20 @@ export default function ThreadListItemContent({
           toggleReaction={toggleReaction}
           isOpenedFromThread
           deleteMessage={deleteMessage}
+          onDownloadClick={async (e) => {
+            if (!onBeforeDownloadFileMessage) {
+              return null;
+            }
+            try {
+              const allowDownload = await onBeforeDownloadFileMessage({ message: message as FileMessage });
+              if (!allowDownload) {
+                e.preventDefault();
+                logger?.info?.('ThreadListItemContent: Not allowed to download.');
+              }
+            } catch (err) {
+              logger?.error?.('ThreadListItemContent: Error occurred while determining download continuation:', err);
+            }
+          }}
         />
       )}
     </div>

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -32,6 +32,7 @@ import useSendVoiceMessageCallback from './hooks/useSendVoiceMessageCallback';
 import { PublishingModuleType, useSendMultipleFilesMessage } from './hooks/useSendMultipleFilesMessage';
 import { SendableMessageType } from '../../../utils';
 import { useThreadFetchers } from './hooks/useThreadFetchers';
+import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
 
 export type ThreadProviderProps = {
   children?: React.ReactElement;
@@ -43,6 +44,7 @@ export type ThreadProviderProps = {
   onBeforeSendFileMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
   onBeforeSendVoiceMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
   onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
   // User Profile
   disableUserProfile?: boolean;
   renderUserProfile?: (props: { user: User, close: () => void }) => ReactElement;
@@ -74,6 +76,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
     onBeforeSendFileMessage,
     onBeforeSendVoiceMessage,
     onBeforeSendMultipleFilesMessage,
+    onBeforeDownloadFileMessage,
     isMultipleFilesMessageEnabled,
     // User Profile
     disableUserProfile,
@@ -233,6 +236,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
         onHeaderActionClick,
         onMoveToParentMessage,
         isMultipleFilesMessageEnabled,
+        onBeforeDownloadFileMessage,
         // ThreadContextInitialState
         currentChannel,
         allThreadMessages,

--- a/src/ui/FileMessageItemBody/index.tsx
+++ b/src/ui/FileMessageItemBody/index.tsx
@@ -30,8 +30,12 @@ export default function FileMessageItemBody({
   truncateLimit = null,
   onBeforeDownloadFileMessage = null,
 }: Props): ReactElement {
-  const { config } = useSendbirdStateContext();
-  const { logger } = config;
+  let logger = null;
+  try {
+    logger = useSendbirdStateContext()?.config?.logger;
+  } catch (err) {
+    // TODO: Handle error
+  }
   const { isMobile } = useMediaQueryContext();
   const truncateMaxNum = truncateLimit || (isMobile ? 20 : null);
 

--- a/src/ui/FileMessageItemBody/index.tsx
+++ b/src/ui/FileMessageItemBody/index.tsx
@@ -8,6 +8,8 @@ import TextButton from '../TextButton';
 import { getClassName, getUIKitFileType, truncateString } from '../../utils';
 import { Colors } from '../../utils/color';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
+import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
+import type { OnBeforeDownloadFileMessageType } from '../../modules/GroupChannel/context/GroupChannelProvider';
 
 interface Props {
   className?: string | Array<string>;
@@ -16,6 +18,7 @@ interface Props {
   mouseHover?: boolean;
   isReactionEnabled?: boolean;
   truncateLimit?: number;
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 }
 
 export default function FileMessageItemBody({
@@ -25,9 +28,29 @@ export default function FileMessageItemBody({
   mouseHover = false,
   isReactionEnabled = false,
   truncateLimit = null,
+  onBeforeDownloadFileMessage = null,
 }: Props): ReactElement {
+  const { config } = useSendbirdStateContext?.();
+  const { logger } = config;
   const { isMobile } = useMediaQueryContext();
   const truncateMaxNum = truncateLimit || (isMobile ? 20 : null);
+
+  const downloadFileWithUrl = () => window.open(message?.url);
+  const handleOnClickTextButton = onBeforeDownloadFileMessage
+    ? async () => {
+      try {
+        const allowDownload = await onBeforeDownloadFileMessage({ message });
+        if (allowDownload) {
+          downloadFileWithUrl();
+        } else {
+          logger?.info?.('FileMessageItemBody: Not allowed to download.');
+        }
+      } catch (err) {
+        logger?.error?.('FileMessageItemBody: Error occurred while determining download continuation:', err);
+      }
+    }
+    : downloadFileWithUrl;
+
   return (
     <div className={getClassName([
       className,
@@ -53,7 +76,7 @@ export default function FileMessageItemBody({
       </div>
       <TextButton
         className="sendbird-file-message-item-body__file-name"
-        onClick={() => { window.open(message?.url); }}
+        onClick={handleOnClickTextButton}
         color={isByMe ? Colors.ONCONTENT_1 : Colors.ONBACKGROUND_1}
       >
         <Label

--- a/src/ui/FileMessageItemBody/index.tsx
+++ b/src/ui/FileMessageItemBody/index.tsx
@@ -30,7 +30,7 @@ export default function FileMessageItemBody({
   truncateLimit = null,
   onBeforeDownloadFileMessage = null,
 }: Props): ReactElement {
-  const { config } = useSendbirdStateContext?.();
+  const { config } = useSendbirdStateContext();
   const { logger } = config;
   const { isMobile } = useMediaQueryContext();
   const truncateMaxNum = truncateLimit || (isMobile ? 20 : null);

--- a/src/ui/FileViewer/index.tsx
+++ b/src/ui/FileViewer/index.tsx
@@ -18,9 +18,17 @@ import { useKeyDown } from '../../hooks/useKeyDown/useKeyDown';
 import { UploadedFileInfoWithUpload } from '../../types';
 
 export const FileViewerComponent = (props: FileViewerComponentProps): ReactElement => {
+  const {
+    profileUrl,
+    nickname,
+    onClose,
+    onDownloadClick,
+  } = props;
+  const {
+    onClickLeft,
+    onClickRight,
+  } = props as MultiFilesViewer;
   const ref = useRef<HTMLDivElement>(null);
-  const { profileUrl, nickname, onClose } = props;
-  const { onClickLeft, onClickRight } = props as MultiFilesViewer;
   const onKeyDown = useKeyDown(ref, {
     Escape: (e) => onClose?.(e),
     ArrowLeft: () => onClickLeft?.(),
@@ -68,6 +76,7 @@ export const FileViewerComponent = (props: FileViewerComponentProps): ReactEleme
                   rel="noopener noreferrer"
                   href={url}
                   target="_blank"
+                  onClick={onDownloadClick}
                 >
                   <Icon
                     type={IconTypes.DOWNLOAD}
@@ -140,6 +149,7 @@ export interface FileViewerProps {
   onDelete?: (e: MouseEvent) => void;
   onClickLeft?: () => void;
   onClickRight?: () => void;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export default function FileViewer({
@@ -151,6 +161,7 @@ export default function FileViewer({
   currentIndex,
   onClickLeft,
   onClickRight,
+  onDownloadClick,
 }: FileViewerProps): ReactElement {
   if (isMultipleFilesMessage(message)) {
     const castedMessage = message as MultipleFilesMessage;
@@ -174,6 +185,7 @@ export default function FileViewer({
         onClickLeft={onClickLeft || noop}
         onClickRight={onClickRight || noop}
         onClose={onClose}
+        onDownloadClick={onDownloadClick}
       />
     );
   } else if (isFileMessage(message)) {
@@ -190,6 +202,7 @@ export default function FileViewer({
           disableDelete={(castedMessage.threadInfo?.replyCount || 0) > 0}
           onClose={onClose}
           onDelete={onDelete || noop}
+          onDownloadClick={onDownloadClick}
         />
       ),
       (document.getElementById(MODAL_ROOT) as HTMLElement),

--- a/src/ui/FileViewer/types.ts
+++ b/src/ui/FileViewer/types.ts
@@ -1,7 +1,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
 
 // TODO: refactor this to -> as const pattern
-import { KeyboardEvent } from 'react';
+import { KeyboardEvent, MouseEvent } from 'react';
 
 export type SupportedImageMimesType = 'image/jpeg' | 'image/jpg' | 'image/png' | 'image/gif' | 'image/svg+xml' | 'image/webp';
 export type SupportedVideoMimesType = 'video/mpeg' | 'video/ogg' | 'video/webm' | 'video/mp4';
@@ -61,7 +61,8 @@ export interface SingleFileViewer extends SenderInfo, FileInfo, BaseViewer {
   viewerType?: typeof ViewerTypes.SINGLE;
   isByMe?: boolean;
   disableDelete?: boolean;
-  onDelete: (e: React.MouseEvent) => void;
+  onDelete: (e: MouseEvent) => void;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export interface MultiFilesViewer extends SenderInfo, BaseViewer {
@@ -70,6 +71,7 @@ export interface MultiFilesViewer extends SenderInfo, BaseViewer {
   currentIndex: number;
   onClickLeft: () => void;
   onClickRight: () => void;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export type FileViewerComponentProps = SingleFileViewer | MultiFilesViewer;

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -21,6 +21,7 @@ import { Nullable, SendbirdTheme } from '../../../types';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import { match } from 'ts-pattern';
 import TemplateMessageItemBody from '../../TemplateMessageItemBody';
+import type { OnBeforeDownloadFileMessageType } from '../../../modules/GroupChannel/context/GroupChannelProvider';
 
 const MESSAGE_ITEM_BODY_CLASSNAME = 'sendbird-message-content__middle__message-item-body';
 
@@ -29,6 +30,7 @@ export interface MessageBodyProps {
   message: CoreMessageType;
   showFileViewer?: (bool: boolean) => void;
   onMessageHeightChange?: () => void;
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 
   mouseHover: boolean;
   isMobile: boolean;
@@ -43,6 +45,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
     channel,
     showFileViewer,
     onMessageHeightChange,
+    onBeforeDownloadFileMessage,
 
     mouseHover,
     isMobile,
@@ -98,6 +101,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         isByMe={isByMe}
         mouseHover={mouseHover}
         isReactionEnabled={isReactionEnabledInChannel}
+        onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
       />
     ))
     .when(isMultipleFilesMessage, () => (

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -113,6 +113,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         isReactionEnabled={isReactionEnabledInChannel}
         threadMessageKindKey={threadMessageKindKey}
         statefulFileInfoList={statefulFileInfoList}
+        onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
       />
     ))
     .when(isVoiceMessage, () => (

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -141,6 +141,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
 
   const { dateLocale } = useLocalization();
   const { config, eventHandlers } = useSendbirdStateContext?.() || {};
+  const { logger } = config;
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const contentRef = useRef(null);
   const { isMobile } = useMediaQueryContext();
@@ -517,6 +518,20 @@ export default function MessageContent(props: MessageContentProps): ReactElement
               onReplyInThread?.({ message });
             } else if (threadReplySelectType === ThreadReplySelectType.PARENT) {
               scrollToMessage?.(message?.parentMessage?.createdAt || 0, message?.parentMessageId || 0);
+            }
+          },
+          onDownloadClick: async (e) => {
+            if (!onBeforeDownloadFileMessage) {
+              return null;
+            }
+            try {
+              const allowDownload = await onBeforeDownloadFileMessage({ message: message as FileMessage });
+              if (!allowDownload) {
+                e.preventDefault();
+                logger?.info?.('MessageContent: Not allowed to download.');
+              }
+            } catch (err) {
+              logger?.error?.('MessageContent: Error occurred while determining download continuation:', err);
             }
           },
         })

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -15,6 +15,7 @@ import EmojiReactions, { EmojiReactionsProps } from '../EmojiReactions';
 import ClientAdminMessage from '../AdminMessage';
 import QuoteMessage from '../QuoteMessage';
 
+import type { OnBeforeDownloadFileMessageType } from '../../modules/GroupChannel/context/GroupChannelProvider';
 import {
   getClassName,
   isOGMessage,
@@ -73,6 +74,7 @@ export interface MessageContentProps {
   // onClick listener for thread quote message view (for open thread module)
   onQuoteMessageClick?: (props: { message: SendableMessageType }) => void;
   onMessageHeightChange?: () => void;
+  onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 
   // For injecting customizable sub-components
   renderSenderProfile?: (props: MessageProfileProps) => ReactNode;
@@ -111,6 +113,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     onReplyInThread,
     onQuoteMessageClick,
     onMessageHeightChange,
+    onBeforeDownloadFileMessage,
 
     // Public props for customization
     renderSenderProfile = (props: MessageProfileProps) => (
@@ -340,6 +343,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
               config,
               isReactionEnabledInChannel,
               isByMe,
+              onBeforeDownloadFileMessage,
             })
           }
           {/* reactions */}

--- a/src/ui/MobileMenu/MobileBottomSheet.tsx
+++ b/src/ui/MobileMenu/MobileBottomSheet.tsx
@@ -44,6 +44,7 @@ const MobileBottomSheet: React.FunctionComponent<MobileBottomSheetProps> = (prop
     setQuoteMessage,
     onReplyInThread,
     isOpenedFromThread = false,
+    onDownloadClick,
   } = props;
   const isByMe = message?.sender?.userId === userId;
   const { stringSet } = useLocalization();
@@ -336,6 +337,7 @@ const MobileBottomSheet: React.FunctionComponent<MobileBottomSheetProps> = (prop
                       rel="noopener noreferrer"
                       href={fileMessage?.url}
                       target="_blank"
+                      onClick={onDownloadClick}
                     >
                       <Icon
                         type={IconTypes.DOWNLOAD}

--- a/src/ui/MobileMenu/MobileContextMenu.tsx
+++ b/src/ui/MobileMenu/MobileContextMenu.tsx
@@ -35,6 +35,7 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
     parentRef,
     onReplyInThread,
     isOpenedFromThread = false,
+    onDownloadClick = null,
   } = props;
   const isByMe = message?.sender?.userId === userId;
   const { stringSet } = useLocalization();
@@ -248,6 +249,7 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
                 rel="noopener noreferrer"
                 href={fileMessage?.url}
                 target="_blank"
+                onClick={onDownloadClick}
               >
                 <Label
                   type={LabelTypography.SUBTITLE_1}

--- a/src/ui/MobileMenu/index.tsx
+++ b/src/ui/MobileMenu/index.tsx
@@ -26,6 +26,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
     parentRef,
     onReplyInThread,
     isOpenedFromThread,
+    onDownloadClick,
   } = props;
   return (
     <>
@@ -51,6 +52,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
               isReactionEnabled={isReactionEnabled}
               onReplyInThread={onReplyInThread}
               isOpenedFromThread={isOpenedFromThread}
+              onDownloadClick={onDownloadClick}
             />
           ) : (
             <MobileContextMenu
@@ -70,6 +72,7 @@ const MobileMenu: React.FC<MobileBottomSheetProps> = (props: MobileBottomSheetPr
               parentRef={parentRef}
               onReplyInThread={onReplyInThread}
               isOpenedFromThread={isOpenedFromThread}
+              onDownloadClick={onDownloadClick}
             />
           )
       }

--- a/src/ui/MobileMenu/types.ts
+++ b/src/ui/MobileMenu/types.ts
@@ -1,7 +1,7 @@
+import React, { MouseEvent } from 'react';
 import type { EmojiContainer } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
-import React from 'react';
 import { CoreMessageType, SendableMessageType } from '../../utils';
 import { ReplyType } from '../../types';
 
@@ -27,6 +27,7 @@ export interface BaseMenuProps {
   parentRef?: React.RefObject<HTMLElement>;
   onReplyInThread?: (props: { message: SendableMessageType }) => void;
   isOpenedFromThread?: boolean;
+  onDownloadClick?: (e: MouseEvent) => Promise<void>;
 }
 
 export interface MobileBottomSheetProps extends BaseMenuProps {


### PR DESCRIPTION
[CLNP-2565](https://sendbird.atlassian.net/browse/CLNP-2565)

### Original Reason
* There was no interface available to decide whether to proceed with the file download or not

### ChangeLog & Feature
* Added `onBeforeDownloadFileMessage` to the `<GroupChannel />` and `<Thread />` modules
* Added `onDownloadClick` to the `FileViewer`, `FileViewerView`, `MobileBottomSheet`, `MobileContextMenu`, and `MobileMenu`

### How to use
```tsx
const ONE_MB = 1024 * 1024;
/**
  * Use this list to check if it's displayed as a ThumbnailMessage.
  * (https://github.com/sendbird/sendbird-uikit-react/blob/main/src/utils/index.ts)
*/
const ThumbnailMessageTypes = [
  'image/jpeg',
  'image/jpg',
  'image/png',
  'image/gif',
  'image/svg+xml',
  'image/webp', // not supported in IE
  'video/mpeg',
  'video/ogg',
  'video/webm',
  'video/mp4',
];

<GroupChannel // or Thread
  onBeforeDownloadFileMessage={async ({ message, index = null }) => {
    if (message.isFileMessage()) {
      const confirmed = window.confirm(`The file size is ${(message.size / ONE_MB).toFixed(2)}MB. Would you like to continue downloading?`);
      return confirmed;
    }
    if (message.isMultipleFilesMessage()) {
      const confirmed = window.confirm(`The file size is ${(message.fileInfoList[index].fileSize / ONE_MB).toFixed(2)}MB. Would you like to continue downloading?`);
      return confirmed;
    }
    return true;
  }}
/>
```

[CLNP-2565]: https://sendbird.atlassian.net/browse/CLNP-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ