### PR TITLE
chore: Auto focus message input on disabled set to false

### DIFF
--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -170,6 +170,16 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     [],
   );
 
+  /**
+   * Whenever user given disabled is set to false, set focus.
+   */
+  useEffect(() => {
+    const textField = internalRef?.current;
+    if (textField && !disabled) {
+      textField.focus();
+    }
+  }, [disabled]);
+
   // #Edit mode
   // for easilly initialize input value from outside, but
   // useEffect(_, [channelUrl]) erase it


### PR DESCRIPTION
### Chore
- Auto focus message input on disabled set to false

related to:
https://github.com/sendbird/chat-ai-widget/pull/237

Fixes: [AC-2293](https://sendbird.atlassian.net/browse/AC-2293)

[Sendbird AI ChatBot (7).webm](https://github.com/sendbird/sendbird-uikit-react/assets/16806397/aa227395-bbc7-4272-ab20-488ae1f3e275)


for some reason recording is now showing. go here instead:
https://sendbird.slack.com/archives/C0585965FFA/p1716450373337189?thread_ts=1716364563.896959&cid=C0585965FFA

[AC-2293]: https://sendbird.atlassian.net/browse/AC-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ