### PR TITLE
release v3.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - v3
 
+## [v3.14.1] (Apr 12, 2024)
+
+### Fixes
+* Fix a bug where injecting an optional property with null value not rendering the expected default component
+* Update the type of renderMessage in the OpenChannel module
+* Deprecate the renderInput prop and add a new `renderMessageInput` prop
+
 ## [v3.14.0] (Apr 5, 2024)
 ### Feature
 - `TemplateMessageItemBody` now supports `CarouselView` type template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [v3.14.1] (Apr 12, 2024)
 
 ### Fixes
-* Fix a bug where injecting an optional property with null value not rendering the expected default component
-* Update the type of renderMessage in the OpenChannel module
-* Deprecate the renderInput prop and add a new `renderMessageInput` prop
+* Fixed a bug where injecting an optional property with null value not rendering the expected default component
+* Updated the type of renderMessage in the OpenChannel module
+* Deprecated the renderInput prop and add a new `renderMessageInput` prop
 
 ## [v3.14.0] (Apr 5, 2024)
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 * Fixed a bug where injecting an optional property with null value not rendering the expected default component
-* Updated the type of renderMessage in the OpenChannel module
+* Updated the type of `renderMessage` in the `OpenChannel` module
 * Deprecated the renderInput prop and add a new `renderMessageInput` prop
 
 ## [v3.14.0] (Apr 5, 2024)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.11.3",
+    "@sendbird/chat": "^4.12.1",
     "@sendbird/react-uikit-message-template-view": "0.0.1-alpha.72",
     "@sendbird/uikit-tools": "0.0.1-alpha.72",
     "css-vars-ponyfill": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,15 +2647,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat@npm:^4.11.3":
-  version: 4.11.3
-  resolution: "@sendbird/chat@npm:4.11.3"
+"@sendbird/chat@npm:^4.12.1":
+  version: 4.12.1
+  resolution: "@sendbird/chat@npm:4.12.1"
   peerDependencies:
     "@react-native-async-storage/async-storage": ^1.17.6
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
-  checksum: 17ed462c2db13afacd93dd3219a6af4f032f9f251e2e6af3d38cc7cd6b3f3b3648753cf5bcd6a7a9b6ad492971d73e473cb09cddb58aa6c36c7c5dae3a1015e1
+  checksum: 79ac1fe287ea20756c5cd3c47df4e323e6c671ff7e089a4eb879b45dea1c34b862cab2f9dd5ba950416e4126123e74b59cb866b0884adbc41b89b7e7b819bcd0
   languageName: node
   linkType: hard
 
@@ -2699,7 +2699,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.2.3
     "@rollup/plugin-replace": ^5.0.4
     "@rollup/plugin-typescript": ^11.1.5
-    "@sendbird/chat": ^4.11.3
+    "@sendbird/chat": ^4.12.1
     "@sendbird/react-uikit-message-template-view": 0.0.1-alpha.72
     "@sendbird/uikit-tools": 0.0.1-alpha.72
     "@storybook/addon-actions": ^6.5.10


### PR DESCRIPTION
## [v3.14.1] (Apr 12, 2024)

### Fixes
* Fixed a bug where injecting an optional property with null value not rendering the expected default component
* Updated the type of renderMessage in the OpenChannel module
* Deprecated the renderInput prop and add a new `renderMessageInput` prop