### PR TITLE
[CLNP-3380] chore: add release automation workflow

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,81 @@
+name: Package build and publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version'
+        required: true
+        type: string
+      npm_tag:
+        description: 'release tag'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: 'recursive'
+          fetch-depth: 0
+      - name: Enable corepack
+        run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'yarn'
+      - name: Check if the release branch exists
+        run: |
+          set -x
+          branch_name="release/v${{ github.event.inputs.version }}"
+          if ! git ls-remote --exit-code --heads origin "$branch_name" > /dev/null; then
+            echo "Branch $branch_name does not exist. Make sure to create the branch and create a Jira ticket with pr-comment-bot."
+            exit 1
+          fi
+      - name: Setup jq
+        if: ${{ github.event.inputs.npm_tag }}
+        uses: dcarbone/install-jq-action@v2
+      - name: Update version in package.json if npm_tag is provided
+        if: ${{ github.event.inputs.npm_tag }}
+        run: |
+          npm_version="${{ github.event.inputs.version }}-${{ github.event.inputs.npm_tag }}"
+          jq --arg npm_version "$npm_version" '.version = $npm_version' package.json > package.json.tmp && mv package.json.tmp package.json
+      - name: Set environments
+        run: |
+          git config --global user.name "sendbird-sdk-deployment"
+          git config --global user.email "sha.sdk_deployment@sendbird.com"
+      - name: Install and Build
+        run: |
+          yarn install --immutable --immutable-cache
+          touch .env.production
+          echo "VITE_CHAT_AI_WIDGET_KEY=${{ secrets.chat_ai_widget_key }}" >> .env.production && \
+          yarn build:npm
+      - name: Publish to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" >> .npmrc
+          if [ -z "${{ github.event.inputs.npm_tag }}" ]; then
+            npm publish --access=public
+          else
+            npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public
+            echo "npm_tag is provided; Skipping the rest of the steps."
+            exit 1
+          fi
+
+      - name: Update installed chat-ai-widget version to latest under packages/*
+        run: |
+          packages=( "self-service" )
+          for package in "${packages[@]}"; do
+            cd ./packages/$package
+            yarn add @sendbird/chat-ai-widget@${{ github.event.inputs.version }}
+            cd -
+          done
+          git add .
+          git commit -m "chore: update chat-ai-widget version to v${{ github.event.inputs.version }}"
+          git push origin release/v${{ github.event.inputs.version }}
+      - name: Tag new target and push to origin
+        run: |
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -19,10 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          submodules: 'recursive'
           fetch-depth: 0
-      - name: Enable corepack
-        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
@@ -50,31 +47,18 @@ jobs:
       - name: Install and Build
         run: |
           yarn install --immutable --immutable-cache
-          touch .env.production
-          echo "VITE_CHAT_AI_WIDGET_KEY=${{ secrets.chat_ai_widget_key }}" >> .env.production && \
-          yarn build:npm
+          yarn build
       - name: Publish to npm
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" >> .npmrc
           if [ -z "${{ github.event.inputs.npm_tag }}" ]; then
-            npm publish --access=public
+            yarn npm publish --access=public
           else
-            npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public
+            yarn npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public
             echo "npm_tag is provided; Skipping the rest of the steps."
             exit 1
           fi
-
-      - name: Update installed chat-ai-widget version to latest under packages/*
-        run: |
-          packages=( "self-service" )
-          for package in "${packages[@]}"; do
-            cd ./packages/$package
-            yarn add @sendbird/chat-ai-widget@${{ github.event.inputs.version }}
-            cd -
-          done
-          git add .
-          git commit -m "chore: update chat-ai-widget version to v${{ github.event.inputs.version }}"
-          git push origin release/v${{ github.event.inputs.version }}
+          cd -
       - name: Tag new target and push to origin
         run: |
           git tag v${{ github.event.inputs.version }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Publish to npm
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" >> .npmrc
+          cd dist
           if [ -z "${{ github.event.inputs.npm_tag }}" ]; then
             yarn npm publish --access=public
           else


### PR DESCRIPTION
Our current release steps are like below. 
1. Preparation
  a. Create a release branch; `release/v{version}`
  b. Update package.json
  c. Write CHANGELOG
  d. Push to remote
  e. create a PR
2. Run `/bot create ticket` to create a release ticket and get an approval from a manager
3. Once 2 is done, run `yarn run build` -> `cd dist` -> `yarn npm publish`


This workflow will cover step 3. Step 1 & 2 need to be done manually as we've done.

### How can we trigger the workflow?
<img width="367" alt="Screenshot 2024-05-22 at 4 39 15 PM" src="https://github.com/sendbird/sendbird-uikit-react/assets/10060731/95d0030b-d200-417b-aff2-3520c91195aa">

```mermaid
graph TD
  A[Start: Run workflow] --> B[Check if release branch exists]
  B --> C{npm_tag provided?}
  C -- Yes --> E[Update version in package.json]
  C -- No --> F[Install and Build]
  E --> F
  F --> G[Publish to npm]
  G --> H{npm_tag provided?}
  H -- Yes --> I[Publish with tag] --> End
  H -- No --> J[Publish without tag]
  J --> L[Tag new target and push to origin]
  L --> End
```