### PR TITLE
fix: Use await inside of the Component, not in global scope

### DIFF
--- a/src/stories/common/getSampleChannel.ts
+++ b/src/stories/common/getSampleChannel.ts
@@ -1,34 +1,40 @@
+import { useState } from "react";
 import SendbirdChat from "@sendbird/chat";
 import { GroupChannel, GroupChannelListOrder, GroupChannelModule } from "@sendbird/chat/groupChannel";
 import { OpenChannelModule } from "@sendbird/chat/openChannel";
+import { useAsyncEffect } from "@sendbird/uikit-tools";
 
 interface GetSampleChannelParams {
   appId: string;
   userId: string;
 }
-export const getSampleChannel = async ({
+export const getSampleChannel = ({
   appId,
   userId,
-}: GetSampleChannelParams): Promise<GroupChannel> => {
-  try {
-    const chat = SendbirdChat.init({
-      appId,
-      modules: [new GroupChannelModule, new OpenChannelModule],
-    });
+}: GetSampleChannelParams): GroupChannel | null => {
+  const [channel, setChannel] = useState<GroupChannel | null>(null);
+  useAsyncEffect(async () => {
+    try {
+      const chat = SendbirdChat.init({
+        appId,
+        modules: [new GroupChannelModule, new OpenChannelModule],
+      });
 
-    await chat.connect(userId);
-    const query = chat.groupChannel.createMyGroupChannelListQuery({ limit: 1, order: GroupChannelListOrder.LATEST_LAST_MESSAGE });
-    const channelList = await query.next();
+      await chat.connect(userId);
+      const query = chat.groupChannel.createMyGroupChannelListQuery({ limit: 1, order: GroupChannelListOrder.LATEST_LAST_MESSAGE });
+      const channelList = await query.next();
 
-    if (channelList.length > 0) {
-      return channelList[0];
-    } {
-      const query = chat.createApplicationUserListQuery({ limit: 10 });
-      const userList = await query.next();
-      const newChannel = await chat.groupChannel.createChannel({ invitedUserIds: userList.map(user => user.userId) });
-      return newChannel;
+      if (channelList.length > 0) {
+        setChannel(channelList[0]);
+      } {
+        const query = chat.createApplicationUserListQuery({ limit: 10 });
+        const userList = await query.next();
+        const newChannel = await chat.groupChannel.createChannel({ invitedUserIds: userList.map(user => user.userId) });
+        setChannel(newChannel);
+      }
+    } catch (err) {
+      console.warn('Sendbird storybook - getSampleChannel: ', err);
     }
-  } catch (err) {
-    console.warn('Sendbird storybook - getSampleChannel: ', err);
-  }
+  }, []);
+  return channel;
 };

--- a/src/stories/common/useSampleChannel.ts
+++ b/src/stories/common/useSampleChannel.ts
@@ -3,15 +3,16 @@ import SendbirdChat from "@sendbird/chat";
 import { GroupChannel, GroupChannelListOrder, GroupChannelModule } from "@sendbird/chat/groupChannel";
 import { OpenChannelModule } from "@sendbird/chat/openChannel";
 import { useAsyncEffect } from "@sendbird/uikit-tools";
+import { STORYBOOK_APP_ID, STORYBOOK_USER_ID } from '../common/const';
 
-interface UseSampleChannelParams {
-  appId: string;
-  userId: string;
+type UseSampleChannelParams = {
+  appId?: string;
+  userId?: string;
 }
 export const useSampleChannel = ({
-  appId,
-  userId,
-}: UseSampleChannelParams): GroupChannel | null => {
+  appId = STORYBOOK_APP_ID,
+  userId = STORYBOOK_USER_ID,
+}: UseSampleChannelParams = {}): GroupChannel | null => {
   const [channel, setChannel] = useState<GroupChannel | null>(null);
   useAsyncEffect(async () => {
     try {

--- a/src/stories/common/useSampleChannel.ts
+++ b/src/stories/common/useSampleChannel.ts
@@ -4,14 +4,14 @@ import { GroupChannel, GroupChannelListOrder, GroupChannelModule } from "@sendbi
 import { OpenChannelModule } from "@sendbird/chat/openChannel";
 import { useAsyncEffect } from "@sendbird/uikit-tools";
 
-interface GetSampleChannelParams {
+interface UseSampleChannelParams {
   appId: string;
   userId: string;
 }
-export const getSampleChannel = ({
+export const useSampleChannel = ({
   appId,
   userId,
-}: GetSampleChannelParams): GroupChannel | null => {
+}: UseSampleChannelParams): GroupChannel | null => {
   const [channel, setChannel] = useState<GroupChannel | null>(null);
   useAsyncEffect(async () => {
     try {
@@ -33,7 +33,7 @@ export const getSampleChannel = ({
         setChannel(newChannel);
       }
     } catch (err) {
-      console.warn('Sendbird storybook - getSampleChannel: ', err);
+      console.warn('Sendbird storybook - useSampleChannel: ', err);
     }
   }, []);
   return channel;

--- a/src/stories/modules/ChannelSettings.stories.tsx
+++ b/src/stories/modules/ChannelSettings.stories.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import ChannelSettings from '../../modules/ChannelSettings';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
+import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof ChannelSettings> = {
   title: '1.Module/ChannelSettings',
@@ -74,7 +75,13 @@ const meta: Meta<typeof ChannelSettings> = {
 };
 export default meta;
 
-export const Default = (args): React.ReactElement => {
+export const Default = (): React.ReactElement => {
+  const [channelUrl, setChannelUrl] = useState('');
+  useAsyncEffect(async () => {
+    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+    setChannelUrl(channel.url);
+  }, []);
+
   return (
     <div style={{ height: 500 }}>
       <SendbirdProvider
@@ -84,14 +91,10 @@ export const Default = (args): React.ReactElement => {
         breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
       >
         <ChannelSettings
-          {...args}
+          channelUrl={channelUrl}
+          disableUserProfile={false}
         />
       </SendbirdProvider>
     </div>
   );
-};
-const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-Default.args = {
-  channelUrl: channel.url,
-  disableUserProfile: false,
 };

--- a/src/stories/modules/ChannelSettings.stories.tsx
+++ b/src/stories/modules/ChannelSettings.stories.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import ChannelSettings from '../../modules/ChannelSettings';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
-import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof ChannelSettings> = {
   title: '1.Module/ChannelSettings',
@@ -76,11 +75,7 @@ const meta: Meta<typeof ChannelSettings> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const [channelUrl, setChannelUrl] = useState('');
-  useAsyncEffect(async () => {
-    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-    setChannelUrl(channel.url);
-  }, []);
+  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 500 }}>
@@ -91,7 +86,7 @@ export const Default = (): React.ReactElement => {
         breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
       >
         <ChannelSettings
-          channelUrl={channelUrl}
+          channelUrl={channel?.url ?? ''}
           disableUserProfile={false}
         />
       </SendbirdProvider>

--- a/src/stories/modules/ChannelSettings.stories.tsx
+++ b/src/stories/modules/ChannelSettings.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import SendbirdProvider from '../../lib/Sendbird';
 import ChannelSettings from '../../modules/ChannelSettings';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
-import { getSampleChannel } from '../common/getSampleChannel';
+import { useSampleChannel } from '../common/useSampleChannel';
 
 const meta: Meta<typeof ChannelSettings> = {
   title: '1.Module/ChannelSettings',
@@ -75,7 +75,7 @@ const meta: Meta<typeof ChannelSettings> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 500 }}>

--- a/src/stories/modules/ChannelSettings.stories.tsx
+++ b/src/stories/modules/ChannelSettings.stories.tsx
@@ -75,7 +75,7 @@ const meta: Meta<typeof ChannelSettings> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel();
 
   return (
     <div style={{ height: 500 }}>

--- a/src/stories/modules/GroupChannel.stories.tsx
+++ b/src/stories/modules/GroupChannel.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import SendbirdProvider from '../../lib/Sendbird';
 import GroupChannel from '../../modules/GroupChannel';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
-import { getSampleChannel } from '../common/getSampleChannel';
+import { useSampleChannel } from '../common/useSampleChannel';
 
 const meta: Meta<typeof GroupChannel> = { 
   title: '1.Module/GroupChannel',
@@ -104,7 +104,7 @@ const meta: Meta<typeof GroupChannel> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 500 }}>

--- a/src/stories/modules/GroupChannel.stories.tsx
+++ b/src/stories/modules/GroupChannel.stories.tsx
@@ -104,7 +104,7 @@ const meta: Meta<typeof GroupChannel> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel();
 
   return (
     <div style={{ height: 500 }}>

--- a/src/stories/modules/GroupChannel.stories.tsx
+++ b/src/stories/modules/GroupChannel.stories.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import GroupChannel from '../../modules/GroupChannel';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
+import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof GroupChannel> = { 
   title: '1.Module/GroupChannel',
@@ -103,7 +104,13 @@ const meta: Meta<typeof GroupChannel> = {
 };
 export default meta;
 
-export const Default = (args): React.ReactElement => {
+export const Default = (): React.ReactElement => {
+  const [channelUrl, setChannelUrl] = useState('');
+  useAsyncEffect(async () => {
+    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+    setChannelUrl(channel.url);
+  }, []);
+
   return (
     <div style={{ height: 500 }}>
       <SendbirdProvider
@@ -113,20 +120,17 @@ export const Default = (args): React.ReactElement => {
         breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
       >
         <GroupChannel
-          {...args}
+          {...{
+            channelUrl,
+            isReactionEnabled: true,
+            isMessageGroupingEnabled: true,
+            showSearchIcon: true,
+            replyType: 'THREAD',
+            isMultipleFilesMessageEnabled: true,
+            disableUserProfile: false,
+          }}
         />
       </SendbirdProvider>
     </div>
   );
-};
-const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-Default.args = {
-  channelUrl: channel.url,
-  isReactionEnabled: true,
-  isMessageGroupingEnabled: true,
-  showSearchIcon: true,
-  replyType: 'THREAD',
-  threadReplySelectType: 'THREAD',
-  isMultipleFilesMessageEnabled: true,
-  disableUserProfile: false,
 };

--- a/src/stories/modules/GroupChannel.stories.tsx
+++ b/src/stories/modules/GroupChannel.stories.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import GroupChannel from '../../modules/GroupChannel';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID, STORYBOOK_NICKNAME } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
-import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof GroupChannel> = { 
   title: '1.Module/GroupChannel',
@@ -105,11 +104,7 @@ const meta: Meta<typeof GroupChannel> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const [channelUrl, setChannelUrl] = useState('');
-  useAsyncEffect(async () => {
-    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-    setChannelUrl(channel.url);
-  }, []);
+  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 500 }}>
@@ -121,7 +116,7 @@ export const Default = (): React.ReactElement => {
       >
         <GroupChannel
           {...{
-            channelUrl,
+            channelUrl: channel?.url ?? '',
             isReactionEnabled: true,
             isMessageGroupingEnabled: true,
             showSearchIcon: true,

--- a/src/stories/modules/MessageSearch.stories.tsx
+++ b/src/stories/modules/MessageSearch.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import SendbirdProvider from '../../lib/Sendbird';
 import MessageSearch from '../../modules/MessageSearch';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID } from '../common/const';
-import { getSampleChannel } from '../common/getSampleChannel';
+import { useSampleChannel } from '../common/useSampleChannel';
 
 const meta: Meta<typeof MessageSearch> = {
   title: '1.Module/MessageSearch',
@@ -62,7 +62,7 @@ const meta: Meta<typeof MessageSearch> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 520 }}>

--- a/src/stories/modules/MessageSearch.stories.tsx
+++ b/src/stories/modules/MessageSearch.stories.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import MessageSearch from '../../modules/MessageSearch';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
+import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof MessageSearch> = {
   title: '1.Module/MessageSearch',
@@ -61,7 +62,13 @@ const meta: Meta<typeof MessageSearch> = {
 };
 export default meta;
 
-export const Default = (args): React.ReactElement => {
+export const Default = (): React.ReactElement => {
+  const [channelUrl, setChannelUrl] = useState('');
+  useAsyncEffect(async () => {
+    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+    setChannelUrl(channel.url);
+  }, []);
+
   return (
     <div style={{ height: 520 }}>
       <SendbirdProvider
@@ -69,12 +76,8 @@ export const Default = (args): React.ReactElement => {
         userId={STORYBOOK_USER_ID}
         breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
       >
-        <MessageSearch {...args} />
+        <MessageSearch channelUrl={channelUrl} />
       </SendbirdProvider>
     </div>
   );
-};
-const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-Default.args = {
-  channelUrl: channel.url,
 };

--- a/src/stories/modules/MessageSearch.stories.tsx
+++ b/src/stories/modules/MessageSearch.stories.tsx
@@ -62,7 +62,7 @@ const meta: Meta<typeof MessageSearch> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const channel = useSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
+  const channel = useSampleChannel();
 
   return (
     <div style={{ height: 520 }}>

--- a/src/stories/modules/MessageSearch.stories.tsx
+++ b/src/stories/modules/MessageSearch.stories.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import SendbirdProvider from '../../lib/Sendbird';
 import MessageSearch from '../../modules/MessageSearch';
 import { STORYBOOK_APP_ID, STORYBOOK_USER_ID } from '../common/const';
 import { getSampleChannel } from '../common/getSampleChannel';
-import { useAsyncEffect } from '@sendbird/uikit-tools';
 
 const meta: Meta<typeof MessageSearch> = {
   title: '1.Module/MessageSearch',
@@ -63,11 +62,7 @@ const meta: Meta<typeof MessageSearch> = {
 export default meta;
 
 export const Default = (): React.ReactElement => {
-  const [channelUrl, setChannelUrl] = useState('');
-  useAsyncEffect(async () => {
-    const channel = await getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
-    setChannelUrl(channel.url);
-  }, []);
+  const channel = getSampleChannel({ appId: STORYBOOK_APP_ID, userId: STORYBOOK_USER_ID });
 
   return (
     <div style={{ height: 520 }}>
@@ -76,7 +71,7 @@ export const Default = (): React.ReactElement => {
         userId={STORYBOOK_USER_ID}
         breakpoint={/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)}
       >
-        <MessageSearch channelUrl={channelUrl} />
+        <MessageSearch channelUrl={channel?.url ?? ''} />
       </SendbirdProvider>
     </div>
   );


### PR DESCRIPTION
[CLNP-3433](https://sendbird.atlassian.net/browse/CLNP-3433)

### Issue
```
Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
```
![image](https://github.com/sendbird/sendbird-uikit-react/assets/46333979/5221f359-ea3b-4fa8-baab-1a7810e1e438)


[CLNP-3433]: https://sendbird.atlassian.net/browse/CLNP-3433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ