### PR TITLE
fix: remove unused addon-docs from storybook addons

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,7 @@ module.exports = {
     // '../docs/**/*.@(js|mdx)',
   ],
   addons: [
-    '@storybook/addon-docs',
+    // '@storybook/addon-docs',
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/preset-scss',


### PR DESCRIPTION
The updated TypeScript version is not compatible with the `@storybook/react-docgen-typescript-plugin`.
Removing the unused `addon-docs` in Storybook resolves this issue.