### PR TITLE
feat: added modal.onMounted handler

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,11 +4,13 @@ import type { User, SendbirdChatParams, SendbirdError } from '@sendbird/chat';
 
 import type {
   GroupChannel,
-  GroupChannelCreateParams, GroupChannelModule,
+  GroupChannelCreateParams,
+  GroupChannelModule,
 } from '@sendbird/chat/groupChannel';
 import type {
   OpenChannel,
-  OpenChannelCreateParams, OpenChannelModule,
+  OpenChannelCreateParams,
+  OpenChannelModule,
 } from '@sendbird/chat/openChannel';
 import type {
   FileMessage,
@@ -53,7 +55,10 @@ export interface SBUEventHandlers {
   },
   connection?: {
     onFailed?(error: SendbirdError): void;
-  }
+  },
+  modal?: {
+    onMounted?(params: { id: string; close(): void; }): void | (() => void);
+  };
 }
 
 export interface SendBirdStateConfig {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -34,6 +34,11 @@ export function openURL(url?: string | null) {
   }
 }
 
+type Falsy = undefined | null | false | 0 | '';
+export function classnames(...args: (string | Falsy)[]) {
+  return args.filter(Boolean).join(' ');
+}
+
 export default {
   getSenderName,
   getSenderProfileUrl,


### PR DESCRIPTION
- Added `modal.onMounted` handler to global eventHandlers.
This event handler is triggered within the `useEffect` of the Modal component at mounting time.

---

Example usage
```tsx
const App = () => {
  return (
    <SendbirdProvider
      eventHandlers={{
        modal: {
          onMounted({ id, close }) {
            // Push the state to prevent the browser's back button press
            window.history.pushState({ id }, '');

            // Close the modal if the back button is pressed
            const onPopState = (e: PopStateEvent) => {
              e.preventDefault(); // Prevents the default back action
              close(); // Closes the modal
            };
            window.addEventListener('popstate', onPopState);

            // Cleanup function
            return () => {
              // Clear the current state when the modal is closed without using the back button
              if (window.history.state?.id === id) window.history.back();
              window.removeEventListener('popstate', onPopState);
            };
          }
        }
      }}
    />
  );
};
```

ticket: [CLNP-3057]

[CLNP-3057]: https://sendbird.atlassian.net/browse/CLNP-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ