### PR TITLE
fix: remove image section in og message if there is no og image

### DIFF
--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -19,6 +19,7 @@ import {
   truncateString,
   SendableMessageType,
   isMultipleFilesMessage,
+  isFileMessage,
 } from '../../../../utils';
 
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
@@ -37,6 +38,7 @@ import { useThreadMessageKindKeySelector } from '../../../Channel/context/hooks/
 import { useFileInfoListWithUploaded } from '../../../Channel/context/hooks/useFileInfoListWithUploaded';
 import { Colors } from '../../../../utils/color';
 import type { OnBeforeDownloadFileMessageType } from '../../../GroupChannel/context/GroupChannelProvider';
+import { openURL } from '../../../../utils/utils';
 
 export interface ParentMessageInfoItemProps {
   className?: string;
@@ -97,9 +99,7 @@ export default function ParentMessageInfoItem({
 
   // Only for the FileMessageItemBody
   const downloadFileWithUrl = () => {
-    if (message.messageType === 'file') {
-      window.open((message as FileMessage)?.url);
-    }
+    if (isFileMessage(message)) openURL(message.url);
   };
   const handleOnClickTextButton = onBeforeDownloadFileMessage
     ? async () => {

--- a/src/ui/FileMessageItemBody/index.tsx
+++ b/src/ui/FileMessageItemBody/index.tsx
@@ -10,6 +10,7 @@ import { Colors } from '../../utils/color';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import type { OnBeforeDownloadFileMessageType } from '../../modules/GroupChannel/context/GroupChannelProvider';
+import { openURL } from '../../utils/utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -39,7 +40,7 @@ export default function FileMessageItemBody({
   const { isMobile } = useMediaQueryContext();
   const truncateMaxNum = truncateLimit || (isMobile ? 20 : null);
 
-  const downloadFileWithUrl = () => window.open(message?.url);
+  const downloadFileWithUrl = () => openURL(message?.url);
   const handleOnClickTextButton = onBeforeDownloadFileMessage
     ? async () => {
       try {

--- a/src/ui/LinkLabel/index.tsx
+++ b/src/ui/LinkLabel/index.tsx
@@ -4,6 +4,7 @@ import Label, { LabelColors, LabelTypography } from '../Label';
 import { changeColorToClassName } from '../Label/utils';
 import './index.scss';
 import { ObjectValues } from '../../utils/typeHelpers/objectValues';
+import { openURL } from '../../utils/utils';
 
 const http = /https?:\/\//;
 
@@ -32,7 +33,7 @@ export default function LinkLabel({ className = '', src, type, color, children }
       onTouchEnd={(e) => {
         e.preventDefault();
         e.nativeEvent.stopImmediatePropagation();
-        window.open(url, '_blank', 'noopener,noreferrer');
+        openURL(url);
       }}
     >
       <Label className="sendbird-link-label__label" type={type} color={color}>

--- a/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
+++ b/src/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
@@ -12,7 +12,9 @@ describe('ui/OGMessageItemBody', () => {
         title: text,
         description: text,
         url: text,
-        image: text,
+        defaultImage: {
+          url: 'https://image-url.com'
+        },
       },
       message: text,
     };
@@ -25,10 +27,13 @@ describe('ui/OGMessageItemBody', () => {
   });
 
   it('should add .sendbird-og-message-item-body__og-thumbnail__image-empty classname when image is empty', () => {
-    const message = { message: 'example-text' };
+    const message = {
+      message: 'example-text',
+      ogMetaData: { defaultImage: { url: undefined } },
+    };
     const { container } = render(
       <MessageProvider message={message}>
-        <OGMessageItemBody message={{ message: 'example-text' }} />
+        <OGMessageItemBody message={message} />
       </MessageProvider>
     );
     expect(container.getElementsByClassName('sendbird-og-message-item-body__og-thumbnail__empty').length).toBe(1);

--- a/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -15,26 +15,21 @@ exports[`ui/OGMessageItemBody should do a snapshot test of the OGMessageItemBody
       </div>
     </span>
     <div
-      class="sendbird-og-message-item-body__og-thumbnail
-          sendbird-og-message-item-body__og-thumbnail__empty
-        "
+      class="sendbird-og-message-item-body__og-thumbnail "
     >
       <div
         class="sendbird-og-message-item-body__og-thumbnail__image sendbird-image-renderer"
         style="width: 100%; min-width: min(400px, 100%); max-width: 400px;"
       >
         <div
-          class="sendbird-og-message-item-body__og-thumbnail__place-holder"
-        >
-          <div
-            class="sendbird-og-message-item-body__og-thumbnail__place-holder__icon sendbird-icon sendbird-icon-thumbnail-none "
-            role="button"
-            style="width: 56px; min-width: 56px; height: 56px; min-height: 56px;"
-            tabindex="0"
-          >
-            <test-file-stub />
-          </div>
-        </div>
+          class="sendbird-image-renderer__image"
+          style="width: 100%; min-width: min(400px, 100%); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url(https://image-url.com);"
+        />
+        <img
+          alt=""
+          class="sendbird-image-renderer__hidden-image-loader"
+          src="https://image-url.com"
+        />
       </div>
     </div>
     <div

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -1,11 +1,6 @@
 import './index.scss';
-import React, {
-  ReactElement,
-  useContext,
-  useMemo,
-  useRef,
-} from 'react';
-import type { UserMessage } from '@sendbird/chat/message';
+import React, { ReactElement, useContext, useEffect, useMemo, useRef } from 'react';
+import type { OGImage, OGMetaData, UserMessage } from '@sendbird/chat/message';
 
 import ImageRenderer from '../ImageRenderer';
 import Icon, { IconTypes } from '../Icon';
@@ -16,6 +11,7 @@ import TextFragment from '../../modules/Message/components/TextFragment';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
 import { OG_MESSAGE_BODY_CLASSNAME } from './consts';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
+import { openURL } from '../../utils/utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -34,21 +30,12 @@ export default function OGMessageItemBody({
   mouseHover = false,
   isMentionEnabled = false,
   isReactionEnabled = false,
-  onMessageHeightChange = () => { /* noop */ },
+  onMessageHeightChange = () => {
+    /* noop */
+  },
 }: Props): ReactElement {
-  const imageRef = useRef<HTMLDivElement>(null);
   const { stringSet } = useContext(LocalizationContext);
-  const { isMobile } = useMediaQueryContext();
 
-  const openOGUrl = (): void => {
-    let url = message?.ogMetaData?.url;
-    if (url) {
-      if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        url = 'https://' + url;
-      }
-      window.open(url);
-    }
-  };
   const isMessageMentioned = isMentionEnabled && message?.mentionedMessageTemplate?.length > 0 && message?.mentionedUsers?.length > 0;
   const tokens = useMemo(() => {
     if (isMessageMentioned) {
@@ -61,99 +48,125 @@ export default function OGMessageItemBody({
       messageText: message?.message,
     });
   }, [message?.updatedAt, message?.message]);
+
+  const openOpenGraphURL = () => openURL(message?.ogMetaData?.url);
+
   return (
-    <div className={getClassName([
-      className,
-      'sendbird-og-message-item-body',
-      isByMe ? 'outgoing' : 'incoming',
-      mouseHover ? 'mouse-hover' : '',
-      (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
-    ])}>
-      <Label
-        type={LabelTypography.BODY_1}
-        color={isByMe ? LabelColors.ONCONTENT_1 : LabelColors.ONBACKGROUND_1}
-      >
+    <div
+      className={getClassName([
+        className,
+        'sendbird-og-message-item-body',
+        isByMe ? 'outgoing' : 'incoming',
+        mouseHover ? 'mouse-hover' : '',
+        isReactionEnabled && message?.reactions?.length > 0 ? 'reactions' : '',
+      ])}
+    >
+      <Label type={LabelTypography.BODY_1} color={isByMe ? LabelColors.ONCONTENT_1 : LabelColors.ONBACKGROUND_1}>
         <div className={OG_MESSAGE_BODY_CLASSNAME}>
           <TextFragment tokens={tokens} />
-          {
-            isEditedMessage(message) && (
-              <Label
-                className="sendbird-og-message-item-body__text-bubble__message"
-                type={LabelTypography.BODY_1}
-                color={isByMe ? LabelColors.ONCONTENT_2 : LabelColors.ONBACKGROUND_2}
-              >
-                {` ${stringSet.MESSAGE_EDITED} `}
-              </Label>
-            )
-          }
+          {isEditedMessage(message) && (
+            <Label
+              className="sendbird-og-message-item-body__text-bubble__message"
+              type={LabelTypography.BODY_1}
+              color={isByMe ? LabelColors.ONCONTENT_2 : LabelColors.ONBACKGROUND_2}
+            >
+              {` ${stringSet.MESSAGE_EDITED} `}
+            </Label>
+          )}
         </div>
       </Label>
-      <div
-        ref={imageRef}
-        className={`sendbird-og-message-item-body__og-thumbnail
-          ${message?.ogMetaData?.defaultImage?.url ? '' : 'sendbird-og-message-item-body__og-thumbnail__empty'}
-        `}
-        onClick={openOGUrl}
-      >
-        <ImageRenderer
-          className="sendbird-og-message-item-body__og-thumbnail__image"
-          url={message?.ogMetaData?.defaultImage?.url || ''}
-          alt={message?.ogMetaData?.defaultImage?.alt}
-          width="100%"
-          height={isMobile ? '136px' : '240px'}
-          onLoad={onMessageHeightChange}
-          onError={() => {
-            try {
-              imageRef?.current?.classList?.add('sendbird-og-message-item-body__og-thumbnail__empty');
-            } catch (error) {
-              // do nothing
-            }
-          }}
-          defaultComponent={(
-            <div className="sendbird-og-message-item-body__og-thumbnail__place-holder">
-              <Icon
-                className="sendbird-og-message-item-body__og-thumbnail__place-holder__icon"
-                type={IconTypes.THUMBNAIL_NONE}
-                width="56px"
-                height="56px"
-              />
-            </div>
-          )}
+      {message.ogMetaData?.defaultImage && (
+        <OGImageSection
+          onClick={openOpenGraphURL}
+          ogImage={message.ogMetaData.defaultImage}
+          onMessageHeightChange={onMessageHeightChange}
         />
-      </div>
-      <div
-        className="sendbird-og-message-item-body__description"
-        onClick={openOGUrl}
-      >
-        {message?.ogMetaData?.title && (
-          <Label
-            className="sendbird-og-message-item-body__description__title"
-            type={LabelTypography.SUBTITLE_2}
-            color={LabelColors.ONBACKGROUND_1}
-          >
-            {message.ogMetaData.title}
-          </Label>
-        )}
-        {message?.ogMetaData?.description && (
-          <Label
-            className="sendbird-og-message-item-body__description__description"
-            type={LabelTypography.BODY_2}
-            color={LabelColors.ONBACKGROUND_1}
-          >
-            {message.ogMetaData.description}
-          </Label>
-        )}
-        {message?.ogMetaData?.url && (
-          <Label
-            className="sendbird-og-message-item-body__description__url"
-            type={LabelTypography.CAPTION_3}
-            color={LabelColors.ONBACKGROUND_2}
-          >
-            {message.ogMetaData.url}
-          </Label>
-        )}
-      </div>
+      )}
+      {message.ogMetaData && (
+        <OGDescriptionSection onClick={openOpenGraphURL} ogMetaData={message.ogMetaData} onMessageHeightChange={onMessageHeightChange} />
+      )}
       <div className="sendbird-og-message-item-body__cover" />
     </div>
   );
 }
+
+const OGImageSection = (props: { onClick: () => void; ogImage: OGImage; onMessageHeightChange: () => void }) => {
+  const { onClick, ogImage, onMessageHeightChange } = props;
+
+  const imageRef = useRef<HTMLDivElement>(null);
+  const { isMobile } = useMediaQueryContext();
+
+  return (
+    <div
+      ref={imageRef}
+      className={`sendbird-og-message-item-body__og-thumbnail ${ogImage.url ? '' : 'sendbird-og-message-item-body__og-thumbnail__empty'}`}
+      onClick={() => onClick()}
+    >
+      <ImageRenderer
+        className="sendbird-og-message-item-body__og-thumbnail__image"
+        url={ogImage.url || ''}
+        alt={ogImage.alt}
+        width="100%"
+        height={isMobile ? '136px' : '240px'}
+        onLoad={onMessageHeightChange}
+        onError={() => {
+          try {
+            imageRef?.current?.classList?.add('sendbird-og-message-item-body__og-thumbnail__empty');
+          } catch (error) {
+            // do nothing
+          }
+        }}
+        defaultComponent={
+          <div className="sendbird-og-message-item-body__og-thumbnail__place-holder">
+            <Icon
+              className="sendbird-og-message-item-body__og-thumbnail__place-holder__icon"
+              type={IconTypes.THUMBNAIL_NONE}
+              width="56px"
+              height="56px"
+            />
+          </div>
+        }
+      />
+    </div>
+  );
+};
+
+const OGDescriptionSection = (props: { onClick: () => void; ogMetaData: OGMetaData; onMessageHeightChange: () => void }) => {
+  const { onClick, ogMetaData, onMessageHeightChange } = props;
+
+  useEffect(() => {
+    onMessageHeightChange();
+  }, [ogMetaData.title, ogMetaData.description, ogMetaData.url]);
+
+  return (
+    <div className="sendbird-og-message-item-body__description" onClick={() => onClick()}>
+      {ogMetaData.title && (
+        <Label
+          className="sendbird-og-message-item-body__description__title"
+          type={LabelTypography.SUBTITLE_2}
+          color={LabelColors.ONBACKGROUND_1}
+        >
+          {ogMetaData.title}
+        </Label>
+      )}
+      {ogMetaData.description && (
+        <Label
+          className="sendbird-og-message-item-body__description__description"
+          type={LabelTypography.BODY_2}
+          color={LabelColors.ONBACKGROUND_1}
+        >
+          {ogMetaData.description}
+        </Label>
+      )}
+      {ogMetaData.url && (
+        <Label
+          className="sendbird-og-message-item-body__description__url"
+          type={LabelTypography.CAPTION_3}
+          color={LabelColors.ONBACKGROUND_2}
+        >
+          {ogMetaData.url}
+        </Label>
+      )}
+    </div>
+  );
+};

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -26,6 +26,7 @@ import {
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import OpenChannelMobileMenu from '../OpenChannelMobileMenu';
 import useLongPress from '../../hooks/useLongPress';
+import { openURL } from '../../utils/utils';
 
 interface OpenChannelFileMessageProps {
   className?: string | Array<string>;
@@ -40,7 +41,7 @@ interface OpenChannelFileMessageProps {
   resendMessage(message: FileMessage): void;
 }
 
-export default function OpenchannelFileMessage({
+export default function OpenChannelFileMessage({
   className,
   message,
   isOperator,
@@ -59,7 +60,7 @@ export default function OpenchannelFileMessage({
   const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
 
   const { isMobile } = useMediaQueryContext();
-  const openFileUrl = () => { window.open(message.url); };
+  const openFileUrl = () => openURL(message.url);
 
   const isPending = checkIsPending(status);
   const isFailed = checkIsFailed(status);

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -17,7 +17,6 @@ import { UserProfileContext } from '../../lib/UserProfileContext';
 import uuidv4 from '../../utils/uuid';
 import { copyToClipboard } from '../OpenchannelUserMessage/utils';
 import { useLocalization } from '../../lib/LocalizationContext';
-import { checkOGIsEnalbed } from './utils';
 import {
   checkIsPending,
   checkIsFailed,
@@ -33,6 +32,7 @@ import useLongPress from '../../hooks/useLongPress';
 import OpenChannelMobileMenu from '../OpenChannelMobileMenu';
 import TextFragment from '../../modules/Message/components/TextFragment';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
+import { openURL } from '../../utils/utils';
 
 interface OpenChannelOGMessageProps {
   message: UserMessage;
@@ -48,7 +48,7 @@ interface OpenChannelOGMessageProps {
   userId: string;
 }
 
-export default function OpenchannelOGMessage({
+export default function OpenChannelOGMessage({
   message,
   isOperator,
   isEphemeral = false,
@@ -70,11 +70,7 @@ export default function OpenchannelOGMessage({
   const [contextStyle, setContextStyle] = useState({});
   const [showContextMenu, setShowContextMenu] = useState(false);
 
-  const openLink = () => {
-    if (checkOGIsEnalbed(message) && ogMetaData?.url) {
-      window.open(ogMetaData.url, '_blank', 'noopener,noreferrer');
-    }
-  };
+  const openLink = () => openURL(ogMetaData?.url);
 
   const onLongPress = useLongPress({
     onLongPress: () => setShowContextMenu(true),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,14 +1,10 @@
 import { SendableMessageType } from './index';
 
-export const noop = () => { /** noop * */ };
+export const noop = () => {
+  /** noop * */
+};
 export const getSenderProfileUrl = (message: SendableMessageType) => message.sender && message.sender.profileUrl;
-export const getSenderName = (message: SendableMessageType) => (
-  message.sender && (
-    message.sender.friendName
-    || message.sender.nickname
-    || message.sender.userId
-  )
-);
+export const getSenderName = (message: SendableMessageType) => message.sender && (message.sender.friendName || message.sender.nickname || message.sender.userId);
 export const isAboutSame = (a: number, b: number, px: number) => Math.abs(a - b) <= px;
 export const isMobileIOS = (userAgent: string) => {
   const isIOS = /iPhone|iPad|iPod/i.test(userAgent);
@@ -27,6 +23,16 @@ export const deleteNullish = <T>(obj: T): T => {
   });
   return cleaned;
 };
+
+export function openURL(url?: string | null) {
+  let safeURL = url;
+  if (safeURL) {
+    if (!safeURL.startsWith('http://') && !safeURL.startsWith('https://')) {
+      safeURL = 'https://' + safeURL;
+    }
+    window.open(safeURL);
+  }
+}
 
 export default {
   getSenderName,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -30,7 +30,7 @@ export function openURL(url?: string | null) {
     if (!safeURL.startsWith('http://') && !safeURL.startsWith('https://')) {
       safeURL = 'https://' + safeURL;
     }
-    window.open(safeURL);
+    window.open(safeURL, '_blank', 'noopener,noreferrer');
   }
 }
 


### PR DESCRIPTION
- Removed image section in the OGMessageItemBody if there is no og image
- Fixed that safely opens URL to prevent XSS

tickets: [CLNP-2924] [CLNP-2843]


[CLNP-2924]: https://sendbird.atlassian.net/browse/CLNP-2924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CLNP-2843]: https://sendbird.atlassian.net/browse/CLNP-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ