### PR TITLE
feat: support carousel template with simple templates

### DIFF
--- a/src/lib/dux/appInfo/utils.ts
+++ b/src/lib/dux/appInfo/utils.ts
@@ -6,7 +6,7 @@ import { SendbirdMessageTemplate } from '../../../ui/TemplateMessageItemBody/typ
  */
 export const getProcessedTemplate = (parsedTemplate: SendbirdMessageTemplate): ProcessedMessageTemplate => {
   return {
-    version: parsedTemplate.ui_template.version,
+    version: Number(parsedTemplate.ui_template.version),
     uiTemplate: JSON.stringify(parsedTemplate.ui_template.body.items),
     colorVariables: parsedTemplate.color_variables,
   };

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -23,12 +23,14 @@ import { match } from 'ts-pattern';
 import TemplateMessageItemBody from '../../TemplateMessageItemBody';
 
 const MESSAGE_ITEM_BODY_CLASSNAME = 'sendbird-message-content__middle__message-item-body';
+export type RenderedTemplateBodyType = 'failed' | 'composite' | 'simple';
 
 export interface MessageBodyProps {
   channel: Nullable<GroupChannel>;
   message: CoreMessageType;
   showFileViewer?: (bool: boolean) => void;
   onMessageHeightChange?: (isBottomMessageAffected?: boolean) => void;
+  onTemplateMessageRenderedCallback?: (renderedTemplateBodyType: RenderedTemplateBodyType) => void;
 
   mouseHover: boolean;
   isMobile: boolean;
@@ -43,6 +45,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
     channel,
     showFileViewer,
     onMessageHeightChange,
+    onTemplateMessageRenderedCallback,
 
     mouseHover,
     isMobile,
@@ -66,6 +69,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         message={message as BaseMessage}
         isByMe={isByMe}
         theme={config?.theme as SendbirdTheme}
+        onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
       />
     ))
     .when((message) => isOgMessageEnabledInGroupChannel

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import './index.scss';
 
@@ -151,7 +151,6 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   const [showFeedbackOptionsMenu, setShowFeedbackOptionsMenu] = useState(false);
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
   const [feedbackFailedText, setFeedbackFailedText] = useState('');
-  const [totalBottom, setTotalBottom] = useState<number>(0);
   const [uiContainerType, setUiContainerType] = useState<UI_CONTAINER_TYPES>(getMessageContentMiddleClassNameByContainerType({
     message,
     isMobile,
@@ -210,6 +209,22 @@ export default function MessageContent(props: MessageContentProps): ReactElement
 
   const isTimestampBottom = !!uiContainerType;
 
+  const getTotalBottom = (): number => {
+    let sum = 2;
+    if (timestampRef.current && isTimestampBottom) {
+      sum += 4 + timestampRef.current.clientHeight;
+    }
+    if (threadRepliesRef.current) {
+      sum += 4 + threadRepliesRef.current.clientHeight;
+    }
+    if (feedbackButtonsRef.current) {
+      sum += 4 + feedbackButtonsRef.current.clientHeight;
+    }
+    return sum;
+  };
+  
+  const totalBottom = useMemo(() => getTotalBottom(), [isTimestampBottom]);
+
   const onCloseFeedbackForm = () => {
     setShowFeedbackModal(false);
   };
@@ -242,23 +257,6 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   if (message?.isAdminMessage?.() || message?.messageType === 'admin') {
     return (<ClientAdminMessage message={message as AdminMessage} />);
   }
-
-  useEffect(() => {
-    const getTotalBottom = (): number => {
-      let sum = 2;
-      if (timestampRef.current && isTimestampBottom) {
-        sum += 4 + timestampRef.current.clientHeight;
-      }
-      if (threadRepliesRef.current) {
-        sum += 4 + threadRepliesRef.current.clientHeight;
-      }
-      if (feedbackButtonsRef.current) {
-        sum += 4 + feedbackButtonsRef.current.clientHeight;
-      }
-      return sum;
-    };
-    setTotalBottom(getTotalBottom());
-  }, [isTimestampBottom]);
 
   return (
     <div

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -44,7 +44,6 @@ import MessageFeedbackModal from '../../modules/Channel/components/MessageFeedba
 import { SbFeedbackStatus } from './types';
 import MessageFeedbackFailedModal from '../../modules/Channel/components/MessageFeedbackFailedModal';
 import { MobileBottomSheetProps } from '../MobileMenu/types';
-import { CarouselType, MessageTemplateData, MessageTemplateItem } from '../TemplateMessageItemBody/types';
 
 export interface MessageContentProps {
   className?: string | Array<string>;
@@ -137,7 +136,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   } = props;
 
   const { dateLocale } = useLocalization();
-  const { config, eventHandlers, utils } = useSendbirdStateContext?.() || {};
+  const { config, eventHandlers } = useSendbirdStateContext?.() || {};
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const contentRef = useRef(null);
   const timestampRef = useRef(null);

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -44,6 +44,7 @@ import MessageFeedbackModal from '../../modules/Channel/components/MessageFeedba
 import { SbFeedbackStatus } from './types';
 import MessageFeedbackFailedModal from '../../modules/Channel/components/MessageFeedbackFailedModal';
 import { MobileBottomSheetProps } from '../MobileMenu/types';
+import { CarouselType, MessageTemplateData, MessageTemplateItem } from '../TemplateMessageItemBody/types';
 
 export interface MessageContentProps {
   className?: string | Array<string>;
@@ -136,7 +137,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   } = props;
 
   const { dateLocale } = useLocalization();
-  const { config, eventHandlers } = useSendbirdStateContext?.() || {};
+  const { config, eventHandlers, utils } = useSendbirdStateContext?.() || {};
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const contentRef = useRef(null);
   const timestampRef = useRef(null);
@@ -152,11 +153,21 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
   const [feedbackFailedText, setFeedbackFailedText] = useState('');
   const [totalBottom, setTotalBottom] = useState<number>(0);
-
-  const uiContainerType: UI_CONTAINER_TYPES = getMessageContentMiddleClassNameByContainerType({
+  const [uiContainerType, setUiContainerType] = useState<UI_CONTAINER_TYPES>(getMessageContentMiddleClassNameByContainerType({
     message,
     isMobile,
-  });
+  }));
+
+  const onTemplateMessageRenderedCallback = (renderedTemplateType: 'failed' | 'composite' | 'simple') => {
+    if (renderedTemplateType === 'failed') {
+      setUiContainerType(UI_CONTAINER_TYPES.DEFAULT);
+    } else if (renderedTemplateType === 'composite') {
+      /**
+       * Composite templates must have default carousel view irregardless of given containerType.
+       */
+      setUiContainerType(UI_CONTAINER_TYPES.DEFAULT_CAROUSEL);
+    }
+  };
 
   const { stringSet } = useContext(LocalizationContext);
 
@@ -382,6 +393,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
               config,
               isReactionEnabledInChannel,
               isByMe,
+              onTemplateMessageRenderedCallback,
             })
           }
           {/* reactions */}

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { ReactElement, ReactNode, useContext, useMemo, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import './index.scss';
 
@@ -222,7 +222,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     }
     return sum;
   };
-  
+
   const totalBottom = useMemo(() => getTotalBottom(), [isTimestampBottom]);
 
   const onCloseFeedbackForm = () => {

--- a/src/ui/MessageTemplate/messageTemplateErrorBoundary.tsx
+++ b/src/ui/MessageTemplate/messageTemplateErrorBoundary.tsx
@@ -1,9 +1,12 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { LoggerInterface } from '../../lib/Logger';
+import { RenderedTemplateBodyType } from '../MessageContent/MessageBody';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallbackMessage: ReactNode;
+  onTemplateMessageRenderedCallback: (renderedTemplateBodyType: RenderedTemplateBodyType) => void;
+  isComposite?: boolean;
   logger?: LoggerInterface;
 }
 
@@ -27,8 +30,10 @@ export class MessageTemplateErrorBoundary extends Component<ErrorBoundaryProps, 
 
   render() {
     if (this.state.hasError) {
+      this.props.onTemplateMessageRenderedCallback('failed');
       return this.props.fallbackMessage;
     }
+    this.props.onTemplateMessageRenderedCallback(this.props.isComposite ? 'composite' : 'simple');
     return this.props.children;
   }
 }

--- a/src/ui/TemplateMessageItemBody/FallbackTemplateMessageItemBody.tsx
+++ b/src/ui/TemplateMessageItemBody/FallbackTemplateMessageItemBody.tsx
@@ -3,19 +3,24 @@ import React, { ReactElement, useContext } from 'react';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import { getClassName } from '../../utils';
 import Label, { LabelColors, LabelTypography } from '../Label';
+import { RenderedTemplateBodyType } from '../MessageContent/MessageBody';
 
 export interface FallbackTemplateMessageItemBodyProps {
   className?: string | Array<string>;
   message: BaseMessage;
   isByMe?: boolean;
+  onTemplateMessageRenderedCallback?: (renderedTemplateBodyType: RenderedTemplateBodyType) => void;
 }
 export function FallbackTemplateMessageItemBody({
   className,
   message,
   isByMe,
+  onTemplateMessageRenderedCallback = () => { /* noop */ },
 }: FallbackTemplateMessageItemBodyProps): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const text = message['message'];
+
+  onTemplateMessageRenderedCallback('failed');
 
   return (
     <div

--- a/src/ui/TemplateMessageItemBody/FallbackTemplateMessageItemBody.tsx
+++ b/src/ui/TemplateMessageItemBody/FallbackTemplateMessageItemBody.tsx
@@ -3,24 +3,19 @@ import React, { ReactElement, useContext } from 'react';
 import { LocalizationContext } from '../../lib/LocalizationContext';
 import { getClassName } from '../../utils';
 import Label, { LabelColors, LabelTypography } from '../Label';
-import { RenderedTemplateBodyType } from '../MessageContent/MessageBody';
 
 export interface FallbackTemplateMessageItemBodyProps {
   className?: string | Array<string>;
   message: BaseMessage;
   isByMe?: boolean;
-  onTemplateMessageRenderedCallback?: (renderedTemplateBodyType: RenderedTemplateBodyType) => void;
 }
 export function FallbackTemplateMessageItemBody({
   className,
   message,
   isByMe,
-  onTemplateMessageRenderedCallback = () => { /* noop */ },
 }: FallbackTemplateMessageItemBodyProps): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const text = message['message'];
-
-  onTemplateMessageRenderedCallback('failed');
 
   return (
     <div

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -5,7 +5,6 @@ import { getClassName, removeAtAndBraces, startsWithAtAndEndsWithBraces } from '
 import MessageTemplateWrapper from '../../modules/GroupChannel/components/MessageTemplateWrapper';
 import {
   CarouselItem,
-  CarouselType,
   MessageTemplateData,
   MessageTemplateItem,
   SendbirdUiTemplate,
@@ -224,7 +223,7 @@ export function TemplateMessageItemBody({
         /**
          * Composite template validation
          */
-        if (parsedUiTemplate[0].type === CarouselType) {
+        if (parsedUiTemplate[0].type === CompositeComponentType.Carousel) {
           const carouselItem = parsedUiTemplate[0] as unknown as CarouselItem;
           if (parsedUiTemplate.length > 1) { // TODO: in future, support multiple templates
             logger.error('TemplateMessageItemBody | composite template currently does not support multiple items: ', parsedUiTemplate);

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -125,8 +125,8 @@ export function TemplateMessageItemBody({
     simpleTemplateDataList.forEach((simpleTemplateData: SimpleTemplateData) => {
       const simpleTemplateKey = simpleTemplateData.key;
       if (!simpleTemplateKey) {
-        logger.error('TemplateMessageItemBody | simple template keys are not found in view_variables: ', simpleTemplateDataList, message);
-        throw new Error();
+        logger.error('TemplateMessageItemBody | simple template keys are not found in view_variables: ', simpleTemplateDataList);
+        throw new Error('TemplateMessageItemBody | simple template keys are not found in view_variables.');
       }
       const simpleCachedTemplate = getCachedTemplate(simpleTemplateKey);
       cachedSimpleTemplates.push(simpleCachedTemplate);
@@ -206,7 +206,7 @@ export function TemplateMessageItemBody({
           });
         });
       } catch (e) {
-        logger.error('TemplateMessageItemBody | received view_variables is malformed: ', templateData, message);
+        logger.error('TemplateMessageItemBody | received view_variables is malformed: ', templateData);
         result.isErrored = true;
         return result;
       }
@@ -217,8 +217,8 @@ export function TemplateMessageItemBody({
       } else {
         const parsedUiTemplate: MessageTemplateItem[] = JSON.parse(cachedTemplate.uiTemplate);
         if (!Array.isArray(parsedUiTemplate) || parsedUiTemplate.length === 0) {
-          logger.error('TemplateMessageItemBody | parsed template is missing ui_template: ', parsedUiTemplate, message);
-          throw new Error();
+          logger.error('TemplateMessageItemBody | parsed template is missing ui_template: ', parsedUiTemplate);
+          throw new Error('TemplateMessageItemBody | parsed template is missing ui_template. See error log in console for details');
         }
         /**
          * Composite template validation
@@ -226,23 +226,23 @@ export function TemplateMessageItemBody({
         if (parsedUiTemplate[0].type === CarouselType) {
           const carouselItem = parsedUiTemplate[0] as unknown as CarouselItem;
           if (parsedUiTemplate.length > 1) { // TODO: in future, support multiple templates
-            logger.error('TemplateMessageItemBody | composite template currently does not support multiple items: ', parsedUiTemplate, message);
-            throw new Error();
+            logger.error('TemplateMessageItemBody | composite template currently does not support multiple items: ', parsedUiTemplate);
+            throw new Error('TemplateMessageItemBody | composite template currently does not support multiple items. See error log in console for details');
           }
           if (typeof carouselItem.items === 'string') {
             if (!startsWithAtAndEndsWithBraces(carouselItem.items)) {
-              logger.error('TemplateMessageItemBody | composite template with reservation key must follow the following string format "{@your-reservation-key}": ', templateKey, carouselItem, message);
-              throw new Error();
+              logger.error('TemplateMessageItemBody | composite template with reservation key must follow the following string format "{@your-reservation-key}": ', templateKey, carouselItem);
+              throw new Error('TemplateMessageItemBody | composite template with reservation key must follow the following string format "{@your-reservation-key}". See error log in console for details');
             }
             if (!templateData.view_variables) {
-              logger.error('TemplateMessageItemBody | template key suggests composite template but template data is missing view_variables: ', templateKey, templateData, message);
-              throw new Error();
+              logger.error('TemplateMessageItemBody | template key suggests composite template but template data is missing view_variables: ', templateKey, templateData);
+              throw new Error('TemplateMessageItemBody | template key suggests composite template but template data is missing view_variables. See error log in console for details');
             }
             const reservationKey = removeAtAndBraces(carouselItem.items);
             const simpleTemplateDataList: SimpleTemplateData[] | undefined = templateData.view_variables[reservationKey];
             if (!simpleTemplateDataList) {
-              logger.error('TemplateMessageItemBody | no reservation key found in view_variables: ', reservationKey, templateData.view_variables, message);
-              throw new Error();
+              logger.error('TemplateMessageItemBody | no reservation key found in view_variables: ', reservationKey, templateData.view_variables);
+              throw new Error('TemplateMessageItemBody | no reservation key found in view_variables. See error log in console for details');
             }
             const { maxVersion, filledTemplates } = getFilledMessageTemplateItemsForCarouselTemplateByMessagePayload(
               simpleTemplateDataList,
@@ -266,8 +266,8 @@ export function TemplateMessageItemBody({
               items: filledTemplates,
             }];
           } else {
-            logger.error('TemplateMessageItemBody | composite template is malformed: ', templateKey, carouselItem, message);
-            throw new Error();
+            logger.error('TemplateMessageItemBody | composite template is malformed: ', templateKey, carouselItem);
+            throw new Error('TemplateMessageItemBody | composite template is malformed. See error log in console for details');
           }
         } else {
           result.templateVersion = cachedTemplate.version;
@@ -315,7 +315,7 @@ export function TemplateMessageItemBody({
         ) {
           keysToUpdate.push(templateKey);
         } else if (waitingTemplateKeyData.erroredMessageIds.indexOf(message.messageId) > -1) {
-          throw new Error();
+          throw new Error(`TemplateMessageItemBody | fetching template key ${templateKey} for messageId: ${message.messageId} has failed.`);
         }
       });
       if (keysToUpdate.length > 0) {

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -270,6 +270,7 @@ export function TemplateMessageItemBody({
             throw new Error();
           }
         } else {
+          result.templateVersion = cachedTemplate.version;
           result.filledMessageTemplateItemsList = getFilledMessageTemplateItemsForSimpleTemplate(
             parsedUiTemplate,
             cachedTemplate.colorVariables,

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -21,6 +21,7 @@ import FallbackTemplateMessageItemBody from './FallbackTemplateMessageItemBody';
 import LoadingTemplateMessageItemBody from './LoadingTemplateMessageItemBody';
 import MessageTemplateErrorBoundary from '../MessageTemplate/messageTemplateErrorBoundary';
 import { RenderedTemplateBodyType } from '../MessageContent/MessageBody';
+import { CompositeComponentType } from '@sendbird/uikit-message-template';
 
 const TEMPLATE_FETCH_RETRY_BUFFER_TIME_IN_MILLIES = 500; // It takes about 450ms for isError update
 
@@ -250,7 +251,7 @@ export function TemplateMessageItemBody({
             result.isComposite = true;
             result.templateVersion = Math.max(cachedTemplate.version, maxVersion);
             result.filledMessageTemplateItemsList = [{
-              type: carouselItem.type as any,
+              type: carouselItem.type as CompositeComponentType,
               spacing: carouselItem.spacing,
               items: filledTemplates,
             }];
@@ -261,7 +262,7 @@ export function TemplateMessageItemBody({
             result.isComposite = true;
             result.templateVersion = Math.max(cachedTemplate.version, maxVersion);
             result.filledMessageTemplateItemsList = [{
-              type: carouselItem.type as any,
+              type: carouselItem.type as CompositeComponentType,
               spacing: carouselItem.spacing,
               items: filledTemplates,
             }];

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -125,7 +125,7 @@ export function TemplateMessageItemBody({
     simpleTemplateDataList.forEach((simpleTemplateData: SimpleTemplateData) => {
       const simpleTemplateKey = simpleTemplateData.key;
       if (!simpleTemplateKey) {
-        logger.error('TemplateMessageItemBody | simple template keys are not found in view_variables: ', simpleTemplateDataList);
+        logger.error('TemplateMessageItemBody | simple template keys are not found in view_variables: ', simpleTemplateDataList, message);
         throw new Error();
       }
       const simpleCachedTemplate = getCachedTemplate(simpleTemplateKey);
@@ -206,7 +206,7 @@ export function TemplateMessageItemBody({
           });
         });
       } catch (e) {
-        logger.error('TemplateMessageItemBody | received view_variables is malformed: ', templateData);
+        logger.error('TemplateMessageItemBody | received view_variables is malformed: ', templateData, message);
         result.isErrored = true;
         return result;
       }
@@ -217,7 +217,7 @@ export function TemplateMessageItemBody({
       } else {
         const parsedUiTemplate: MessageTemplateItem[] = JSON.parse(cachedTemplate.uiTemplate);
         if (!Array.isArray(parsedUiTemplate) || parsedUiTemplate.length === 0) {
-          logger.error('TemplateMessageItemBody | parsed template is missing ui_template: ', parsedUiTemplate);
+          logger.error('TemplateMessageItemBody | parsed template is missing ui_template: ', parsedUiTemplate, message);
           throw new Error();
         }
         /**
@@ -226,22 +226,22 @@ export function TemplateMessageItemBody({
         if (parsedUiTemplate[0].type === CarouselType) {
           const carouselItem = parsedUiTemplate[0] as unknown as CarouselItem;
           if (parsedUiTemplate.length > 1) { // TODO: in future, support multiple templates
-            logger.error('TemplateMessageItemBody | composite template currently does not support multiple items: ', parsedUiTemplate);
+            logger.error('TemplateMessageItemBody | composite template currently does not support multiple items: ', parsedUiTemplate, message);
             throw new Error();
           }
           if (typeof carouselItem.items === 'string') {
             if (!startsWithAtAndEndsWithBraces(carouselItem.items)) {
-              logger.error('TemplateMessageItemBody | composite template with reservation key must follow the following string format "{@your-reservation-key}": ', templateKey, carouselItem);
+              logger.error('TemplateMessageItemBody | composite template with reservation key must follow the following string format "{@your-reservation-key}": ', templateKey, carouselItem, message);
               throw new Error();
             }
             if (!templateData.view_variables) {
-              logger.error('TemplateMessageItemBody | template key suggests composite template but template data is missing view_variables: ', templateKey, templateData);
+              logger.error('TemplateMessageItemBody | template key suggests composite template but template data is missing view_variables: ', templateKey, templateData, message);
               throw new Error();
             }
             const reservationKey = removeAtAndBraces(carouselItem.items);
             const simpleTemplateDataList: SimpleTemplateData[] | undefined = templateData.view_variables[reservationKey];
             if (!simpleTemplateDataList) {
-              logger.error('TemplateMessageItemBody | no reservation key found in view_variables: ', reservationKey, templateData.view_variables);
+              logger.error('TemplateMessageItemBody | no reservation key found in view_variables: ', reservationKey, templateData.view_variables, message);
               throw new Error();
             }
             const { maxVersion, filledTemplates } = getFilledMessageTemplateItemsForCarouselTemplateByMessagePayload(
@@ -266,7 +266,7 @@ export function TemplateMessageItemBody({
               items: filledTemplates,
             }];
           } else {
-            logger.error('TemplateMessageItemBody | composite template is malformed: ', templateKey, carouselItem);
+            logger.error('TemplateMessageItemBody | composite template is malformed: ', templateKey, carouselItem, message);
             throw new Error();
           }
         } else {

--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -77,24 +77,24 @@ export function TemplateMessageItemBody({
   onTemplateMessageRenderedCallback = () => { /* noop */ },
 }: TemplateMessageItemBodyProps): ReactElement {
   const templateData: MessageTemplateData | undefined = message.extendedMessagePayload?.['template'] as MessageTemplateData;
-  if (!templateData?.key) {
+
+  const getFailedBody = () => {
+    onTemplateMessageRenderedCallback('failed');
     return <FallbackTemplateMessageItemBody
       className={className}
       message={message}
       isByMe={isByMe}
-      onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
     />;
+  };
+
+  if (!templateData?.key) {
+    return getFailedBody();
   }
   const templateKey = templateData.key;
 
   const globalState = useSendbirdStateContext();
   if (!globalState) {
-    return <FallbackTemplateMessageItemBody
-      className={className}
-      message={message}
-      isByMe={isByMe}
-      onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
-    />;
+    return getFailedBody();
   }
 
   const {
@@ -326,20 +326,12 @@ export function TemplateMessageItemBody({
   }
 
   if (renderData.isErrored) {
-    return <FallbackTemplateMessageItemBody
-      className={className}
-      message={message}
-      isByMe={isByMe}
-      onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
-    />;
+    return getFailedBody();
   }
 
   if (renderData.filledMessageTemplateItemsList.length === 0) {
     return <LoadingTemplateMessageItemBody className={className} isByMe={isByMe} />;
   }
-
-  onTemplateMessageRenderedCallback(renderData.isComposite ? 'composite' : 'simple');
-
   return (
     <div className={getClassName([
       className,
@@ -352,9 +344,10 @@ export function TemplateMessageItemBody({
             className={className}
             message={message}
             isByMe={isByMe}
-            onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
           />
         }
+        onTemplateMessageRenderedCallback={onTemplateMessageRenderedCallback}
+        isComposite={renderData.isComposite}
         logger={logger}
       >
         <MessageTemplateWrapper

--- a/src/ui/TemplateMessageItemBody/types.ts
+++ b/src/ui/TemplateMessageItemBody/types.ts
@@ -1,4 +1,4 @@
-import {ComponentsUnion, CompositeComponentType} from '@sendbird/uikit-message-template';
+import { ComponentsUnion, CompositeComponentType } from '@sendbird/uikit-message-template';
 
 type SendbirdFontWeight = 'bold' | 'normal';
 

--- a/src/ui/TemplateMessageItemBody/types.ts
+++ b/src/ui/TemplateMessageItemBody/types.ts
@@ -86,7 +86,7 @@ export const CarouselType = 'carouselView';
 export interface CarouselItem {
   type: string;
   spacing: number;
-  items: string; // Reservation key. ex. "{@some_key}"
+  items: string | SendbirdUiTemplate[]; // Reservation key. ex. "{@some_key}"
 }
 
 // FIXME: This needs to be updated in the future.
@@ -99,16 +99,18 @@ export type SimpleTemplateData = {
   variables?: Record<string, any>;
 };
 
+export interface SendbirdUiTemplate {
+  version: number;
+  body: {
+    items: MessageTemplateItem[];
+  };
+}
+
 export type SendbirdMessageTemplate = {
   key: string;
   created_at: number;
   updated_at: number;
-  ui_template: {
-    version: number;
-    body: {
-      items: MessageTemplateItem[];
-    };
-  };
+  ui_template: SendbirdUiTemplate;
   name?: string;
   color_variables?: Record<string, string>;
 };

--- a/src/ui/TemplateMessageItemBody/types.ts
+++ b/src/ui/TemplateMessageItemBody/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentsUnion } from '@sendbird/uikit-message-template';
+import {ComponentsUnion, CompositeComponentType} from '@sendbird/uikit-message-template';
 
 type SendbirdFontWeight = 'bold' | 'normal';
 
@@ -81,10 +81,8 @@ export type MessageTemplateTheme = {
 
 export type MessageTemplateItem = ComponentsUnion['properties'];
 
-export const CarouselType = 'carouselView';
-
 export interface CarouselItem {
-  type: string;
+  type: CompositeComponentType.Carousel;
   spacing: number;
   items: string | SendbirdUiTemplate[]; // Reservation key. ex. "{@some_key}"
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -276,11 +276,6 @@ export const isThreadMessage = (message: CoreMessageType): boolean => (
 export const isTemplateMessage = (message: CoreMessageType): boolean => !!(
   message && message.extendedMessagePayload?.['template']
 );
-
-export const isCompositeTemplateMessage = (message: CoreMessageType): boolean => !!(
-  message && message.extendedMessagePayload?.['template']?.['view_variables']
-);
-
 export enum UI_CONTAINER_TYPES {
   DEFAULT = '',
   WIDE = 'ui_container_type__wide',
@@ -299,12 +294,6 @@ export const getMessageContentMiddleClassNameByContainerType = ({
    * WIDE: all message types.
    */
   const containerType: string | undefined = message.extendedMessagePayload?.['ui']?.['container_type'];
-  if (isCompositeTemplateMessage(message)) {
-    /**
-     * Composite templates must have default carousel view irregardless of given containerType.
-     */
-    return UI_CONTAINER_TYPES.DEFAULT_CAROUSEL;
-  }
   if (!isMobile) return UI_CONTAINER_TYPES.DEFAULT;
   if (containerType === MessageContentMiddleContainerType.WIDE) {
     return UI_CONTAINER_TYPES.WIDE;


### PR DESCRIPTION
1. Carousel templates created with direct simple templates in items (no reservations keys) should be suppported as fallback logic.

ex.
![Screenshot 2024-04-01 at 3 55 08 PM](https://github.com/sendbird/sendbird-uikit-react/assets/16806397/9c6249a3-3aee-45fc-aaeb-a7f90a06523b)

2. timestamp location of carousel template body must be dynamically updated.
![Screenshot 2024-04-01 at 5 02 16 PM](https://github.com/sendbird/sendbird-uikit-react/assets/16806397/f8ae40d0-34f0-48a2-ac2f-0d002a328e27)
![Screenshot 2024-04-01 at 5 02 11 PM](https://github.com/sendbird/sendbird-uikit-react/assets/16806397/92746254-d674-48a5-9b38-a59fb3d2e6e7)
![Screenshot 2024-04-01 at 5 01 53 PM](https://github.com/sendbird/sendbird-uikit-react/assets/16806397/33bb745f-d4f6-47f5-af2a-b32a5a86f1b1)

3. For composite template, template version should be max of (composite + its simple templstes).