### PR TITLE
fix: Attempt to fix a bug where vertical scrolls are blocked in some mobile web environments

### DIFF
--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
@@ -49,6 +49,7 @@
     flex-direction: column;
     height: calc(100% - 64px);
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .sendbird-channel-settings__panel-item {

--- a/src/modules/GroupChannel/components/FileViewer/index.scss
+++ b/src/modules/GroupChannel/components/FileViewer/index.scss
@@ -105,6 +105,7 @@
     height: calc(100% - 72px);
     margin-top: 4px;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/modules/GroupChannel/components/GroupChannelUI/index.scss
+++ b/src/modules/GroupChannel/components/GroupChannelUI/index.scss
@@ -49,6 +49,7 @@
   display: flex;
   height: 100%;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   flex-direction: column;
   .sendbird-conversation__padding {

--- a/src/modules/GroupChannelList/components/GroupChannelListUI/index.scss
+++ b/src/modules/GroupChannelList/components/GroupChannelListUI/index.scss
@@ -30,5 +30,6 @@
   flex: 1 1 0;
   -ms-flex: 1;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
 }

--- a/src/modules/OpenChannel/components/OpenChannelUI/open-channel-ui.scss
+++ b/src/modules/OpenChannel/components/OpenChannelUI/open-channel-ui.scss
@@ -12,6 +12,7 @@
 
   .sendbird-openchannel-conversation-scroll {
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     flex: 1 1 0;
     width: 100%;
   }
@@ -24,6 +25,7 @@
     display: flex;
     height: 100%;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     flex-direction: column;
 

--- a/src/ui/FileViewer/index.scss
+++ b/src/ui/FileViewer/index.scss
@@ -93,6 +93,7 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
     height: calc(100% - 72px);
     margin-top: 4px;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fixes: [AC-2300](https://sendbird.atlassian.net/browse/AC-2300)

This is totally experimental based on finding solutions for similar cases
- https://stackoverflow.com/questions/60445289/css-overflowscroll-does-not-work-on-mobile
- https://stackoverflow.com/questions/13933868/overflow-scrolling-on-android-doesnt-work

### Changelogs
- Attempt to fix a bug where vertical scrolls are blocked in some mobile web environments

[AC-2300]: https://sendbird.atlassian.net/browse/AC-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ