### PR TITLE
refactor: mark deprecated in legacy configs where marks are missing

### DIFF
--- a/apps/testing/src/utils/paramsBuilder.ts
+++ b/apps/testing/src/utils/paramsBuilder.ts
@@ -91,7 +91,7 @@ export const paramKeys = [
   'groupChannel_showSuggestedRepliesFor',
   'groupChannelList_enableTypingIndicator',
   'groupChannelList_enableMessageReceiptStatus',
-  'groupChannelSetting_enableMessageSearch',
+  'groupChannelSettings_enableMessageSearch',
   'openChannel_enableOgtag',
   'openChannel_input_camera_enablePhoto',
   'openChannel_input_camera_enableVideo',

--- a/src/hooks/VoiceRecorder/index.tsx
+++ b/src/hooks/VoiceRecorder/index.tsx
@@ -36,12 +36,13 @@ const Context = createContext<VoiceRecorderContext>({
 export const VoiceRecorderProvider = (props: VoiceRecorderProps): React.ReactElement => {
   const { children } = props;
   const { config } = useSendbirdStateContext();
-  const { logger, isVoiceMessageEnabled } = config;
+  const { logger, groupChannel } = config;
   const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder>(null);
   const [isRecordable, setIsRecordable] = useState<boolean>(false);
   const [permissionWarning, setPermissionWarning] = useState<boolean>(false);
   const { stringSet } = useLocalization();
 
+  const isVoiceMessageEnabled = groupChannel.enableVoiceMessage;
   const [webAudioUtils, setWebAudioUtils] = useState(null);
 
   const browserSupportMimeType = BROWSER_SUPPORT_MIME_TYPE_LIST.find((mimeType) => MediaRecorder.isTypeSupported(mimeType)) ?? '';

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -37,7 +37,7 @@ import { uikitConfigMapper } from './utils/uikitConfigMapper';
 import { useMarkAsReadScheduler } from './hooks/useMarkAsReadScheduler';
 import { ConfigureSessionTypes } from './hooks/useConnect/types';
 import { useMarkAsDeliveredScheduler } from './hooks/useMarkAsDeliveredScheduler';
-import { getCaseResolvedReplyType, getCaseResolvedThreadReplySelectType } from './utils/resolvedReplyType';
+import { getCaseResolvedReplyType } from './utils/resolvedReplyType';
 import { useUnmount } from '../hooks/useUnmount';
 import { disconnectSdk } from './hooks/useConnect/disconnectSdk';
 import {
@@ -376,42 +376,43 @@ const SendbirdSDK = ({
           },
           markAsReadScheduler,
           markAsDeliveredScheduler,
-          // From UIKitConfigProvider.localConfigs
-          disableUserProfile:
-            !configs.common.enableUsingDefaultUserProfile,
-          isReactionEnabled:
-            sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactions,
-          isMentionEnabled:
-            configs.groupChannel.channel.enableMention,
-          isVoiceMessageEnabled:
-            configs.groupChannel.channel.enableVoiceMessage,
-          replyType:
-            getCaseResolvedReplyType(configs.groupChannel.channel.replyType).upperCase,
-          isTypingIndicatorEnabledOnChannelList:
-            configs.groupChannel.channelList.enableTypingIndicator,
-          isMessageReceiptStatusEnabledOnChannelList:
-            configs.groupChannel.channelList.enableMessageReceiptStatus,
-          showSearchIcon:
-            sdkInitialized && configsWithAppAttr(sdk).groupChannel.setting.enableMessageSearch,
           // Remote configs set from dashboard by UIKit feature configuration
+          common: configs.common,
           groupChannel: {
             enableOgtag: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableOgtag,
             enableTypingIndicator: configs.groupChannel.channel.enableTypingIndicator,
-            enableDocument: configs.groupChannel.channel.input.enableDocument,
             enableReactions: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactions,
             enableReactionsSupergroup: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactionsSupergroup,
+            enableMention: configs.groupChannel.channel.enableMention,
             replyType: configs.groupChannel.channel.replyType,
-            threadReplySelectType: getCaseResolvedThreadReplySelectType(configs.groupChannel.channel.threadReplySelectType).lowerCase,
+            threadReplySelectType: configs.groupChannel.channel.threadReplySelectType,
+            enableVoiceMessage: configs.groupChannel.channel.enableVoiceMessage,
+            enableDocument: configs.groupChannel.channel.input.enableDocument,
             typingIndicatorTypes: configs.groupChannel.channel.typingIndicatorTypes,
             enableFeedback: configs.groupChannel.channel.enableFeedback,
             enableSuggestedReplies: configs.groupChannel.channel.enableSuggestedReplies,
             showSuggestedRepliesFor: configs.groupChannel.channel.showSuggestedRepliesFor,
           },
+          groupChannelList: {
+            enableTypingIndicator: configs.groupChannel.channelList.enableTypingIndicator,
+            enableMessageReceiptStatus: configs.groupChannel.channelList.enableMessageReceiptStatus,
+          },
+          groupChannelSettings: {
+            enableMessageSearch: sdkInitialized && configsWithAppAttr(sdk).groupChannel.setting.enableMessageSearch,
+          },
           openChannel: {
-            enableOgtag:
-              sdkInitialized && configsWithAppAttr(sdk).openChannel.channel.enableOgtag,
+            enableOgtag: sdkInitialized && configsWithAppAttr(sdk).openChannel.channel.enableOgtag,
             enableDocument: configs.openChannel.channel.input.enableDocument,
           },
+          // deprecated configs
+          disableUserProfile: !configs.common.enableUsingDefaultUserProfile,
+          isReactionEnabled: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactions,
+          isMentionEnabled: configs.groupChannel.channel.enableMention,
+          isVoiceMessageEnabled: configs.groupChannel.channel.enableVoiceMessage,
+          replyType: getCaseResolvedReplyType(configs.groupChannel.channel.replyType).upperCase,
+          isTypingIndicatorEnabledOnChannelList: configs.groupChannel.channelList.enableTypingIndicator,
+          isMessageReceiptStatusEnabledOnChannelList: configs.groupChannel.channelList.enableMessageReceiptStatus,
+          showSearchIcon: sdkInitialized && configsWithAppAttr(sdk).groupChannel.setting.enableMessageSearch,
         },
         eventHandlers,
         emojiManager,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,8 +57,6 @@ export interface SBUEventHandlers {
 }
 
 export interface SendBirdStateConfig {
-  disableUserProfile: boolean;
-  disableMarkAsDelivered: boolean;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onUserProfileMessage?: (props: GroupChannel) => void;
   allowProfileEdit: boolean;
@@ -70,13 +68,7 @@ export interface SendBirdStateConfig {
   pubSub: SBUGlobalPubSub;
   logger: Logger;
   setCurrentTheme: (theme: 'light' | 'dark') => void;
-  /** @deprecated Please use setCurrentTheme instead * */
-  setCurrenttheme: (theme: 'light' | 'dark') => void;
   userListQuery?(): UserListQuery;
-  isReactionEnabled: boolean;
-  isMentionEnabled: boolean;
-  isMultipleFilesMessageEnabled: boolean;
-  isVoiceMessageEnabled?: boolean;
   uikitUploadSizeLimit: number;
   uikitMultipleFilesMessageLimit: number;
   voiceRecord?: {
@@ -90,28 +82,56 @@ export interface SendBirdStateConfig {
   imageCompression?: ImageCompressionOptions;
   markAsReadScheduler: MarkAsReadSchedulerType;
   markAsDeliveredScheduler: MarkAsDeliveredSchedulerType;
-  isTypingIndicatorEnabledOnChannelList?: boolean;
-  isMessageReceiptStatusEnabledOnChannelList?: boolean;
-  replyType: ReplyType;
-  showSearchIcon?: boolean;
+  disableMarkAsDelivered: boolean;
+  isMultipleFilesMessageEnabled: boolean;
   // Remote configs set from dashboard by UIKit feature configuration
+  common: {
+    enableUsingDefaultUserProfile: SBUConfig['common']['enableUsingDefaultUserProfile'];
+  },
   groupChannel: {
     enableOgtag: SBUConfig['groupChannel']['channel']['enableOgtag'];
     enableTypingIndicator: SBUConfig['groupChannel']['channel']['enableTypingIndicator'];
-    enableDocument: SBUConfig['groupChannel']['channel']['input']['enableDocument'];
     enableReactions: SBUConfig['groupChannel']['channel']['enableReactions'];
     enableReactionsSupergroup: SBUConfig['groupChannel']['channel']['enableReactionsSupergroup'];
+    enableMention: SBUConfig['groupChannel']['channel']['enableMention'];
     replyType: SBUConfig['groupChannel']['channel']['replyType'];
     threadReplySelectType: SBUConfig['groupChannel']['channel']['threadReplySelectType'];
+    enableVoiceMessage: SBUConfig['groupChannel']['channel']['enableVoiceMessage'];
     typingIndicatorTypes: SBUConfig['groupChannel']['channel']['typingIndicatorTypes'];
+    enableDocument: SBUConfig['groupChannel']['channel']['input']['enableDocument'];
     enableFeedback: SBUConfig['groupChannel']['channel']['enableFeedback'];
     enableSuggestedReplies: SBUConfig['groupChannel']['channel']['enableSuggestedReplies'];
     showSuggestedRepliesFor: SBUConfig['groupChannel']['channel']['showSuggestedRepliesFor'];
+  },
+  groupChannelList: {
+    enableTypingIndicator: SBUConfig['groupChannel']['channelList']['enableTypingIndicator'];
+    enableMessageReceiptStatus: SBUConfig['groupChannel']['channelList']['enableMessageReceiptStatus'];
+  },
+  groupChannelSettings: {
+    enableMessageSearch: SBUConfig['groupChannel']['setting']['enableMessageSearch'];
   },
   openChannel: {
     enableOgtag: SBUConfig['openChannel']['channel']['enableOgtag'];
     enableDocument: SBUConfig['openChannel']['channel']['input']['enableDocument'];
   },
+  /** @deprecated Please use `common.enableUsingDefaultUserProfile` instead * */
+  disableUserProfile: boolean;
+  /** @deprecated Please use `groupChannel.enableReactions` instead * */
+  isReactionEnabled: boolean;
+  /** @deprecated Please use `groupChannel.enableMention` instead * */
+  isMentionEnabled: boolean;
+  /** @deprecated Please use `groupChannel.enableVoiceMessage` instead * */
+  isVoiceMessageEnabled?: boolean;
+  /** @deprecated Please use `groupChannel.replyType` instead * */
+  replyType: ReplyType;
+  /** @deprecated Please use `groupChannelSettings.enableMessageSearch` instead * */
+  showSearchIcon?: boolean;
+  /** @deprecated Please use `groupChannelList.enableTypingIndicator` instead * */
+  isTypingIndicatorEnabledOnChannelList?: boolean;
+  /** @deprecated Please use `groupChannelList.enableMessageReceiptStatus` instead * */
+  isMessageReceiptStatusEnabledOnChannelList?: boolean;
+  /** @deprecated Please use setCurrentTheme instead * */
+  setCurrenttheme: (theme: 'light' | 'dark') => void;
 }
 
 export type SendbirdChatType = SendbirdChat & ModuleNamespaces<[GroupChannelModule, OpenChannelModule]>;
@@ -233,13 +253,21 @@ export interface sendbirdSelectorsInterface {
 }
 
 export interface CommonUIKitConfigProps {
-  replyType?: 'NONE' | 'QUOTE_REPLY' | 'THREAD';
-  isMentionEnabled?: boolean;
-  isReactionEnabled?: boolean;
+  /** @deprecated Please use `uikitOptions.common.enableUsingDefaultUserProfile` instead * */
   disableUserProfile?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannel.replyType` instead * */
+  replyType?: 'NONE' | 'QUOTE_REPLY' | 'THREAD';
+  /** @deprecated Please use `uikitOptions.groupChannel.enableReactions` instead * */
+  isReactionEnabled?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannel.enableMention` instead * */
+  isMentionEnabled?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannel.enableVoiceMessage` instead * */
   isVoiceMessageEnabled?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannelList.enableTypingIndicator` instead * */
   isTypingIndicatorEnabledOnChannelList?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannelList.enableMessageReceiptStatus` instead * */
   isMessageReceiptStatusEnabledOnChannelList?: boolean;
+  /** @deprecated Please use `uikitOptions.groupChannelSettings.enableMessageSearch` instead * */
   showSearchIcon?: boolean;
 }
 

--- a/src/lib/utils/uikitConfigMapper.ts
+++ b/src/lib/utils/uikitConfigMapper.ts
@@ -18,9 +18,7 @@ export function uikitConfigMapper({
   return {
     common: {
       enableUsingDefaultUserProfile: uikitOptions.common?.enableUsingDefaultUserProfile
-        ?? (typeof disableUserProfile === 'boolean'
-          ? !disableUserProfile
-          : undefined),
+        ?? (typeof disableUserProfile === 'boolean' ? !disableUserProfile : undefined),
     },
     groupChannel: {
       enableOgtag: uikitOptions.groupChannel?.enableOgtag,

--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -8,6 +8,7 @@ import { MobileLayout } from './MobileLayout';
 
 import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import { SendableMessageType } from '../../utils';
+import { getCaseResolvedReplyType } from '../../lib/utils/resolvedReplyType';
 
 export const AppLayout: React.FC<AppLayoutProps> = (
   props: AppLayoutProps,
@@ -23,7 +24,7 @@ export const AppLayout: React.FC<AppLayoutProps> = (
   } = props;
 
   const globalStore = useSendbirdStateContext();
-  const globalConfigs = globalStore?.config;
+  const globalConfigs = globalStore.config;
 
   const [showThread, setShowThread] = useState(false);
   const [threadTargetMessage, setThreadTargetMessage] = useState<SendableMessageType | null>(null);
@@ -37,9 +38,9 @@ export const AppLayout: React.FC<AppLayoutProps> = (
    * Below configs can be set via Dashboard UIKit config setting but as a lower priority than App props.
    * So need to be have fallback value \w global configs even though each prop values are undefined
    */
-  const replyType = props.replyType ?? globalConfigs?.replyType;
-  const isReactionEnabled = props.isReactionEnabled ?? globalConfigs?.isReactionEnabled;
-  const showSearchIcon = props.showSearchIcon ?? globalConfigs?.showSearchIcon;
+  const replyType = props.replyType ?? getCaseResolvedReplyType(globalConfigs.groupChannel.replyType).upperCase;
+  const isReactionEnabled = props.isReactionEnabled ?? globalConfigs.groupChannel.enableReactions;
+  const showSearchIcon = props.showSearchIcon ?? globalConfigs.groupChannelSettings.enableMessageSearch;
 
   return (
     <>

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -26,22 +26,14 @@ export interface AppProps {
   profileUrl?: SendbirdProviderProps['profileUrl'];
   dateLocale?: SendbirdProviderProps['dateLocale'];
   config?: SendbirdProviderProps['config'];
-  isReactionEnabled?: SendbirdProviderProps['isReactionEnabled'];
-  isMentionEnabled?: SendbirdProviderProps['isMentionEnabled'];
-  isVoiceMessageEnabled?: SendbirdProviderProps['isVoiceMessageEnabled'];
   voiceRecord?: SendbirdProviderProps['voiceRecord'];
-  replyType?: SendbirdProviderProps['replyType'];
   isMultipleFilesMessageEnabled?: SendbirdProviderProps['isMultipleFilesMessageEnabled'];
   colorSet?: SendbirdProviderProps['colorSet'];
   stringSet?: SendbirdProviderProps['stringSet'];
   allowProfileEdit?: SendbirdProviderProps['allowProfileEdit'];
-  disableUserProfile?: SendbirdProviderProps['disableUserProfile'];
   disableMarkAsDelivered?: SendbirdProviderProps['disableMarkAsDelivered'];
   renderUserProfile?: SendbirdProviderProps['renderUserProfile'];
-  showSearchIcon?: SendbirdProviderProps['showSearchIcon'];
   imageCompression?: SendbirdProviderProps['imageCompression'];
-  isTypingIndicatorEnabledOnChannelList?: SendbirdProviderProps['isTypingIndicatorEnabledOnChannelList'];
-  isMessageReceiptStatusEnabledOnChannelList?: SendbirdProviderProps['isMessageReceiptStatusEnabledOnChannelList'];
   uikitOptions?: SendbirdProviderProps['uikitOptions'];
   isUserIdUsedForNickname?: SendbirdProviderProps['isUserIdUsedForNickname'];
   sdkInitParams?: SendbirdProviderProps['sdkInitParams'];
@@ -57,6 +49,23 @@ export interface AppProps {
    * If this option is enabled, it uses legacy modules (Channel, ChannelList) that are not applied local caching.
    * */
   enableLegacyChannelModules?: boolean;
+
+  /** @deprecated Please use `uikitOptions.common.enableUsingDefaultUserProfile` instead * */
+  disableUserProfile?: SendbirdProviderProps['disableUserProfile'];
+  /** @deprecated Please use `uikitOptions.groupChannel.replyType` instead * */
+  replyType?: SendbirdProviderProps['replyType'];
+  /** @deprecated Please use `uikitOptions.groupChannel.enableReactions` instead * */
+  isReactionEnabled?: SendbirdProviderProps['isReactionEnabled'];
+  /** @deprecated Please use `uikitOptions.groupChannel.enableMention` instead * */
+  isMentionEnabled?: SendbirdProviderProps['isMentionEnabled'];
+  /** @deprecated Please use `uikitOptions.groupChannel.enableVoiceMessage` instead * */
+  isVoiceMessageEnabled?: SendbirdProviderProps['isVoiceMessageEnabled'];
+  /** @deprecated Please use `uikitOptions.groupChannelList.enableTypingIndicator` instead * */
+  isTypingIndicatorEnabledOnChannelList?: SendbirdProviderProps['isTypingIndicatorEnabledOnChannelList'];
+  /** @deprecated Please use `uikitOptions.groupChannelList.enableMessageReceiptStatus` instead * */
+  isMessageReceiptStatusEnabledOnChannelList?: SendbirdProviderProps['isMessageReceiptStatusEnabledOnChannelList'];
+  /** @deprecated Please use `uikitOptions.groupChannelSettings.enableMessageSearch` instead * */
+  showSearchIcon?: SendbirdProviderProps['showSearchIcon'];
 }
 
 export default function App(props: AppProps) {
@@ -86,6 +95,9 @@ export default function App(props: AppProps) {
     sdkInitParams,
     customExtensionParams,
     eventHandlers,
+    isMultipleFilesMessageEnabled,
+    isUserIdUsedForNickname = true,
+    enableLegacyChannelModules = false,
     uikitOptions,
     // The below configs are duplicates of the Dashboard UIKit Configs.
     // Since their default values will be set in the Sendbird component,
@@ -96,11 +108,8 @@ export default function App(props: AppProps) {
     replyType,
     disableUserProfile,
     isVoiceMessageEnabled,
-    isMultipleFilesMessageEnabled,
     isTypingIndicatorEnabledOnChannelList,
     isMessageReceiptStatusEnabledOnChannelList,
-    isUserIdUsedForNickname = true,
-    enableLegacyChannelModules = false,
   } = props;
   const [currentChannel, setCurrentChannel] = useState(null);
 
@@ -120,18 +129,19 @@ export default function App(props: AppProps) {
       userListQuery={userListQuery}
       config={config}
       colorSet={colorSet}
-      disableUserProfile={disableUserProfile}
       disableMarkAsDelivered={disableMarkAsDelivered}
       renderUserProfile={renderUserProfile}
       imageCompression={imageCompression}
-      isReactionEnabled={isReactionEnabled}
-      isMentionEnabled={isMentionEnabled}
-      isVoiceMessageEnabled={isVoiceMessageEnabled}
       isMultipleFilesMessageEnabled={isMultipleFilesMessageEnabled}
       voiceRecord={voiceRecord}
       onUserProfileMessage={(channel) => {
         setCurrentChannel(channel);
       }}
+      uikitOptions={uikitOptions}
+      isUserIdUsedForNickname={isUserIdUsedForNickname}
+      sdkInitParams={sdkInitParams}
+      customExtensionParams={customExtensionParams}
+      eventHandlers={eventHandlers}
       isTypingIndicatorEnabledOnChannelList={
         isTypingIndicatorEnabledOnChannelList
       }
@@ -140,16 +150,12 @@ export default function App(props: AppProps) {
       }
       replyType={replyType}
       showSearchIcon={showSearchIcon}
-      uikitOptions={uikitOptions}
-      isUserIdUsedForNickname={isUserIdUsedForNickname}
-      sdkInitParams={sdkInitParams}
-      customExtensionParams={customExtensionParams}
-      eventHandlers={eventHandlers}
+      disableUserProfile={disableUserProfile}
+      isReactionEnabled={isReactionEnabled}
+      isMentionEnabled={isMentionEnabled}
+      isVoiceMessageEnabled={isVoiceMessageEnabled}
     >
       <AppLayout
-        isReactionEnabled={isReactionEnabled}
-        replyType={replyType}
-        showSearchIcon={showSearchIcon}
         isMessageGroupingEnabled={isMessageGroupingEnabled}
         allowProfileEdit={allowProfileEdit}
         onProfileEditSuccess={onProfileEditSuccess}
@@ -157,6 +163,9 @@ export default function App(props: AppProps) {
         currentChannel={currentChannel}
         setCurrentChannel={setCurrentChannel}
         enableLegacyChannelModules={enableLegacyChannelModules}
+        isReactionEnabled={isReactionEnabled}
+        replyType={replyType}
+        showSearchIcon={showSearchIcon}
       />
     </Sendbird>
   );

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -160,16 +160,14 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
   const {
     markAsDeliveredScheduler,
     disableMarkAsDelivered = false,
-    isTypingIndicatorEnabledOnChannelList = false,
-    isMessageReceiptStatusEnabledOnChannelList = false,
     isOnline,
   } = config;
   const sdk = sdkStore?.sdk;
   const { premiumFeatureList = [] } = sdk?.appInfo ?? {};
 
   // derive some variables
-  // enable if it is true atleast once(both are flase by default)
-  const userDefinedDisableUserProfile = disableUserProfile || config?.disableUserProfile;
+  // enable if it is true at least once(both are false by default)
+  const userDefinedDisableUserProfile = disableUserProfile ?? !config.common.enableUsingDefaultUserProfile;
   const userDefinedRenderProfile = config?.renderUserProfile;
   const enableEditProfile = allowProfileEdit || config?.allowProfileEdit;
 
@@ -395,17 +393,13 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
         ...channelListStore,
         allChannels: sortedChannels,
         typingChannels,
-        isTypingIndicatorEnabled:
-          isTypingIndicatorEnabled !== null ? isTypingIndicatorEnabled : isTypingIndicatorEnabledOnChannelList,
-        isMessageReceiptStatusEnabled:
-          isMessageReceiptStatusEnabled !== null
-            ? isMessageReceiptStatusEnabled
-            : isMessageReceiptStatusEnabledOnChannelList,
+        isTypingIndicatorEnabled: isTypingIndicatorEnabled ?? config.groupChannelList.enableTypingIndicator,
+        isMessageReceiptStatusEnabled: isMessageReceiptStatusEnabled ?? config.groupChannelList.enableMessageReceiptStatus,
         fetchChannelList,
       }}
     >
       <UserProfileProvider
-        disableUserProfile={userDefinedDisableUserProfile ?? config?.disableUserProfile}
+        disableUserProfile={userDefinedDisableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
         renderUserProfile={userDefinedRenderProfile}
         onUserProfileMessage={onUserProfileMessage}
       >

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -133,7 +133,7 @@ const ChannelSettingsProvider = ({
     >
       <UserProfileProvider
         renderUserProfile={renderUserProfile}
-        disableUserProfile={disableUserProfile ?? config?.disableUserProfile}
+        disableUserProfile={disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
         onUserProfileMessage={onUserProfileMessage}
       >
         <div className={`sendbird-channel-settings ${className}`}>{children}</div>

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -152,7 +152,7 @@ const MessageView = (props: MessageViewProps) => {
   const { dateLocale, stringSet } = useLocalization();
   const globalStore = useSendbirdStateContext();
 
-  const { userId, isOnline, isMentionEnabled, userMention, logger } = globalStore.config;
+  const { userId, isOnline, userMention, logger, groupChannel } = globalStore.config;
   const maxUserMentionCount = userMention?.maxMentionCount || MAX_USER_MENTION_COUNT;
   const maxUserSuggestionCount = userMention?.maxSuggestionCount || MAX_USER_SUGGESTION_COUNT;
 
@@ -169,7 +169,7 @@ const MessageView = (props: MessageViewProps) => {
   const editMessageInputRef = useRef(null);
   const messageScrollRef = useRef(null);
 
-  const displaySuggestedMentionList = isOnline && isMentionEnabled && mentionNickname.length > 0 && !isDisabledBecauseFrozen(channel) && !isDisabledBecauseMuted(channel);
+  const displaySuggestedMentionList = isOnline && groupChannel.enableMention && mentionNickname.length > 0 && !isDisabledBecauseFrozen(channel) && !isDisabledBecauseMuted(channel);
 
   const mentionNodes = useDirtyGetMentions({ ref: editMessageInputRef }, { logger });
   const ableMention = mentionNodes?.length < maxUserMentionCount;
@@ -320,7 +320,7 @@ const MessageView = (props: MessageViewProps) => {
             disabled={editInputDisabled}
             ref={editMessageInputRef}
             mentionSelectedUser={selectedUser}
-            isMentionEnabled={isMentionEnabled}
+            isMentionEnabled={groupChannel.enableMention}
             message={message}
             onStartTyping={() => {
               channel?.startTyping?.();

--- a/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
@@ -57,7 +57,6 @@ export const MessageInputWrapperView = React.forwardRef((
   // Props
   const {
     currentChannel,
-    isMultipleFilesMessageEnabled: localIsMFMEnabled,
     loading,
     quoteMessage,
     setQuoteMessage,
@@ -77,19 +76,15 @@ export const MessageInputWrapperView = React.forwardRef((
   const { stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
   const { stores, config } = useSendbirdStateContext();
-  const {
-    isOnline,
-    isMentionEnabled,
-    isVoiceMessageEnabled,
-    isMultipleFilesMessageEnabled: globalIsMFMenabled,
-    userMention,
-    logger,
-  } = config;
+  const { isOnline, userMention, logger, groupChannel } = config;
   const sdk = stores.sdkStore.sdk;
   const { maxMentionCount, maxSuggestionCount } = userMention;
 
   const isBroadcast = currentChannel?.isBroadcast;
   const isOperator = currentChannel?.myRole === 'operator';
+  const isMultipleFilesMessageEnabled = props.isMultipleFilesMessageEnabled ?? config.isMultipleFilesMessageEnabled;
+  const isMentionEnabled = groupChannel.enableMention;
+  const isVoiceMessageEnabled = groupChannel.enableVoiceMessage;
 
   // States
   const [mentionNickname, setMentionNickname] = useState('');
@@ -111,7 +106,6 @@ export const MessageInputWrapperView = React.forwardRef((
     && isMentionEnabled
     && mentionNickname.length > 0
     && !isBroadcast;
-  const isMultipleFilesMessageEnabled = localIsMFMEnabled ?? globalIsMFMenabled;
   const mentionNodes = useDirtyGetMentions({ ref: ref || messageInputRef }, { logger });
   const ableMention = mentionNodes?.length < maxMentionCount;
 

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -386,7 +386,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
         isReactionEnabled,
         isMessageGroupingEnabled,
         isMultipleFilesMessageEnabled,
-        showSearchIcon: showSearchIcon ?? config.showSearchIcon,
+        showSearchIcon: showSearchIcon ?? config.groupChannelSettings.enableMessageSearch,
         replyType,
         threadReplySelectType,
         disableMarkAsRead,

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
@@ -52,9 +52,10 @@ export const GroupChannelListItemView = ({
   renderChannelAction,
 }: GroupChannelListItemViewProps) => {
   const { config } = useSendbirdStateContext();
-  const { theme, isMentionEnabled, userId } = config;
+  const { theme, userId } = config;
   const { dateLocale, stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
+  const isMentionEnabled = config.groupChannel.enableMention;
 
   const [showMobileLeave, setShowMobileLeave] = useState(false);
   const onLongPress = useLongPress(

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -55,18 +55,15 @@ export interface GroupChannelListProviderProps
 export const GroupChannelListContext = React.createContext<GroupChannelListContextType>(null);
 export const GroupChannelListProvider = (props: GroupChannelListProviderProps) => {
   const {
-    // Default
     children,
     className = '',
     selectedChannelUrl,
 
-    // Flags
-    allowProfileEdit = true,
     disableAutoSelect = false,
-    isTypingIndicatorEnabled = false,
-    isMessageReceiptStatusEnabled = false,
+    allowProfileEdit,
+    isTypingIndicatorEnabled,
+    isMessageReceiptStatusEnabled,
 
-    // Custom
     channelListQueryParams,
     onThemeChange,
     onChannelSelect = noop,
@@ -75,7 +72,6 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
     onBeforeCreateChannel,
     onUserProfileUpdated,
 
-    // UserProfile
     disableUserProfile,
     renderUserProfile,
     onUserProfileMessage,
@@ -83,7 +79,6 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
   const globalStore = useSendbirdStateContext();
   const { config, stores } = globalStore;
   const { sdkStore } = stores;
-  const { isTypingIndicatorEnabledOnChannelList = false, isMessageReceiptStatusEnabledOnChannelList = false } = config;
 
   const sdk = sdkStore.sdk;
   const isConnected = useOnlineStatus(sdk, config.logger);
@@ -123,25 +118,19 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
   return (
     <GroupChannelListContext.Provider
       value={{
-        // Default
         className,
         selectedChannelUrl,
-        // Flags
-        allowProfileEdit: allowProfileEdit ?? config?.allowProfileEdit,
         disableAutoSelect,
-        isTypingIndicatorEnabled: isTypingIndicatorEnabled ?? isTypingIndicatorEnabledOnChannelList,
-        isMessageReceiptStatusEnabled: isMessageReceiptStatusEnabled ?? isMessageReceiptStatusEnabledOnChannelList,
-        // Essential
+        allowProfileEdit: allowProfileEdit ?? config.allowProfileEdit ?? true,
+        isTypingIndicatorEnabled: isTypingIndicatorEnabled ?? config.groupChannelList.enableTypingIndicator ?? false,
+        isMessageReceiptStatusEnabled: isMessageReceiptStatusEnabled ?? config.groupChannelList.enableMessageReceiptStatus ?? false,
         onChannelSelect,
         onChannelCreated,
-        // Partial props
         onThemeChange,
         onCreateChannelClick,
         onBeforeCreateChannel,
         onUserProfileUpdated,
-        // Internal
         typingChannelUrls,
-        // ReturnType<UseGroupChannelList>
         refreshing,
         initialized,
         groupChannels,
@@ -150,7 +139,7 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
       }}
     >
       <UserProfileProvider
-        disableUserProfile={disableUserProfile ?? config?.disableUserProfile}
+        disableUserProfile={disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
         renderUserProfile={renderUserProfile ?? config?.renderUserProfile}
         onUserProfileMessage={onUserProfileMessage ?? config?.onUserProfileMessage}
       >

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -53,14 +53,9 @@ export default function ParentMessageInfoItem({
   showFileViewer,
   onBeforeDownloadFileMessage = null,
 }: ParentMessageInfoItemProps): ReactElement {
-  const { stores, config, eventHandlers } = useSendbirdStateContext?.() || {};
+  const { stores, config, eventHandlers } = useSendbirdStateContext();
   const { logger } = config;
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
-  const {
-    replyType,
-    isMentionEnabled,
-    isReactionEnabled,
-  } = config;
   const currentUserId = stores?.userStore?.user?.userId;
   const { stringSet } = useLocalization();
   const {
@@ -70,6 +65,10 @@ export default function ParentMessageInfoItem({
     toggleReaction,
   } = useThreadContext();
   const { isMobile } = useMediaQueryContext();
+
+  const isReactionEnabled = config.groupChannel.enableReactions;
+  const isMentionEnabled = config.groupChannel.enableMention;
+
   const threadMessageKindKey = useThreadMessageKindKeySelector({
     threadMessageKind: ThreadMessageKind.PARENT,
     isMobile,
@@ -82,7 +81,7 @@ export default function ParentMessageInfoItem({
 
   // Emoji reactions
   const isReactionActivated = isReactionEnabled
-    && replyType === 'THREAD'
+    && config.groupChannel.replyType === 'thread'
     && message?.reactions?.length > 0;
 
   const tokens = useMemo(() => {

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -28,6 +28,7 @@ import { useMediaQueryContext } from '../../../../lib/MediaQueryContext';
 import useLongPress from '../../../../hooks/useLongPress';
 import MobileMenu from '../../../../ui/MobileMenu';
 import { useDirtyGetMentions } from '../../../Message/hooks/useDirtyGetMentions';
+import { getCaseResolvedReplyType } from '../../../../lib/utils/resolvedReplyType';
 
 export interface ParentMessageInfoProps {
   className?: string;
@@ -37,14 +38,7 @@ export default function ParentMessageInfo({
   className,
 }: ParentMessageInfoProps): React.ReactElement {
   const { stores, config } = useSendbirdStateContext();
-  const {
-    isMentionEnabled,
-    isReactionEnabled,
-    replyType,
-    isOnline,
-    userMention,
-    logger,
-  } = config;
+  const { isOnline, userMention, logger, groupChannel } = config;
   const userId = stores.userStore.user?.userId ?? '';
   const { dateLocale } = useLocalization();
   const {
@@ -66,11 +60,12 @@ export default function ParentMessageInfo({
   const [showRemove, setShowRemove] = useState(false);
   const [supposedHover, setSupposedHover] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
-  const usingReaction = getIsReactionEnabled({
+  const isReactionEnabled = getIsReactionEnabled({
     channel: currentChannel,
     config,
-    moduleLevel: isReactionEnabled,
   });
+  const isMentionEnabled = groupChannel.enableMention;
+  const replyType = getCaseResolvedReplyType(groupChannel.replyType).upperCase;
   const isByMe = userId === parentMessage.sender.userId;
 
   // Mobile
@@ -275,7 +270,7 @@ export default function ParentMessageInfo({
       <div className="sendbird-parent-message-info__content">
         <div className="sendbird-parent-message-info__content__info">
           <Label
-            className={`sendbird-parent-message-info__content__info__sender-name${usingReaction ? '--use-reaction' : ''}`}
+            className={`sendbird-parent-message-info__content__info__sender-name${isReactionEnabled ? '--use-reaction' : ''}`}
             type={LabelTypography.CAPTION_2}
             color={LabelColors.ONBACKGROUND_2}
           >
@@ -302,7 +297,7 @@ export default function ParentMessageInfo({
       {/* context menu */}
       {!isMobile && (
         <MessageItemMenu
-          className={`sendbird-parent-message-info__context-menu ${usingReaction ? 'use-reaction' : ''} ${supposedHover ? 'sendbird-mouse-hover' : ''}`}
+          className={`sendbird-parent-message-info__context-menu ${isReactionEnabled ? 'use-reaction' : ''} ${supposedHover ? 'sendbird-mouse-hover' : ''}`}
           channel={currentChannel}
           message={parentMessage}
           isByMe={userId === parentMessage?.sender?.userId}
@@ -317,7 +312,7 @@ export default function ParentMessageInfo({
           deleteMessage={deleteMessage}
         />
       )}
-      {(usingReaction && !isMobile) && (
+      {(isReactionEnabled && !isMobile) && (
         <MessageItemReactionMenu
           className={`sendbird-parent-message-info__reaction-menu ${supposedHover ? 'sendbird-mouse-hover' : ''}`}
           message={parentMessage}
@@ -365,7 +360,7 @@ export default function ParentMessageInfo({
               ? 'ACTIVE'
               : 'HIDE'
           }
-          isReactionEnabled={usingReaction}
+          isReactionEnabled={isReactionEnabled}
           isByMe={isByMe}
           emojiContainer={emojiContainer}
           showEdit={setShowEditInput}

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -18,6 +18,7 @@ import { Role } from '../../../../lib/types';
 import { useDirtyGetMentions } from '../../../Message/hooks/useDirtyGetMentions';
 import { getIsReactionEnabled } from '../../../../utils/getIsReactionEnabled';
 import { SendableMessageType } from '../../../../utils';
+import { getCaseResolvedReplyType } from '../../../../lib/utils/resolvedReplyType';
 
 export interface ThreadListItemProps {
   className?: string;
@@ -39,14 +40,7 @@ export default function ThreadListItem({
   handleScroll,
 }: ThreadListItemProps): React.ReactElement {
   const { stores, config } = useSendbirdStateContext();
-  const {
-    isReactionEnabled,
-    isMentionEnabled,
-    isOnline,
-    replyType,
-    userMention,
-    logger,
-  } = config;
+  const { isOnline, userMention, logger, groupChannel } = config;
   const userId = stores?.userStore?.user?.userId;
   const { dateLocale, stringSet } = useLocalization();
   const threadContext = useThreadContext?.();
@@ -68,11 +62,12 @@ export default function ThreadListItem({
   const [showEdit, setShowEdit] = useState(false);
   const [showRemove, setShowRemove] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
-  const usingReaction = getIsReactionEnabled({
+  const isReactionEnabled = getIsReactionEnabled({
     channel: currentChannel,
     config,
-    moduleLevel: isReactionEnabled,
   });
+  const isMentionEnabled = groupChannel.enableMention;
+  const replyType = getCaseResolvedReplyType(groupChannel.replyType).upperCase;
 
   // Move to message
   const messageScrollRef = useRef(null);
@@ -238,7 +233,7 @@ export default function ThreadListItem({
         message={message}
         chainTop={chainTop}
         chainBottom={chainBottom}
-        isReactionEnabled={usingReaction}
+        isReactionEnabled={isReactionEnabled}
         isMentionEnabled={isMentionEnabled}
         disableQuoteMessage
         replyType={replyType}

--- a/src/modules/Thread/components/ThreadList/index.tsx
+++ b/src/modules/Thread/components/ThreadList/index.tsx
@@ -10,6 +10,7 @@ import { compareMessagesForGrouping } from '../../../../utils/messages';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { isSameDay } from 'date-fns';
 import { MessageProvider } from '../../../Message/context/MessageProvider';
+import { getCaseResolvedReplyType } from '../../../../lib/utils/resolvedReplyType';
 
 export interface ThreadListProps {
   className?: string;
@@ -32,7 +33,7 @@ export default function ThreadList({
   scrollBottom,
 }: ThreadListProps): React.ReactElement {
   const { config } = useSendbirdStateContext();
-  const { replyType, userId } = config;
+  const { userId } = config;
   const {
     currentChannel,
     allThreadMessages,
@@ -70,7 +71,7 @@ export default function ThreadList({
             message as SendableMessageType,
             nextMessage as SendableMessageType,
             currentChannel,
-            replyType,
+            getCaseResolvedReplyType(config.groupChannel.replyType).upperCase,
           )
           : [false, false];
         const hasSeparator = !(prevMessage?.createdAt > 0 && (
@@ -120,7 +121,7 @@ export default function ThreadList({
             message as SendableMessageType,
             nextMessage as SendableMessageType,
             currentChannel,
-            replyType,
+            getCaseResolvedReplyType(config.groupChannel.replyType).upperCase,
           )
           : [false, false];
         const hasSeparator = !(prevMessage?.createdAt > 0 && (

--- a/src/modules/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/modules/Thread/components/ThreadMessageInput/index.tsx
@@ -42,13 +42,7 @@ const ThreadMessageInput = (
   const { config } = useSendbirdStateContext();
   const { isMobile } = useMediaQueryContext();
   const { stringSet } = useLocalization();
-  const {
-    isMentionEnabled,
-    isOnline,
-    userMention,
-    isVoiceMessageEnabled,
-    logger,
-  } = config;
+  const { isOnline, userMention, logger, groupChannel } = config;
   const threadContext = useThreadContext();
   const {
     currentChannel,
@@ -63,10 +57,9 @@ const ThreadMessageInput = (
   } = threadContext;
   const messageInputRef = useRef();
 
-  const isMultipleFilesMessageEnabled = (
-    threadContext.isMultipleFilesMessageEnabled
-    ?? config.isMultipleFilesMessageEnabled
-  );
+  const isMentionEnabled = groupChannel.enableMention;
+  const isVoiceMessageEnabled = groupChannel.enableVoiceMessage;
+  const isMultipleFilesMessageEnabled = threadContext.isMultipleFilesMessageEnabled ?? config.isMultipleFilesMessageEnabled;
 
   const threadInputDisabled = props.disabled
     || !isOnline

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -93,14 +93,10 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
   const { user } = userStore;
   const sdkInit = sdkStore?.initialized;
   // // config
-  const {
-    logger,
-    pubSub,
-    replyType,
-    isMentionEnabled,
-    isReactionEnabled,
-    onUserProfileMessage,
-  } = config;
+  const { logger, pubSub, onUserProfileMessage } = config;
+
+  const isMentionEnabled = config.groupChannel.enableMention;
+  const isReactionEnabled = config.groupChannel.enableReactions;
 
   // dux of Thread
   const [threadStore, threadDispatcher] = useReducer(
@@ -222,7 +218,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
 
   // memo
   const nicknamesMap: Map<string, string> = useMemo(() => (
-    (replyType && currentChannel)
+    (config.groupChannel.replyType !== 'none' && currentChannel)
       ? getNicknamesMapFromMembers(currentChannel?.members)
       : new Map()
   ), [currentChannel?.members]);
@@ -269,7 +265,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
     >
       {/* UserProfileProvider */}
       <UserProfileProvider
-        disableUserProfile={disableUserProfile ?? config.disableUserProfile}
+        disableUserProfile={disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
         renderUserProfile={renderUserProfile}
         onUserProfileMessage={onUserProfileMessage}
       >

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -63,7 +63,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
   const statefulFileInfoList = useFileInfoListWithUploaded(message); // For MultipleFilesMessage.
 
   const messageTypes = getUIKitMessageTypes();
-  const isOgMessageEnabledInGroupChannel = channel?.isGroupChannel() && config.groupChannel.enableOgtag;
+  const isOgMessageEnabledInGroupChannel = channel?.isGroupChannel() && config?.groupChannel.enableOgtag;
 
   return match(message)
     .when(isTemplateMessage, () => (
@@ -83,7 +83,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         message={message as UserMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
-        isMentionEnabled={config?.isMentionEnabled || false}
+        isMentionEnabled={config?.groupChannel.enableMention ?? false}
         isReactionEnabled={isReactionEnabledInChannel}
         onMessageHeightChange={onMessageHeightChange}
       />
@@ -94,7 +94,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         message={message as UserMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
-        isMentionEnabled={config?.isMentionEnabled || false}
+        isMentionEnabled={config?.groupChannel.enableMention ?? false}
         isReactionEnabled={isReactionEnabledInChannel}
       />
     ))

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -83,7 +83,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         message={message as UserMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
-        isMentionEnabled={config?.groupChannel.enableMention ?? false}
+        isMentionEnabled={config.groupChannel.enableMention ?? false}
         isReactionEnabled={isReactionEnabledInChannel}
         onMessageHeightChange={onMessageHeightChange}
       />
@@ -94,7 +94,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         message={message as UserMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
-        isMentionEnabled={config?.groupChannel.enableMention ?? false}
+        isMentionEnabled={config.groupChannel.enableMention ?? false}
         isReactionEnabled={isReactionEnabledInChannel}
       />
     ))

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -63,7 +63,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
   const statefulFileInfoList = useFileInfoListWithUploaded(message); // For MultipleFilesMessage.
 
   const messageTypes = getUIKitMessageTypes();
-  const isOgMessageEnabledInGroupChannel = channel?.isGroupChannel() && config?.groupChannel.enableOgtag;
+  const isOgMessageEnabledInGroupChannel = channel?.isGroupChannel() && config.groupChannel.enableOgtag;
 
   return match(message)
     .when(isTemplateMessage, () => (


### PR DESCRIPTION
- We agreed with the team to deprecate legacy configs, but since they were not handled, I've deprecated them.
```ts
  /** @deprecated Please use `common.enableUsingDefaultUserProfile` instead * */
  disableUserProfile: boolean;
  /** @deprecated Please use `groupChannel.enableReactions` instead * */
  isReactionEnabled: boolean;
  /** @deprecated Please use `groupChannel.enableMention` instead * */
  isMentionEnabled: boolean;
  /** @deprecated Please use `groupChannel.enableVoiceMessage` instead * */
  isVoiceMessageEnabled?: boolean;
  /** @deprecated Please use `groupChannel.replyType` instead * */
  replyType: ReplyType;
  /** @deprecated Please use `groupChannelSettings.enableMessageSearch` instead * */
  showSearchIcon?: boolean;
  /** @deprecated Please use `groupChannelList.enableTypingIndicator` instead * */
  isTypingIndicatorEnabledOnChannelList?: boolean;
  /** @deprecated Please use `groupChannelList.enableMessageReceiptStatus` instead * */
  isMessageReceiptStatusEnabledOnChannelList?: boolean;
  /** @deprecated Please use setCurrentTheme instead * */
  setCurrenttheme: (theme: 'light' | 'dark') => void;
```
|SendbirdProvider|App|
|--|--|
|<img width="486" alt="스크린샷 2024-04-22 오전 11 50 01" src="https://github.com/sendbird/sendbird-uikit-react/assets/26326015/4191e76a-602a-47bb-9068-08bfcefee39b">|<img width="489" alt="스크린샷 2024-04-22 오전 11 49 48" src="https://github.com/sendbird/sendbird-uikit-react/assets/26326015/fe02fe65-e501-4d8f-91ed-17aceee2cbd0">|


- Below, legacy configs are being transformed as follows:
`legacy configs -> uikit mapper -> uikit configs -> config(sdk state)`
Thus, there's no need to use legacy configs in the config anymore. I've removed the parts of the code using them.
