### PR TITLE
fix: add workaround to reset IME in mobile webkit

### DIFF
--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -133,6 +133,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
   } = props;
 
   const internalRef = (externalRef && 'current' in externalRef) ? externalRef : null;
+  const ghostInputRef = useRef<HTMLInputElement>(null);
 
   const textFieldId = messageFieldId || TEXT_FIELD_ID;
   const { stringSet } = useLocalization();
@@ -394,8 +395,19 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       const params = { message: messageText, mentionTemplate };
       onSendMessage(params);
       resetInput(internalRef);
-      // important: keeps the keyboard open -> must add test on refactor
-      textField.focus();
+
+      /**
+       * Note: contentEditable does not work as expected in mobile WebKit (Safari).
+       * @see https://github.com/sendbird/sendbird-uikit-react/pull/1108
+       */
+      if (isMobileIOS(navigator.userAgent)) {
+        if (ghostInputRef.current) ghostInputRef.current.focus();
+        requestAnimationFrame(() => textField.focus());
+      } else {
+        // important: keeps the keyboard open -> must add test on refactor
+        textField.focus();
+      }
+
       setIsInput(false);
       setHeight();
     }
@@ -426,6 +438,14 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       disabled && 'sendbird-message-input-form__disabled',
     )}>
       <div className={classnames('sendbird-message-input', disabled && 'sendbird-message-input__disabled')} data-testid="sendbird-message-input">
+        {isMobileIOS(navigator.userAgent) && (
+          <input
+            id={'ghost-input-reset-ime-cjk'}
+            ref={ghostInputRef}
+            style={{ opacity: 0, padding: 0, margin: 0, height: 0, border: 'none', position: 'absolute', top: -9999 }}
+            defaultValue={'_'}
+          />
+        )}
         <div
           id={`${textFieldId}${isEdit ? message?.messageId : ''}`}
           className={`sendbird-message-input--textarea ${textFieldId}`}
@@ -455,16 +475,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
                  * Prevents executing the code while the user is still composing characters.
                  */
               ) {
-                /**
-                 * NOTE: contentEditable does not work as expected in mobile WebKit(Safari).
-                 * Events and properties related to composing, necessary for combining characters like Hangul, also seem to be not handled properly.
-                 * When calling e.preventDefault(), it appears that string composition-related behaviors, in addition to the default actions, are also prevented. (maybe)
-                 *
-                 * Due to this issue, even though reset the input with innerHTML, incomplete text compositions from the previous input are displayed in the next input.
-                 * */
-                if (!isMobileIOS(navigator.userAgent)) {
-                  e.preventDefault();
-                }
+                e.preventDefault();
                 sendMessage();
               }
               if (


### PR DESCRIPTION
## Description
contentEditable does not work as expected in mobile WebKit (Safari).
Events and properties related to composing, necessary for combining characters like Hangul, do not seem to be passed to IME properly.

When resetting the input with innerHTML, the previous context should be cleared.
However, if the last text of the previous input was a composable string, it appears in the next input.

1. If the last string is not a composable string, it is not affected. This is why preventing the `e.preventDefault()` call when sending a message with Enter prevents the bug, as the Enter (newline) string is the last text in the IME context and is not affected by this bug.
2. The bug can be avoided by resetting the IME context(blur or moving caret) of the last string. This is similar to how moving the cursor while typing Hangul breaks the composition.

## Changes
In this PR, an attempt is made to reset by moving keyboard focus to another input, and it operates as follows:

1. A ghost input, which is not visible in the UI but selectable via focus, is created.
2. After sending the text and resetting with innerHTML, focus immediately shifts to the ghost input:
   - To prevent the iPhone's virtual keyboard from closing:
   - Changing keyboard focus causes the loss of context for the composing IME string.
   - Using `requestAnimationFrame` to move focus back to the original input:
     - To prevent the change of focus from being treated as input → ghost input → input too quickly, without allowing a minimum interval.
     - Using `setTimeout` or similar causes delays due to waiting for the event loop, resulting in the phenomenon of the virtual keyboard going up and down. Therefore, `requestAnimationFrame`, associated with the browser's cycle of drawing new frames, is used.
3. Focus is then returned to the original input.

## Restrictions
The above approach only applies to input from the `Virtual Keyboard` (like an iPhone keyboard).
The issue still persists when typing using a `Keyboard` in the mobile device.

ticket: [CLNP-3470]

[CLNP-3470]: https://sendbird.atlassian.net/browse/CLNP-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ