### PR TITLE
feat: Support setting output file type in image compression process

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -68,10 +68,12 @@ interface VoiceRecordOptions {
   minRecordingTime?: number;
 }
 
+export type ImageCompressionOutputFormatType = 'preserve' | 'png' | 'jpeg';
 export interface ImageCompressionOptions {
   compressionRate?: number;
   resizingWidth?: number | string;
   resizingHeight?: number | string;
+  outputFormat?: ImageCompressionOutputFormatType;
 }
 
 export interface SendbirdConfig {
@@ -361,6 +363,7 @@ const SendbirdSDK = ({
           pubSub,
           imageCompression: {
             compressionRate: 0.7,
+            outputFormat: 'preserve',
             ...imageCompression,
           },
           voiceRecord: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,7 @@ import type {
   ReplyType,
   UserListQuery,
 } from '../types';
+import type { ImageCompressionOptions } from './Sendbird';
 import { UikitMessageHandler } from './selectors';
 import { Logger } from './SendbirdState';
 import { MarkAsReadSchedulerType } from './hooks/useMarkAsReadScheduler';
@@ -86,11 +87,7 @@ export interface SendBirdStateConfig {
     maxMentionCount: number,
     maxSuggestionCount: number,
   };
-  imageCompression?: {
-    compressionRate?: number,
-    resizingWidth?: number | string,
-    resizingHeight?: number | string,
-  };
+  imageCompression?: ImageCompressionOptions;
   markAsReadScheduler: MarkAsReadSchedulerType;
   markAsDeliveredScheduler: MarkAsDeliveredSchedulerType;
   isTypingIndicatorEnabledOnChannelList?: boolean;

--- a/src/lib/utils/uikitConfigMapper.ts
+++ b/src/lib/utils/uikitConfigMapper.ts
@@ -26,6 +26,7 @@ export function uikitConfigMapper({
       enableOgtag: uikitOptions.groupChannel?.enableOgtag,
       enableMention: uikitOptions.groupChannel?.enableMention ?? isMentionEnabled,
       enableReactions: uikitOptions.groupChannel?.enableReactions ?? isReactionEnabled,
+      enableReactionsSupergroup: uikitOptions.groupChannel?.enableReactionsSupergroup,
       enableTypingIndicator: uikitOptions.groupChannel?.enableTypingIndicator,
       enableVoiceMessage: uikitOptions.groupChannel?.enableVoiceMessage ?? isVoiceMessageEnabled,
       replyType: uikitOptions.groupChannel?.replyType

--- a/src/modules/OpenChannel/context/hooks/useFileUploadCallback.tsx
+++ b/src/modules/OpenChannel/context/hooks/useFileUploadCallback.tsx
@@ -3,6 +3,7 @@ import type { OpenChannel } from '@sendbird/chat/openChannel';
 import type { FileMessageCreateParams } from '@sendbird/chat/message';
 
 import type { Logger } from '../../../../lib/SendbirdState';
+import type { ImageCompressionOptions } from '../../../../lib/Sendbird';
 import * as messageActionTypes from '../dux/actionTypes';
 import * as utils from '../utils';
 import { SdkStore } from '../../../../lib/types';
@@ -18,11 +19,7 @@ interface DynamicParams {
   currentOpenChannel: OpenChannel;
   onBeforeSendFileMessage: (file: File) => FileMessageCreateParams;
   checkScrollBottom: () => boolean;
-  imageCompression?: {
-    compressionRate?: number,
-    resizingWidth?: number | string,
-    resizingHeight?: number | string,
-  };
+  imageCompression?: ImageCompressionOptions;
 }
 interface StaticParams {
   sdk: SdkStore['sdk'];

--- a/src/utils/compressImages.ts
+++ b/src/utils/compressImages.ts
@@ -55,13 +55,20 @@ export const compressImage = ({
 
       // Change the file.name & file.type for converting file type
       const targetFileType = outputFormat === 'preserve' ? imageFile.type : `image/${outputFormat}`;
-      const originalSubtype = imageFile.type.split('/').pop();
-      const newSubtype = targetFileType.split('/').pop();
-      const newName = imageFile.name.replace(originalSubtype, newSubtype);
+      const targetSubtype = targetFileType.split('/').pop();
+      let targetName = '';
+      const dotIndex = imageFile.name.lastIndexOf('.');
+      if (dotIndex === -1) {
+        // No extension found, use the original filename
+        targetName = imageFile.name;
+      } else {
+        // Replace the old extension with the new one
+        targetName = imageFile.name.substring(0, dotIndex) + '.' + targetSubtype;
+      }
       ctx.canvas.toBlob(
         (blob) => {
           if (blob) {
-            const file = new File([blob], newName, { type: targetFileType });
+            const file = new File([blob], targetName, { type: targetFileType });
             resolve(file);
           } else {
             reject(new Error('Failed to compress image'));


### PR DESCRIPTION
[CLNP-2718](https://sendbird.atlassian.net/browse/CLNP-2718)
[SBISSUE-14611](https://sendbird.atlassian.net/browse/SBISSUE-14611)

### Feature & ChangeLog
* Add `outputFormat` to the image compression options
  ```tsx
  <SendbirdProvider
    ...
    imageCompression={{
      outputFormat: 'preserve' | 'png' | 'jpeg',
    }}
  >
  </SendbirdProvider>
  ```

[CLNP-2718]: https://sendbird.atlassian.net/browse/CLNP-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SBISSUE-14611]: https://sendbird.atlassian.net/browse/SBISSUE-14611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ