### PR TITLE
fix: Add target subType to fileName in every case

### DIFF
--- a/src/utils/compressImages.ts
+++ b/src/utils/compressImages.ts
@@ -56,15 +56,11 @@ export const compressImage = ({
       // Change the file.name & file.type for converting file type
       const targetFileType = outputFormat === 'preserve' ? imageFile.type : `image/${outputFormat}`;
       const targetSubtype = targetFileType.split('/').pop();
-      let targetName = '';
       const dotIndex = imageFile.name.lastIndexOf('.');
-      if (dotIndex === -1) {
-        // No extension found, use the original filename
-        targetName = imageFile.name;
-      } else {
-        // Replace the old extension with the new one
-        targetName = imageFile.name.substring(0, dotIndex) + '.' + targetSubtype;
-      }
+      // targetName = `fileName.targetSubtype`
+      const targetName = `${
+        dotIndex === -1 ? imageFile.name : imageFile.name.substring(0, dotIndex)
+      }.${targetSubtype}`;
       ctx.canvas.toBlob(
         (blob) => {
           if (blob) {

--- a/src/utils/compressImages.ts
+++ b/src/utils/compressImages.ts
@@ -58,9 +58,7 @@ export const compressImage = ({
       const targetSubtype = targetFileType.split('/').pop();
       const dotIndex = imageFile.name.lastIndexOf('.');
       // targetName = `fileName.targetSubtype`
-      const targetName = `${
-        dotIndex === -1 ? imageFile.name : imageFile.name.substring(0, dotIndex)
-      }.${targetSubtype}`;
+      const targetName = `${dotIndex === -1 ? imageFile.name : imageFile.name.substring(0, dotIndex)}.${targetSubtype}`;
       ctx.canvas.toBlob(
         (blob) => {
           if (blob) {


### PR DESCRIPTION
### Issue
* it couldn't convert to the target fileType, if original file's name doesn't contain the file extension