### PR TITLE
fix: Replace the root components order

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -48,12 +48,13 @@ import {
   CustomExtensionParams,
   SBUEventHandlers, SendbirdProviderUtils,
 } from './types';
-import { GlobalModalProvider } from '../hooks/useModal';
+import { GlobalModalProvider, ModalRoot } from '../hooks/useModal';
 import { RenderUserProfileProps } from '../types';
 import PUBSUB_TOPICS, { SBUGlobalPubSub, SBUGlobalPubSubTopicPayloadUnion } from './pubSub/topics';
 import { EmojiManager } from './emojiManager';
 import { uikitConfigStorage } from './utils/uikitConfigStorage';
 import useMessageTemplateUtils from './hooks/useMessageTemplateUtils';
+import { EmojiReactionListRoot, MenuRoot } from '../ui/ContextMenu';
 
 export { useSendbirdStateContext } from '../hooks/useSendbirdStateContext';
 
@@ -257,12 +258,6 @@ const SendbirdSDK = ({
     setLogger(LoggerFactory(logLevel as LogLevel));
   }, [logLevel]);
 
-  useAppendDomNode([
-    'sendbird-modal-root',
-    'sendbird-dropdown-portal',
-    'sendbird-emoji-list-portal',
-  ], 'body');
-
   // should move to reducer
   const [currentTheme, setCurrentTheme] = useState(theme);
   useEffect(() => {
@@ -429,6 +424,10 @@ const SendbirdSDK = ({
           </VoiceMessageProvider>
         </LocalizationProvider>
       </MediaQueryProvider>
+      {/* Roots */}
+      <EmojiReactionListRoot />
+      <ModalRoot />
+      <MenuRoot />
     </SendbirdSdkContext.Provider>
   );
 };

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -22,7 +22,6 @@ import useOnlineStatus from './hooks/useOnlineStatus';
 import useConnect from './hooks/useConnect';
 import { LoggerFactory, LogLevel } from './Logger';
 import pubSubFactory from './pubSub/index';
-import useAppendDomNode from '../hooks/useAppendDomNode';
 
 import { VoiceMessageProvider } from './VoiceMessageProvider';
 import { LocalizationProvider } from './LocalizationContext';


### PR DESCRIPTION
### Fix
* Replace the root components order because dropdown menu is hided by modals

before
<img width="200" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/16842473-d05c-43dc-a4bd-e72395ccd950">

after
<img width="200" alt="image" src="https://github.com/sendbird/sendbird-uikit-react/assets/46333979/30c53cc2-89d0-48e4-afa3-7acfa000e412">
