### PR TITLE
release: v3.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - Added missing margin
 
 ### Features
-- Added support for rendering .mov file type only in Safari browser
+- Added support for rendering `.mov` file type only in Safari browser
 
 
 ## [v3.14.7] (May 23, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog - v3
 
+## [v3.14.8] (May 30, 2024)
+### Fixes
+- Resolved the issue of storybook user leaving the channel
+- Added a workaround to reset IME in mobile webkit for better input handling
+  - This fix involves creating a ghost input to manage focus transitions, preventing the virtual keyboard from closing and ensuring the proper composition of characters like Hangul
+  - The ghost input is used to reset the IME context, and focus is moved back to the original input using `requestAnimationFrame` to avoid delays
+- Retry connection when failed with a token expired error
+- Ensure scroll to the bottom of the list when mounted before painting
+- Minor bug fixes and adjustments for `SuggestedReplyItem` component:
+  - Fixed a bug where horizontal suggested reply items contents are not wrapping to multiple lines
+  - Adjusted bubble size
+  - Added missing margin
+
+### Features
+- Added support for rendering .mov file type only in Safari browser
+
+
 ## [v3.14.7] (May 23, 2024)
 ### Fixes
 * Fixed issue where files that failed to compress were not being sent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.14.7",
+  "version": "3.14.8",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.14.8] (May 30, 2024)
### Fixes
- Resolved the issue of storybook user leaving the channel
- Added a workaround to reset IME in mobile webkit for better input handling
  - This fix involves creating a ghost input to manage focus transitions, preventing the virtual keyboard from closing and ensuring the proper composition of characters like Hangul
  - The ghost input is used to reset the IME context, and focus is moved back to the original input using `requestAnimationFrame` to avoid delays
- Retry connection when failed with a token expired error
- Ensure scroll to the bottom of the list when mounted before painting
- Minor bug fixes and adjustments for `SuggestedReplyItem` component:
  - Fixed a bug where horizontal suggested reply items contents are not wrapping to multiple lines
  - Adjusted bubble size
  - Added missing margin

### Features
- Added support for rendering `.mov` file type only in Safari browser
