### PR TITLE
fix: Put the files that failed to compress into the compressedFiles

### DIFF
--- a/src/utils/compressImages.ts
+++ b/src/utils/compressImages.ts
@@ -123,6 +123,7 @@ export const compressImages = async ({
           });
           result.compressedFiles.push(compressedImage);
         } catch (err) {
+          result.compressedFiles.push(file);
           result.failedIndexes.push(index);
           logger?.warning('utils - compressImages: Failed to compress image file', { file, err });
         }


### PR DESCRIPTION
[CLNP-3111](https://sendbird.atlassian.net/browse/CLNP-3111)

### Issue
The files are not sent when failing to compress them, because the files that failed to compress have not added into the sending file list.
### Fix
* Put the files that failed to compress into the compressedFiles
### Change log
* Fixed issue where files that failed to compress were not being sent

[CLNP-3111]: https://sendbird.atlassian.net/browse/CLNP-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ