### PR TITLE
v3.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - v3
 
+## [v3.14.5] (May 04, 2024)
+### Fixes
+* Fixed a bug where channel scroll to bottom is not called internally when last message is updated with suggested replies
+
 ## [v3.14.4] (May 02, 2024)
 ### Features
 * Added `suggestedRepliesDirection` global option which serves as vertical/horizontal scroll option for `SuggestedReplies`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.14.4",
+  "version": "3.14.5",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.14.5] (May 04, 2024)
### Fixes
* Fixed a bug where channel scroll to bottom is not called internally when last message is updated with suggested replies
