### PR TITLE
chore: fix typo and unused css props

### DIFF
--- a/src/modules/GroupChannel/components/GroupChannelUI/index.scss
+++ b/src/modules/GroupChannel/components/GroupChannelUI/index.scss
@@ -19,7 +19,6 @@
 .sendbird-conversation__messages {
   overflow: hidden;
   flex: 1 1 0;
-  order: 2;
 }
 
 .sendbird-conversation__messages-list {
@@ -31,7 +30,6 @@
 
 .sendbird-conversation__footer {
   width: 100%;
-  order: 3;
   padding: 0px 0px 24px 0px;
 }
 

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -188,7 +188,7 @@ const MessageView = (props: MessageViewProps) => {
   }, [mentionedUserIds]);
 
   /**
-   * Move the messsage list scroll
+   * Move the message list scroll
    * when the message's height is changed by `showEdit` OR `message.reactions`
    */
   useDidMountEffect(() => {

--- a/src/modules/OpenChannel/components/OpenChannelUI/open-channel-ui.scss
+++ b/src/modules/OpenChannel/components/OpenChannelUI/open-channel-ui.scss
@@ -13,12 +13,10 @@
   .sendbird-openchannel-conversation-scroll {
     overflow-y: auto;
     flex: 1 1 0;
-    order: 2;
     width: 100%;
   }
 
   .sendbird-openchannel-footer {
-    order: 3;
     padding: 12px 24px 24px 24px;
   }
 

--- a/src/ui/ThreadReplies/index.scss
+++ b/src/ui/ThreadReplies/index.scss
@@ -18,11 +18,6 @@
     background-color: t(bg-0);
   }
 
-  // inside layout
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-
   &:hover {
     @include themed() {
       background-color: t(bg-1);


### PR DESCRIPTION
Confirmed that this change doesn't make any effect

### Fix
* Fix typo
* Remove CSS `order` props because it's meaningless