### PR TITLE
release: v3.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## [v3.14.2] (Apr 18, 2024)
 
-### Features
-* Added `outputFormat` to the image compression options
-  ```tsx
-  <SendbirdProvider
-    ...
-    imageCompression={{
-      outputFormat: 'preserve' | 'png' | 'jpeg',
-    }}
-  >
-  </SendbirdProvider>
-  ```
-
 ### Fixes
 * Fixed a bug where right padding is added to messages sent by me in mobile devices
 * Removed image section in the OGMessageItemBody if there is no og image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   ```
 
 ### Fixes
+* Fixed a bug where right padding is added to messages sent by me in mobile devices
 * Removed image section in the OGMessageItemBody if there is no og image
 * Fixed that safely opens URL to prevent XSS
 * Fixed that copying URI-list issue in the iOS device/Safari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog - v3
 
+## [v3.14.2] (Apr 18, 2024)
+
+### Features
+* Added `outputFormat` to the image compression options
+  ```tsx
+  <SendbirdProvider
+    ...
+    imageCompression={{
+      outputFormat: 'preserve' | 'png' | 'jpeg',
+    }}
+  >
+  </SendbirdProvider>
+  ```
+
+### Fixes
+* Removed image section in the OGMessageItemBody if there is no og image
+* Fixed that safely opens URL to prevent XSS
+* Fixed that copying URI-list issue in the iOS device/Safari
+* Fixed that channel badge count is not updated on iOS Webview
+
 ## [v3.14.1] (Apr 12, 2024)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.14.2] (Apr 18, 2024)

### Fixes
* Fixed a bug where right padding is added to messages sent by me in mobile devices
* Removed image section in the OGMessageItemBody if there is no og image
* Fixed that safely opens URL to prevent XSS
* Fixed that copying URI-list issue in the iOS device/Safari
* Fixed that channel badge count is not updated on iOS Webview