### PR TITLE
[CLNP: 2977] fix: m4a format audio file playing in Safari

### DIFF
--- a/src/hooks/VoicePlayer/__tests__/utils.spec.ts
+++ b/src/hooks/VoicePlayer/__tests__/utils.spec.ts
@@ -1,0 +1,42 @@
+import {
+  VOICE_MESSAGE_MIME_TYPE,
+  VOICE_MESSAGE_MIME_TYPE__M4A,
+} from '../../../utils/consts';
+import { isSafari } from '../../../utils/browser';
+import { getParsedMimeType } from '../utils';
+
+describe('getParsedMimeType', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      writable: false,
+    });
+  });
+
+  it('should return VOICE_MESSAGE_MIME_TYPE__M4A for Safari and m4a MIME type', () => {
+    const safariUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15';
+
+    Object.defineProperty(navigator, 'userAgent', {
+      value: safariUserAgent,
+      writable: true,
+    });
+
+    expect(isSafari(safariUserAgent)).toBe(true);
+    expect(getParsedMimeType('audio/mp3')).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedMimeType('audio/m4a')).toBe(VOICE_MESSAGE_MIME_TYPE__M4A);
+  });
+
+  it('should return VOICE_MESSAGE_MIME_TYPE for non-Safari browser and m4a MIME type', () => {
+    const chromeUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
+    Object.defineProperty(navigator, 'userAgent', {
+      value: chromeUserAgent,
+      writable: true,
+    });
+
+    expect(isSafari(chromeUserAgent)).toBe(false);
+    expect(getParsedMimeType('audio/mp3')).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedMimeType('audio/m4a')).toBe(VOICE_MESSAGE_MIME_TYPE);
+  });
+});

--- a/src/hooks/VoicePlayer/__tests__/utils.spec.ts
+++ b/src/hooks/VoicePlayer/__tests__/utils.spec.ts
@@ -1,11 +1,13 @@
 import {
+  VOICE_MESSAGE_FILE_NAME,
+  VOICE_MESSAGE_FILE_NAME__XM4A,
   VOICE_MESSAGE_MIME_TYPE,
-  VOICE_MESSAGE_MIME_TYPE__M4A,
+  VOICE_MESSAGE_MIME_TYPE__XM4A,
 } from '../../../utils/consts';
 import { isSafari } from '../../../utils/browser';
-import { getParsedMimeType } from '../utils';
+import { getParsedVoiceAudioFileInfo } from '../utils';
 
-describe('getParsedMimeType', () => {
+describe('getParsedVoiceAudioFileInfo', () => {
   const originalUserAgent = navigator.userAgent;
 
   afterEach(() => {
@@ -15,7 +17,7 @@ describe('getParsedMimeType', () => {
     });
   });
 
-  it('should return VOICE_MESSAGE_MIME_TYPE__M4A for Safari and m4a MIME type', () => {
+  it('should return VOICE_MESSAGE_MIME_TYPE__XM4A for Safari and m4a MIME type', () => {
     const safariUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15';
 
     Object.defineProperty(navigator, 'userAgent', {
@@ -24,8 +26,10 @@ describe('getParsedMimeType', () => {
     });
 
     expect(isSafari(safariUserAgent)).toBe(true);
-    expect(getParsedMimeType('audio/mp3')).toBe(VOICE_MESSAGE_MIME_TYPE);
-    expect(getParsedMimeType('audio/m4a')).toBe(VOICE_MESSAGE_MIME_TYPE__M4A);
+    expect(getParsedVoiceAudioFileInfo('audio/mp3').mimeType).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedVoiceAudioFileInfo('audio/m4a').mimeType).toBe(VOICE_MESSAGE_MIME_TYPE__XM4A);
+    expect(getParsedVoiceAudioFileInfo('audio/mp3').name).toBe(VOICE_MESSAGE_FILE_NAME);
+    expect(getParsedVoiceAudioFileInfo('audio/m4a').name).toBe(VOICE_MESSAGE_FILE_NAME__XM4A);
   });
 
   it('should return VOICE_MESSAGE_MIME_TYPE for non-Safari browser and m4a MIME type', () => {
@@ -36,7 +40,9 @@ describe('getParsedMimeType', () => {
     });
 
     expect(isSafari(chromeUserAgent)).toBe(false);
-    expect(getParsedMimeType('audio/mp3')).toBe(VOICE_MESSAGE_MIME_TYPE);
-    expect(getParsedMimeType('audio/m4a')).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedVoiceAudioFileInfo('audio/mp3').mimeType).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedVoiceAudioFileInfo('audio/m4a').mimeType).toBe(VOICE_MESSAGE_MIME_TYPE);
+    expect(getParsedVoiceAudioFileInfo('audio/mp3').name).toBe(VOICE_MESSAGE_FILE_NAME);
+    expect(getParsedVoiceAudioFileInfo('audio/m4a').name).toBe(VOICE_MESSAGE_FILE_NAME);
   });
 });

--- a/src/hooks/VoicePlayer/index.tsx
+++ b/src/hooks/VoicePlayer/index.tsx
@@ -21,6 +21,7 @@ import {
   VOICE_PLAYER_ROOT_ID,
 } from '../../utils/consts';
 import useSendbirdStateContext from '../useSendbirdStateContext';
+import { getParsedMimeType } from './utils';
 
 // VoicePlayerProvider interface
 export interface VoicePlayerProps {
@@ -30,6 +31,7 @@ export interface VoicePlayerPlayProps {
   groupKey: string;
   audioFile?: File;
   audioFileUrl?: string;
+  audioFileMimeType?: string;
 }
 export interface VoicePlayerContext {
   play: (props: VoicePlayerPlayProps) => void;
@@ -91,6 +93,7 @@ export const VoicePlayerProvider = ({
     groupKey,
     audioFile,
     audioFileUrl = '',
+    audioFileMimeType = VOICE_MESSAGE_MIME_TYPE,
   }: VoicePlayerPlayProps): void => {
     if (groupKey !== currentGroupKey) {
       pause(currentGroupKey);
@@ -128,7 +131,7 @@ export const VoicePlayerProvider = ({
         .then((blob) => {
           const audioFile = new File([blob], VOICE_MESSAGE_FILE_NAME, {
             lastModified: new Date().getTime(),
-            type: VOICE_MESSAGE_MIME_TYPE,
+            type: getParsedMimeType(audioFileMimeType),
           });
           resolve(audioFile);
           logger.info('VoicePlayer: Get the audioFile from URL.');

--- a/src/hooks/VoicePlayer/index.tsx
+++ b/src/hooks/VoicePlayer/index.tsx
@@ -15,13 +15,12 @@ import {
   SET_CURRENT_PLAYER,
 } from './dux/actionTypes';
 import {
-  VOICE_MESSAGE_FILE_NAME,
   VOICE_MESSAGE_MIME_TYPE,
   VOICE_PLAYER_AUDIO_ID,
   VOICE_PLAYER_ROOT_ID,
 } from '../../utils/consts';
 import useSendbirdStateContext from '../useSendbirdStateContext';
-import { getParsedMimeType } from './utils';
+import { getParsedVoiceAudioFileInfo } from './utils';
 
 // VoicePlayerProvider interface
 export interface VoicePlayerProps {
@@ -129,9 +128,9 @@ export const VoicePlayerProvider = ({
       fetch(audioFileUrl)
         .then((res) => res.blob())
         .then((blob) => {
-          const audioFile = new File([blob], VOICE_MESSAGE_FILE_NAME, {
+          const audioFile = new File([blob], getParsedVoiceAudioFileInfo(audioFileMimeType).name, {
             lastModified: new Date().getTime(),
-            type: getParsedMimeType(audioFileMimeType),
+            type: getParsedVoiceAudioFileInfo(audioFileMimeType).mimeType,
           });
           resolve(audioFile);
           logger.info('VoicePlayer: Get the audioFile from URL.');

--- a/src/hooks/VoicePlayer/useVoicePlayer.tsx
+++ b/src/hooks/VoicePlayer/useVoicePlayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useVoicePlayerContext } from '.';
-import { VOICE_PLAYER_AUDIO_ID } from '../../utils/consts';
+import { VOICE_PLAYER_AUDIO_ID, VOICE_MESSAGE_MIME_TYPE } from '../../utils/consts';
 import { useVoiceRecorderContext } from '../VoiceRecorder';
 
 import { AudioUnitDefaultValue, VoicePlayerStatusType } from './dux/initialState';
@@ -11,6 +11,7 @@ export interface UseVoicePlayerProps {
   channelUrl?: string;
   audioFile?: File;
   audioFileUrl?: string;
+  audioFileMimeType?: string;
 }
 
 export interface UseVoicePlayerContext {
@@ -27,6 +28,7 @@ export const useVoicePlayer = ({
   channelUrl = '',
   audioFile,
   audioFileUrl = '',
+  audioFileMimeType = VOICE_MESSAGE_MIME_TYPE,
 }: UseVoicePlayerProps): UseVoicePlayerContext => {
   const groupKey = generateGroupKey(channelUrl, key);
   const {
@@ -44,6 +46,7 @@ export const useVoicePlayer = ({
         groupKey,
         audioFile,
         audioFileUrl,
+        audioFileMimeType,
       });
     }
   };

--- a/src/hooks/VoicePlayer/utils.ts
+++ b/src/hooks/VoicePlayer/utils.ts
@@ -1,2 +1,25 @@
+import { isSafari } from '../../utils/browser';
+import {
+  VOICE_MESSAGE_MIME_TYPE,
+  VOICE_MESSAGE_MIME_TYPE__M4A,
+} from '../../utils/consts';
+
 export type GroupKey = string;
 export const generateGroupKey = (channelUrl = '', key = ''): GroupKey => (`${channelUrl}-${key}`);
+
+/**
+ * Parses and returns the correct MIME type based on the browser.
+ * If the browser is Safari and the file type is m4a, use 'audio/x-m4a' for the audio player.
+ * Safari doesn't support 'audio/mp3' well.
+ * Also, 'audio/m4a' should be converted to 'audio/x-m4a' to be correctly played in Safari.
+ * @link: https://sendbird.atlassian.net/browse/CLNP-2997
+ *
+ * @param mimeType - The original MIME type.
+ * @returns The parsed MIME type.
+ */
+export const getParsedMimeType = (mimeType: string): string => {
+  if (isSafari(navigator.userAgent) && mimeType.includes('m4a')) {
+    return VOICE_MESSAGE_MIME_TYPE__M4A;
+  }
+  return VOICE_MESSAGE_MIME_TYPE;
+};

--- a/src/hooks/VoicePlayer/utils.ts
+++ b/src/hooks/VoicePlayer/utils.ts
@@ -1,7 +1,9 @@
 import { isSafari } from '../../utils/browser';
 import {
   VOICE_MESSAGE_MIME_TYPE,
-  VOICE_MESSAGE_MIME_TYPE__M4A,
+  VOICE_MESSAGE_MIME_TYPE__XM4A,
+  VOICE_MESSAGE_FILE_NAME,
+  VOICE_MESSAGE_FILE_NAME__XM4A,
 } from '../../utils/consts';
 
 export type GroupKey = string;
@@ -15,11 +17,20 @@ export const generateGroupKey = (channelUrl = '', key = ''): GroupKey => (`${cha
  * @link: https://sendbird.atlassian.net/browse/CLNP-2997
  *
  * @param mimeType - The original MIME type.
- * @returns The parsed MIME type.
+ * @returns Converted file name and MIME type.
  */
-export const getParsedMimeType = (mimeType: string): string => {
+export const getParsedVoiceAudioFileInfo = (mimeType: string): {
+  name: string,
+  mimeType: string,
+} => {
   if (isSafari(navigator.userAgent) && mimeType.includes('m4a')) {
-    return VOICE_MESSAGE_MIME_TYPE__M4A;
+    return {
+      name: VOICE_MESSAGE_FILE_NAME__XM4A,
+      mimeType: VOICE_MESSAGE_MIME_TYPE__XM4A,
+    };
   }
-  return VOICE_MESSAGE_MIME_TYPE;
+  return {
+    name: VOICE_MESSAGE_FILE_NAME,
+    mimeType: VOICE_MESSAGE_MIME_TYPE,
+  };
 };

--- a/src/ui/VoiceMessageItemBody/index.tsx
+++ b/src/ui/VoiceMessageItemBody/index.tsx
@@ -41,6 +41,7 @@ export const VoiceMessageItemBody = ({
     channelUrl,
     key: `${message?.messageId}`,
     audioFileUrl: message?.url,
+    audioFileMimeType: message?.type,
   });
 
   useEffect(() => {

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -25,6 +25,7 @@ export const VOICE_PLAYER_AUDIO_ID = 'sendbird-global-audio-player-id';
 // voice message file
 export const VOICE_MESSAGE_FILE_NAME = 'Voice_message.mp3';
 export const VOICE_MESSAGE_MIME_TYPE = 'audio/mp3;sbu_type=voice';
+export const VOICE_MESSAGE_MIME_TYPE__M4A = 'audio/x-m4a;sbu_type=voice';
 
 // meta array
 export const META_ARRAY_VOICE_DURATION_KEY = 'KEY_VOICE_MESSAGE_DURATION';

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -24,8 +24,10 @@ export const VOICE_PLAYER_AUDIO_ID = 'sendbird-global-audio-player-id';
 
 // voice message file
 export const VOICE_MESSAGE_FILE_NAME = 'Voice_message.mp3';
+export const VOICE_MESSAGE_FILE_NAME__XM4A = 'Voice_message.m4a';
+
 export const VOICE_MESSAGE_MIME_TYPE = 'audio/mp3;sbu_type=voice';
-export const VOICE_MESSAGE_MIME_TYPE__M4A = 'audio/x-m4a;sbu_type=voice';
+export const VOICE_MESSAGE_MIME_TYPE__XM4A = 'audio/x-m4a;sbu_type=voice';
 
 // meta array
 export const META_ARRAY_VOICE_DURATION_KEY = 'KEY_VOICE_MESSAGE_DURATION';


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/CLNP-2997

#### Problem Statement

Voice audio files created on platforms other than the web, such as Android/iOS, are in M4A format. When attempting to convert these M4A files to `audio/mp3` or `audio/mpeg` format for playback on the web, Safari browser cannot find the correct codec and throws an error: `Unhandled Promise Rejection: NotSupportedError: The operation is not supported.`
This results in the file not being playable.

#### Solution

For Safari browser only, if the message file type is M4A, ensure it is played in this format. However, the file must be parsed as `audio/x-m4a` instead of `audio/m4a` to be correctly played in the Safari browser.

#### Test Cases Checked

| Browser  | .m4a file(created in iOS / Android UIKit) | .mp3 File(created in React UIKit) |
|----------|----------|----------|
| Safari   | ✅       | ✅       |
| Chrome   | ✅       | ✅       |
| Firefox  | ✅       | ✅       |

>  A testable account credential for .m4a can be found in the linked Jira ticket 
