### PR TITLE
fix: retry connect when failed with token expired error

### DIFF
--- a/src/lib/MediaQueryContext.tsx
+++ b/src/lib/MediaQueryContext.tsx
@@ -51,10 +51,8 @@ const MediaQueryProvider = (props: MediaQueryProviderProps): React.ReactElement 
       if (typeof breakpoint === 'boolean') {
         setIsMobile(breakpoint);
         if (breakpoint) {
-          logger?.info?.('MediaQueryProvider: isMobile: true');
           addClassNameToBody();
         } else {
-          logger?.info?.('MediaQueryProvider: isMobile: false');
           removeClassNameFromBody();
         }
       } else {
@@ -63,11 +61,9 @@ const MediaQueryProvider = (props: MediaQueryProviderProps): React.ReactElement 
         if (mq.matches) {
           setIsMobile(true);
           addClassNameToBody();
-          logger?.info?.('MediaQueryProvider: isMobile: true');
         } else {
           setIsMobile(false);
           removeClassNameFromBody();
-          logger?.info?.('MediaQueryProvider: isMobile: false');
         }
       }
     };

--- a/src/lib/hooks/useConnect/__test__/data.mocks.ts
+++ b/src/lib/hooks/useConnect/__test__/data.mocks.ts
@@ -31,6 +31,7 @@ export const mockSdk = {
   updateCurrentUserInfo: jest.fn().mockImplementation((user) => Promise.resolve(user)),
   setSessionHandler: jest.fn(),
   addExtension: jest.fn(),
+  addSendbirdExtensions: jest.fn(),
   getUIKitConfiguration: jest.fn().mockImplementation(() => Promise.resolve({})),
 } as unknown as ConnectTypes['sdk'];
 

--- a/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
+++ b/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
@@ -2,23 +2,19 @@
 /* eslint-disable global-require */
 import { SDK_ACTIONS } from '../../../dux/sdk/actionTypes';
 import { USER_ACTIONS } from '../../../dux/user/actionTypes';
-import { getMissingParamError, setUpConnection, setUpParams } from '../setupConnection';
+import { getMissingParamError, setUpConnection, initSDK, getConnectSbError } from '../setupConnection';
 import { SetupConnectionTypes } from '../types';
 import { generateSetUpConnectionParams, mockSdk, mockUser, mockUser2 } from './data.mocks';
-
 import { SendbirdError } from '@sendbird/chat';
 
 // todo: combine after mock-sdk is implemented
-jest.mock('@sendbird/chat', () => ({
-  init: jest.fn().mockImplementation(() => mockSdk),
-  SendbirdError: jest.fn(),
-}));
-jest.mock('@sendbird/chat/openChannel', () => ({
-  OpenChannelModule: jest.fn(),
-}));
-jest.mock('@sendbird/chat/groupChannel', () => ({
-  GroupChannelModule: jest.fn(),
-}));
+jest.mock('@sendbird/chat', () => {
+  const originalModule = jest.requireActual('@sendbird/chat');
+  return {
+    init: jest.fn(() => mockSdk),
+    ...originalModule,
+  };
+});
 
 describe('useConnect/setupConnection', () => {
   it('should call SDK_ERROR when there is no appId', async () => {
@@ -26,8 +22,7 @@ describe('useConnect/setupConnection', () => {
     const params = { ...setUpConnectionProps, appId: undefined };
     const errorMessage = getMissingParamError({ userId: params.userId, appId: params.appId });
 
-    await expect(setUpConnection((params as unknown as SetupConnectionTypes)))
-      .rejects.toMatch(errorMessage);
+    await expect(setUpConnection(params as unknown as SetupConnectionTypes)).rejects.toMatch(errorMessage);
 
     expect(mockSdk.connect).not.toBeCalledWith({ type: SDK_ACTIONS.SET_SDK_LOADING, payload: true });
     expect(setUpConnectionProps.sdkDispatcher).toBeCalledWith({ type: SDK_ACTIONS.SDK_ERROR });
@@ -38,8 +33,7 @@ describe('useConnect/setupConnection', () => {
     const params = { ...setUpConnectionProps, userId: undefined };
     const errorMessage = getMissingParamError({ userId: params.userId, appId: params.appId });
 
-    await expect(setUpConnection((params as unknown as SetupConnectionTypes)))
-      .rejects.toMatch(errorMessage);
+    await expect(setUpConnection(params as unknown as SetupConnectionTypes)).rejects.toMatch(errorMessage);
 
     expect(setUpConnectionProps.sdkDispatcher).toHaveBeenCalledWith({ type: SDK_ACTIONS.SET_SDK_LOADING, payload: true });
     expect(mockSdk.connect).not.toBeCalledWith({ type: SDK_ACTIONS.SET_SDK_LOADING, payload: true });
@@ -137,8 +131,7 @@ describe('useConnect/setupConnection', () => {
       nickname: newNickname,
       profileUrl: newprofileUrl,
     });
-    expect(mockSdk.updateCurrentUserInfo)
-      .toHaveBeenCalledWith({ nickname: 'newNickname', profileUrl: 'newprofileUrl' });
+    expect(mockSdk.updateCurrentUserInfo).toHaveBeenCalledWith({ nickname: 'newNickname', profileUrl: 'newprofileUrl' });
     expect(setUpConnectionProps.userDispatcher).toHaveBeenCalledWith({
       type: USER_ACTIONS.INIT_USER,
       payload: {
@@ -157,8 +150,7 @@ describe('useConnect/setupConnection', () => {
       appId: setUpConnectionProps.appId,
     });
 
-    await expect(setUpConnection(setUpConnectionProps))
-      .rejects.toMatch(errorMessage);
+    await expect(setUpConnection(setUpConnectionProps)).rejects.toMatch(errorMessage);
 
     expect(setUpConnectionProps.sdkDispatcher).toHaveBeenCalledWith({
       type: SDK_ACTIONS.SDK_ERROR,
@@ -170,15 +162,26 @@ describe('useConnect/setupConnection', () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     setUpConnectionProps.eventHandlers = { connection: { onFailed: onConnectionFailed } };
 
-    // Force a connection failure by providing an invalid userId
-    const params = { ...setUpConnectionProps, userId: undefined };
-    const expectedErrorMessage = getMissingParamError({ userId: undefined, appId: params.appId });
-
+    const error = new Error('test-error');
+    // @ts-expect-error
+    mockSdk.connect.mockRejectedValueOnce(error);
+    const expected = getConnectSbError(error as SendbirdError);
     // // Ensure that the onConnectionFailed callback is called with the correct error message
-    await expect(setUpConnection((params as unknown as SetupConnectionTypes)))
-      .rejects.toBe(expectedErrorMessage);
+    await expect(setUpConnection(setUpConnectionProps)).rejects.toStrictEqual(expected);
     // Ensure that onConnectionFailed callback is called with the expected error object
-    expect(onConnectionFailed).toHaveBeenCalledWith({ message: expectedErrorMessage } as SendbirdError);
+    expect(onConnectionFailed).toHaveBeenCalledWith(error);
+  });
+
+  it('should call onConnected callback when connection succeeded', async () => {
+    const setUpConnectionProps = generateSetUpConnectionParams();
+    setUpConnectionProps.eventHandlers = { connection: { onConnected: jest.fn() } };
+
+    const user = { userId: 'test-user-id', nickname: 'test-nickname', profileUrl: 'test-profile-url' };
+    // @ts-expect-error
+    mockSdk.connect.mockResolvedValueOnce(user);
+
+    await expect(setUpConnection(setUpConnectionProps)).resolves.toStrictEqual(undefined);
+    expect(setUpConnectionProps.eventHandlers.connection.onConnected).toHaveBeenCalledWith(user);
   });
 });
 
@@ -186,7 +189,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
   it('should call init with correct appId', async () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     const { appId, customApiHost, customWebSocketHost } = setUpConnectionProps;
-    const newSdk = setUpParams({ appId, customApiHost, customWebSocketHost });
+    const newSdk = initSDK({ appId, customApiHost, customWebSocketHost });
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,
@@ -205,7 +208,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
   it('should call init with correct customApiHost & customWebSocketHost', async () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     const { appId, customApiHost, customWebSocketHost } = setUpConnectionProps;
-    const newSdk = setUpParams({ appId, customApiHost, customWebSocketHost });
+    const newSdk = initSDK({ appId, customApiHost, customWebSocketHost });
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,
@@ -226,7 +229,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
   it('should call init with sdkInitParams', async () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     const { appId, sdkInitParams } = setUpConnectionProps;
-    const newSdk = setUpParams({ appId, sdkInitParams });
+    const newSdk = initSDK({ appId, sdkInitParams });
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,
@@ -246,7 +249,7 @@ describe('useConnect/setupConnection/setUpParams', () => {
   it('should call init with customExtensionParams', async () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     const { appId, customExtensionParams } = setUpConnectionProps;
-    const newSdk = setUpParams({ appId, customExtensionParams });
+    const newSdk = initSDK({ appId, customExtensionParams });
     // @ts-ignore
     expect(require('@sendbird/chat').init).toBeCalledWith({
       appId,

--- a/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
+++ b/src/lib/hooks/useConnect/__test__/setupConnection.spec.ts
@@ -185,7 +185,7 @@ describe('useConnect/setupConnection', () => {
   });
 });
 
-describe('useConnect/setupConnection/setUpParams', () => {
+describe('useConnect/setupConnection/initSDK', () => {
   it('should call init with correct appId', async () => {
     const setUpConnectionProps = generateSetUpConnectionParams();
     const { appId, customApiHost, customWebSocketHost } = setUpConnectionProps;

--- a/src/lib/hooks/useConnect/index.ts
+++ b/src/lib/hooks/useConnect/index.ts
@@ -22,7 +22,6 @@ export default function useConnect(triggerTypes: TriggerTypes, staticTypes: Stat
     eventHandlers,
     initializeMessageTemplatesInfo,
   } = staticTypes;
-  logger?.info?.('SendbirdProvider | useConnect', { ...triggerTypes, ...staticTypes });
 
   // Note: This is a workaround to prevent the creation of multiple SDK instances when React strict mode is enabled.
   const connectDeps = useRef<{ appId: string, userId: string }>({

--- a/src/lib/hooks/useConnect/setupConnection.ts
+++ b/src/lib/hooks/useConnect/setupConnection.ts
@@ -1,4 +1,13 @@
-import SendbirdChat, { DeviceOsPlatform, SendbirdError, SendbirdPlatform, SendbirdProduct, User } from '@sendbird/chat';
+import SendbirdChat, {
+  DeviceOsPlatform,
+  SendbirdChatWith,
+  SendbirdError,
+  SendbirdErrorCode,
+  SendbirdPlatform,
+  SendbirdProduct,
+  SessionHandler,
+  User,
+} from '@sendbird/chat';
 import { OpenChannelModule } from '@sendbird/chat/openChannel';
 import { GroupChannelModule } from '@sendbird/chat/groupChannel';
 
@@ -9,43 +18,18 @@ import { isTextuallyNull } from '../../../utils';
 
 import { SetupConnectionTypes } from './types';
 import { CustomExtensionParams, SendbirdChatInitParams } from '../../types';
+import { LoggerInterface } from '../../Logger';
 
 const APP_VERSION_STRING = '__react_dev_mode__';
 
 const { INIT_SDK, SET_SDK_LOADING, RESET_SDK, SDK_ERROR } = SDK_ACTIONS;
 const { INIT_USER, UPDATE_USER_INFO, RESET_USER } = USER_ACTIONS;
 
-export function getMissingParamError({ userId, appId }: { userId?: string, appId?: string }): string {
+export function getMissingParamError({ userId, appId }: { userId?: string; appId?: string }): string {
   return `SendbirdProvider | useConnect/setupConnection/Connection failed UserId: ${userId} or appId: ${appId} missing`;
 }
 export function getConnectSbError(error?: SendbirdError): string {
   return `SendbirdProvider | useConnect/setupConnection/Connection failed. ${error?.code || ''} ${error?.message || ''}`;
-}
-
-export function setUpParams({
-  appId,
-  isNewApp = false,
-  customApiHost,
-  customWebSocketHost,
-  sdkInitParams = {},
-}: {
-  appId: string;
-  isNewApp?: boolean;
-  customApiHost?: string;
-  customWebSocketHost?: string;
-  sdkInitParams?: SendbirdChatInitParams;
-  customExtensionParams?: CustomExtensionParams;
-}) {
-  const params = Object.assign(sdkInitParams, {
-    appId,
-    modules: [new GroupChannelModule(), new OpenChannelModule()],
-    newInstance: isNewApp,
-    localCacheEnabled: true,
-  });
-
-  if (customApiHost) params.customApiHost = customApiHost;
-  if (customWebSocketHost) params.customWebSocketHost = customWebSocketHost;
-  return SendbirdChat.init(params);
 }
 
 // Steps
@@ -82,126 +66,185 @@ export async function setUpConnection({
   initializeMessageTemplatesInfo,
 }: SetupConnectionTypes): Promise<void> {
   return new Promise((resolve, reject) => {
-    logger?.info?.('SendbirdProvider | useConnect/setupConnection/init', { userId, appId });
-    const onConnectionFailed = eventHandlers?.connection?.onFailed;
+    logger.info?.('SendbirdProvider | useConnect/setupConnection/init', { userId, appId });
     sdkDispatcher({ type: SET_SDK_LOADING, payload: true });
 
     if (userId && appId) {
-      const newSdk = setUpParams({
-        appId,
-        customApiHost,
-        customWebSocketHost,
-        isNewApp,
-        sdkInitParams,
-      });
+      logger.info?.(`SendbirdProvider | useConnect/setupConnection/connect connecting using ${accessToken ?? userId}`);
 
-      if (configureSession && typeof configureSession === 'function') {
-        const sessionHandler = configureSession(newSdk);
-        logger?.info?.('SendbirdProvider | useConnect/setupConnection/configureSession', sessionHandler);
-        newSdk.setSessionHandler(sessionHandler);
-      }
+      const sdk = initSDK({ appId, customApiHost, customWebSocketHost, isNewApp, sdkInitParams });
+      const sessionHandler = typeof configureSession === 'function' ? configureSession(sdk) : undefined;
+      setupSDK(sdk, { logger, sessionHandler, customExtensionParams, isMobile });
 
-      logger?.info?.('SendbirdProvider | useConnect/setupConnection/setVersion', { version: APP_VERSION_STRING });
-      /**
-       * Keep optional chaining to the addSendbirdExtensions
-       * for supporting the ChatSDK v4.9.5 or less
-       */
-      newSdk?.addSendbirdExtensions?.(
-        [
-          {
-            product: SendbirdProduct?.UIKIT_CHAT ?? 'uikit-chat' as SendbirdProduct,
-            version: APP_VERSION_STRING,
-            platform: SendbirdPlatform?.JS ?? 'js' as SendbirdPlatform,
-          },
-        ],
-        {
-          platform: (isMobile
-            ? DeviceOsPlatform?.MOBILE_WEB ?? 'mobile_web'
-            : DeviceOsPlatform?.WEB ?? 'web') as DeviceOsPlatform,
-        },
-        customExtensionParams,
-      );
+      sdk
+        .connect(userId, accessToken)
+        .then((user) => onConnected(user))
+        .catch(async (error) => {
+          if (sdk.isCacheEnabled && shouldClearCache(error)) {
+            logger.error?.(`SendbirdProvider | useConnect/setupConnection/connect clear cache [${error.code}/${error.message}]`);
+            await sdk.clearCachedData();
+          }
 
-      newSdk.addExtension('sb_uikit', APP_VERSION_STRING);
+          // NOTE: The part that connects via the SDK must be callable directly by the customer.
+          //  we should refactor this in next major version.
+          if (shouldRetryWithValidSessionToken(error) && sessionHandler) {
+            try {
+              const sessionToken = await new Promise(sessionHandler.onSessionTokenRequired);
+              if (sessionToken) {
+                logger.info?.(
+                  `SendbirdProvider | useConnect/setupConnection/connect retry connect with valid session token: ${sessionToken.slice(0, 10) + '...'}`,
+                );
+                const user = await sdk.connect(userId, sessionToken);
+                return onConnected(user);
+              }
+            } catch (error) {
+              return onConnectFailed(error);
+            }
+          }
 
-      const connectCbSuccess = async (user: User) => {
-        logger?.info?.('SendbirdProvider | useConnect/setupConnection/connectCbSuccess', user);
-        sdkDispatcher({ type: INIT_SDK, payload: newSdk });
+          return onConnectFailed(error);
+        });
+
+      const onConnected = async (user: User) => {
+        logger.info?.('SendbirdProvider | useConnect/setupConnection/onConnected', user);
+        sdkDispatcher({ type: INIT_SDK, payload: sdk });
         userDispatcher({ type: INIT_USER, payload: user });
 
         try {
-          await initializeMessageTemplatesInfo(newSdk);
+          await initializeMessageTemplatesInfo(sdk);
         } catch (error) {
-          logger?.error?.('SendbirdProvider | useConnect/setupConnection/upsertMessageTemplateListInLocalStorage failed', {
-            error,
-          });
+          logger.error?.('SendbirdProvider | useConnect/setupConnection/upsertMessageTemplateListInLocalStorage failed', { error });
         }
 
-        initDashboardConfigs(newSdk)
-          .then(config => {
-            logger?.info?.('SendbirdProvider | useConnect/setupConnection/getUIKitConfiguration success', {
-              config,
-            });
-          })
-          .catch(error => {
-            logger?.error?.('SendbirdProvider | useConnect/setupConnection/getUIKitConfiguration failed', {
-              error,
-            });
-          });
-
-        // use nickname/profileUrl if provided
-        // or set userID as nickname
-        if ((nickname !== user.nickname || profileUrl !== user.profileUrl)
-          && !(isTextuallyNull(nickname) && isTextuallyNull(profileUrl))
-        ) {
-          logger?.info?.('SendbirdProvider | useConnect/setupConnection/updateCurrentUserInfo', {
-            nickname,
-            profileUrl,
-          });
-          newSdk.updateCurrentUserInfo({
-            nickname: nickname || user.nickname || (isUserIdUsedForNickname ? user.userId : ''),
-            profileUrl: profileUrl || user.profileUrl,
-          }).then((namedUser) => {
-            logger?.info?.('SendbirdProvider | useConnect/setupConnection/updateCurrentUserInfo success', {
-              nickname,
-              profileUrl,
-            });
-            userDispatcher({ type: UPDATE_USER_INFO, payload: namedUser });
-          }).finally(() => {
-            resolve();
-          });
-        } else {
-          resolve();
+        try {
+          await initDashboardConfigs(sdk);
+          logger.info?.('SendbirdProvider | useConnect/setupConnection/getUIKitConfiguration success');
+        } catch (error) {
+          logger.error?.('SendbirdProvider | useConnect/setupConnection/getUIKitConfiguration failed', { error });
         }
+
+        try {
+          // use nickname/profileUrl if provided or set userID as nickname
+          if (
+            (nickname !== user.nickname || profileUrl !== user.profileUrl)
+            && !(isTextuallyNull(nickname) && isTextuallyNull(profileUrl))
+          ) {
+            logger.info?.('SendbirdProvider | useConnect/setupConnection/updateCurrentUserInfo', { nickname, profileUrl });
+            const updateParams = {
+              nickname: nickname || user.nickname || (isUserIdUsedForNickname ? user.userId : ''),
+              profileUrl: profileUrl || user.profileUrl,
+            };
+
+            const updatedUser = await sdk.updateCurrentUserInfo(updateParams);
+            logger.info?.('SendbirdProvider | useConnect/setupConnection/updateCurrentUserInfo success', updateParams);
+            userDispatcher({ type: UPDATE_USER_INFO, payload: updatedUser });
+          }
+        } catch {
+          // NO-OP
+        }
+
+        resolve();
+        eventHandlers?.connection?.onConnected?.(user);
       };
 
-      const connectCbError = (e: SendbirdError) => {
+      const onConnectFailed = (e: SendbirdError) => {
         const errorMessage = getConnectSbError(e);
-        logger?.error?.(errorMessage, {
-          e,
-          appId,
-          userId,
-        });
-        sdkDispatcher({ type: RESET_SDK });
+        logger.error?.(errorMessage, { e, appId, userId });
         userDispatcher({ type: RESET_USER });
-
+        sdkDispatcher({ type: RESET_SDK });
         sdkDispatcher({ type: SDK_ERROR });
-        onConnectionFailed?.(e);
-        // exit promise with error
-        reject(errorMessage);
-      };
 
-      logger?.info?.(`SendbirdProvider | useConnect/setupConnection/connect connecting using ${accessToken ?? userId}`);
-      newSdk.connect(userId, accessToken)
-        .then((res) => connectCbSuccess(res))
-        .catch((err) => connectCbError(err));
+        reject(errorMessage);
+        eventHandlers?.connection?.onFailed?.(e);
+      };
     } else {
       const errorMessage = getMissingParamError({ userId, appId });
+      const error = new Error(errorMessage);
+      logger.error?.(error.message);
       sdkDispatcher({ type: SDK_ERROR });
-      onConnectionFailed?.({ message: errorMessage } as SendbirdError);
-      logger?.error?.(errorMessage);
-      // exit promise with error
+
       reject(errorMessage);
     }
   });
+}
+
+/**
+ * Initializes the Sendbird SDK with the provided parameters.
+ * */
+export function initSDK({
+  appId,
+  isNewApp = false,
+  customApiHost,
+  customWebSocketHost,
+  sdkInitParams = {},
+}: {
+  appId: string;
+  isNewApp?: boolean;
+  customApiHost?: string;
+  customWebSocketHost?: string;
+  sdkInitParams?: SendbirdChatInitParams;
+  customExtensionParams?: CustomExtensionParams;
+}) {
+  const params = Object.assign(sdkInitParams, {
+    appId,
+    modules: [new GroupChannelModule(), new OpenChannelModule()],
+    newInstance: isNewApp,
+    localCacheEnabled: true,
+  });
+
+  if (customApiHost) params.customApiHost = customApiHost;
+  if (customWebSocketHost) params.customWebSocketHost = customWebSocketHost;
+  return SendbirdChat.init(params);
+}
+
+/**
+ * Sets up the Sendbird SDK after initialization.
+ * Configures necessary settings, adds extensions, sets the platform, and configures the session handler if provided.
+ */
+function setupSDK(
+  sdk: SendbirdChatWith<[GroupChannelModule, OpenChannelModule]>,
+  params: { logger: LoggerInterface; sessionHandler?: SessionHandler; isMobile?: boolean; customExtensionParams?: CustomExtensionParams },
+) {
+  const { logger, sessionHandler, isMobile, customExtensionParams } = params;
+
+  logger.info?.('SendbirdProvider | useConnect/setupConnection/setVersion', { version: APP_VERSION_STRING });
+  sdk.addExtension('sb_uikit', APP_VERSION_STRING);
+  sdk.addSendbirdExtensions(
+    [{ product: SendbirdProduct.UIKIT_CHAT, version: APP_VERSION_STRING, platform: SendbirdPlatform?.JS }],
+    { platform: isMobile ? DeviceOsPlatform.MOBILE_WEB : DeviceOsPlatform.WEB },
+    customExtensionParams,
+  );
+  if (sessionHandler) {
+    logger.info?.('SendbirdProvider | useConnect/setupConnection/configureSession', sessionHandler);
+    sdk.setSessionHandler(sessionHandler);
+  }
+}
+
+function shouldClearCache(error: unknown): error is SendbirdError {
+  if (!(error instanceof SendbirdError)) return false;
+
+  return [
+    SendbirdErrorCode.USER_AUTH_DEACTIVATED,
+    SendbirdErrorCode.USER_AUTH_DELETED_OR_NOT_FOUND,
+    SendbirdErrorCode.SESSION_TOKEN_EXPIRED,
+    SendbirdErrorCode.SESSION_REVOKED,
+  ].includes(error.code);
+}
+
+function shouldRetryWithValidSessionToken(error: unknown): error is SendbirdError {
+  if (!(error instanceof SendbirdError)) return false;
+
+  return [
+    SendbirdErrorCode.SESSION_TOKEN_EXPIRED,
+    /**
+     * Note: INVALID_TOKEN has been added arbitrarily due to legacy constraints
+     *
+     * In the useEffect of the useConnect hook, authentication is being performed
+     * but changes of the `accessToken` is not being detected.
+     * `disconnectSdk` is called when connect is called redundantly for the same user ID, causing issues, so `accessToken` has been excluded form the deps.
+     *
+     * In case the `accessToken` is missed, an additional attempt to connect is made
+     * */
+    SendbirdErrorCode.INVALID_TOKEN,
+  ].includes(error.code);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface SBUEventHandlers {
     onPressUserProfile?(member: User): void;
   },
   connection?: {
+    onConnected?(user: User): void;
     onFailed?(error: SendbirdError): void;
   },
   modal?: {


### PR DESCRIPTION
## Changes
- When attempting to `connect` with an expired or invalid session token, an error will be returned.
In such cases, the error message is checked, and if a `SessionHandler` is available, it will extract a valid session token and retry the `connect`.
- The `eventHandlers.connection.onFailed(SendbirdError)` will not be called when userId and appId are missing.
This should not be triggered as it is not related to connection errors. (In the first place, this logic should not be reached without an app ID and user ID.)
- Added `eventHandlers.connection.onConnected(User)`


## Recording
https://github.com/sendbird/sendbird-uikit-react/assets/26326015/ab529a97-7fe8-4e47-aa2c-9047886f22c8


- ticket: [AC-2476]





[AC-2476]: https://sendbird.atlassian.net/browse/AC-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ