### PR TITLE
fix: Set the message list padding with 12px in the mobile layout

### DIFF
--- a/src/modules/GroupChannel/components/MessageInputWrapper/index.scss
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/index.scss
@@ -21,8 +21,10 @@
     position: relative;
     width: 100%;
     box-sizing: border-box;
-    padding-left: 24px;
-    padding-right: 24px;
+    padding: 0px 24px;
+    @include mobile() {
+      padding: 0px 16px;
+    }
   }
 }
 

--- a/src/modules/GroupChannel/components/MessageList/index.scss
+++ b/src/modules/GroupChannel/components/MessageList/index.scss
@@ -10,8 +10,10 @@
     position: relative;
     height: 100%;
     overflow-x: hidden;
-    padding-left: 24px;
-    padding-right: 24px;
+    padding: 0px 24px;
+    @include mobile() {
+      padding: 0px 12px;
+    }
   }
   .sendbird-separator,
   .sendbird-admin-message {


### PR DESCRIPTION
### Fix&ChangeLog
* Set the message list padding with `12px` in the mobile mode