### PR TITLE
bug-fix: Fix bug where argb conversion step is skipped for carousel without reservation key

### DIFF
--- a/src/ui/TemplateMessageItemBody/index.tsx
+++ b/src/ui/TemplateMessageItemBody/index.tsx
@@ -158,7 +158,10 @@ export function TemplateMessageItemBody({
     const filledTemplates: MessageTemplateItem[][] = [];
     uiTemplates.forEach((uiTemplate: SendbirdUiTemplate) => {
       maxVersion = Math.max(maxVersion, uiTemplate.version);
-      filledTemplates.push(uiTemplate.body.items);
+      const filledMessageTemplateItems: MessageTemplateItem[] = getFilledMessageTemplateWithData({
+        template: uiTemplate.body.items,
+      });
+      filledTemplates.push(filledMessageTemplateItems);
     });
     return {
       maxVersion,


### PR DESCRIPTION
- Fix bug where argb conversion step is skipped for carousel without reservation key
- string to numeric conversion skipped