### PR TITLE
[CLNP-3254] feat: support descriptive color name 

### DIFF
--- a/src/lib/hooks/useTheme.ts
+++ b/src/lib/hooks/useTheme.ts
@@ -1,5 +1,104 @@
 import { useLayoutEffect } from 'react';
+import { type ColorSet, mapColorKeys } from '../utils/colorMapper';
 import cssVars from 'css-vars-ponyfill';
+
+const DEFAULT_COLOR_SET = {
+  '--sendbird-dark-primary-500': '#4d2aa6',
+  '--sendbird-dark-primary-400': '#6440C4',
+  '--sendbird-dark-primary-300': '#7B53EF',
+  '--sendbird-dark-primary-200': '#9E8CF5',
+  '--sendbird-dark-primary-100': '#E2DFFF',
+
+  '--sendbird-dark-secondary-500': '#007A7A',
+  '--sendbird-dark-secondary-400': '#189A8D',
+  '--sendbird-dark-secondary-300': '#2EBA9F',
+  '--sendbird-dark-secondary-200': '#6FD6BE',
+  '--sendbird-dark-secondary-100': '#AEF2DC',
+
+  '--sendbird-dark-information-100': '#b2d9ff',
+
+  '--sendbird-dark-error-500': '#A30E2D',
+  '--sendbird-dark-error-400': '#C11F41',
+  '--sendbird-dark-error-300': '#E53157',
+  '--sendbird-dark-error-200': '#FF6183',
+  '--sendbird-dark-error-100': '#FFABBD',
+
+  '--sendbird-dark-background-700': '#000000',
+  '--sendbird-dark-background-600': '#161616',
+  '--sendbird-dark-background-500': '#2C2C2C',
+  '--sendbird-dark-background-400': '#393939',
+  '--sendbird-dark-background-300': '#A8A8A8',
+  '--sendbird-dark-background-200': '#D9D9D9',
+  '--sendbird-dark-background-100': '#F0F0F0',
+  '--sendbird-dark-background-50': '#FFFFFF',
+
+  '--sendbird-dark-overlay': 'rgba(0, 0, 0, 0.32)',
+
+  '--sendbird-dark-onlight-01': 'rgba(0, 0, 0, 0.88)',
+  '--sendbird-dark-onlight-02': 'rgba(0, 0, 0, 0.50)',
+  '--sendbird-dark-onlight-03': 'rgba(0, 0, 0, 0.38)',
+  '--sendbird-dark-onlight-04': 'rgba(0, 0, 0, 0.12)',
+
+  '--sendbird-dark-ondark-01': 'rgba(255, 255, 255, 0.88)',
+  '--sendbird-dark-ondark-02': 'rgba(255, 255, 255, 0.50)',
+  '--sendbird-dark-ondark-03': 'rgba(255, 255, 255, 0.38)',
+  '--sendbird-dark-ondark-04': 'rgba(255, 255, 255, 0.12)',
+
+  '--sendbird-dark-shadow-01': '0 1px 5px 0 rgba(33, 34, 66, 0.04), 0 0 3px 0 rgba(0, 0, 0, 0.08), 0 2px 1px 0 rgba(0, 0, 0, 0.12)',
+  '--sendbird-dark-shadow-02': '0 3px 5px -3px rgba(33, 34, 66, 0.04), 0 3px 14px 2px rgba(0, 0, 0, 0.08), 0 8px 10px 1px rgba(0, 0, 0, 0.12)',
+  '--sendbird-dark-shadow-03': '0 6px 10px -5px rgba(0, 0, 0, 0.04), 0 6px 30px 5px rgba(0, 0, 0, 0.08), 0 16px 24px 2px rgba(0, 0, 0, 0.12)',
+  '--sendbird-dark-shadow-04': '0 9px 15px -7px rgba(0, 0, 0, 0.04), 0 9px 46px 8px rgba(0, 0, 0, 0.08), 0 24px 38px 3px rgba(0, 0, 0, 0.12)',
+
+  '--sendbird-dark-shadow-message-input': '0 1px 5px 0 rgba(33, 34, 66, 0.12), 0 0 1px 0 rgba(33, 34, 66, 0.16), 0 2px 1px 0 rgba(33, 34, 66, 0.08), 0 1px 5px 0 rgba(0, 0, 0, 0.12)',
+
+  '--sendbird-light-primary-500': '#4d2aa6',
+  '--sendbird-light-primary-400': '#6440C4',
+  '--sendbird-light-primary-300': '#7B53EF',
+  '--sendbird-light-primary-200': '#9E8CF5',
+  '--sendbird-light-primary-100': '#E2DFFF',
+
+  '--sendbird-light-secondary-500': '#007A7A',
+  '--sendbird-light-secondary-400': '#189A8D',
+  '--sendbird-light-secondary-300': '#2EBA9F',
+  '--sendbird-light-secondary-200': '#6FD6BE',
+  '--sendbird-light-secondary-100': '#AEF2DC',
+
+  '--sendbird-light-information-100': '#b2d9ff',
+
+  '--sendbird-light-error-500': '#A30E2D',
+  '--sendbird-light-error-400': '#C11F41',
+  '--sendbird-light-error-300': '#E53157',
+  '--sendbird-light-error-200': '#FF6183',
+  '--sendbird-light-error-100': '#FFABBD',
+
+  '--sendbird-light-background-700': '#000000',
+  '--sendbird-light-background-600': '#161616',
+  '--sendbird-light-background-500': '#2C2C2C',
+  '--sendbird-light-background-400': '#393939',
+  '--sendbird-light-background-300': '#A8A8A8',
+  '--sendbird-light-background-200': '#D9D9D9',
+  '--sendbird-light-background-100': '#F0F0F0',
+  '--sendbird-light-background-50': ' #FFFFFF',
+
+  '--sendbird-light-overlay': 'rgba(0, 0, 0, 0.32)',
+
+  '--sendbird-light-onlight-01': 'rgba(0, 0, 0, 0.88)',
+  '--sendbird-light-onlight-02': 'rgba(0, 0, 0, 0.50)',
+  '--sendbird-light-onlight-03': 'rgba(0, 0, 0, 0.38)',
+  '--sendbird-light-onlight-04': 'rgba(0, 0, 0, 0.12)',
+
+  '--sendbird-light-ondark-01': 'rgba(255, 255, 255, 0.88)',
+  '--sendbird-light-ondark-02': 'rgba(255, 255, 255, 0.50)',
+  '--sendbird-light-ondark-03': 'rgba(255, 255, 255, 0.38)',
+  '--sendbird-light-ondark-04': 'rgba(255, 255, 255, 0.12)',
+
+  '--sendbird-light-shadow-01': '0 1px 5px 0 rgba(33, 34, 66, 0.04), 0 0 3px 0 rgba(0, 0, 0, 0.08), 0 2px 1px 0 rgba(0, 0, 0, 0.12)',
+  '--sendbird-light-shadow-02': '0 3px 5px -3px rgba(33, 34, 66, 0.04), 0 3px 14px 2px rgba(0, 0, 0, 0.08), 0 8px 10px 1px rgba(0, 0, 0, 0.12)',
+  '--sendbird-light-shadow-03': '0 6px 10px -5px rgba(0, 0, 0, 0.04), 0 6px 30px 5px rgba(0, 0, 0, 0.08), 0 16px 24px 2px rgba(0, 0, 0, 0.12)',
+  '--sendbird-light-shadow-04': '0 9px 15px -7px rgba(0, 0, 0, 0.04), 0 9px 46px 8px rgba(0, 0, 0, 0.08), 0 24px 38px 3px rgba(0, 0, 0, 0.12)',
+
+  '--sendbird-light-shadow-message-input': '0 1px 5px 0 rgba(33, 34, 66, 0.12), 0 0 1px 0 rgba(33, 34, 66, 0.16), 0 2px 1px 0 rgba(33, 34, 66, 0.08), 0 1px 5px 0 rgba(0, 0, 0, 0.12)',
+};
 
 const isEmpty = (obj?: null | Record<string, unknown>) => {
   if (obj === null || obj === undefined) {
@@ -14,111 +113,14 @@ const isEmpty = (obj?: null | Record<string, unknown>) => {
   return JSON.stringify(obj) === JSON.stringify({});
 };
 
-const useTheme = (overrides?: Record<string, string>): void => {
+const useTheme = (overrides?: ColorSet): void => {
   useLayoutEffect(() => {
     if (!isEmpty(overrides)) {
-      cssVars({
-        variables: {
-          ...{
-            '--sendbird-dark-primary-500': '#4d2aa6',
-            '--sendbird-dark-primary-400': '#6440C4',
-            '--sendbird-dark-primary-300': '#7B53EF',
-            '--sendbird-dark-primary-200': '#9E8CF5',
-            '--sendbird-dark-primary-100': '#E2DFFF',
-
-            '--sendbird-dark-secondary-500': '#007A7A',
-            '--sendbird-dark-secondary-400': '#189A8D',
-            '--sendbird-dark-secondary-300': '#2EBA9F',
-            '--sendbird-dark-secondary-200': '#6FD6BE',
-            '--sendbird-dark-secondary-100': '#AEF2DC',
-
-            '--sendbird-dark-information-100': '#b2d9ff',
-
-            '--sendbird-dark-error-500': '#A30E2D',
-            '--sendbird-dark-error-400': '#C11F41',
-            '--sendbird-dark-error-300': '#E53157',
-            '--sendbird-dark-error-200': '#FF6183',
-            '--sendbird-dark-error-100': '#FFABBD',
-
-            '--sendbird-dark-background-700': '#000000',
-            '--sendbird-dark-background-600': '#161616',
-            '--sendbird-dark-background-500': '#2C2C2C',
-            '--sendbird-dark-background-400': '#393939',
-            '--sendbird-dark-background-300': '#A8A8A8',
-            '--sendbird-dark-background-200': '#D9D9D9',
-            '--sendbird-dark-background-100': '#F0F0F0',
-            '--sendbird-dark-background-50': '#FFFFFF',
-
-            '--sendbird-dark-overlay': 'rgba(0, 0, 0, 0.32)',
-
-            '--sendbird-dark-onlight-01': 'rgba(0, 0, 0, 0.88)',
-            '--sendbird-dark-onlight-02': 'rgba(0, 0, 0, 0.50)',
-            '--sendbird-dark-onlight-03': 'rgba(0, 0, 0, 0.38)',
-            '--sendbird-dark-onlight-04': 'rgba(0, 0, 0, 0.12)',
-
-            '--sendbird-dark-ondark-01': 'rgba(255, 255, 255, 0.88)',
-            '--sendbird-dark-ondark-02': 'rgba(255, 255, 255, 0.50)',
-            '--sendbird-dark-ondark-03': 'rgba(255, 255, 255, 0.38)',
-            '--sendbird-dark-ondark-04': 'rgba(255, 255, 255, 0.12)',
-
-            '--sendbird-dark-shadow-01': '0 1px 5px 0 rgba(33, 34, 66, 0.04), 0 0 3px 0 rgba(0, 0, 0, 0.08), 0 2px 1px 0 rgba(0, 0, 0, 0.12)',
-            '--sendbird-dark-shadow-02': '0 3px 5px -3px rgba(33, 34, 66, 0.04), 0 3px 14px 2px rgba(0, 0, 0, 0.08), 0 8px 10px 1px rgba(0, 0, 0, 0.12)',
-            '--sendbird-dark-shadow-03': '0 6px 10px -5px rgba(0, 0, 0, 0.04), 0 6px 30px 5px rgba(0, 0, 0, 0.08), 0 16px 24px 2px rgba(0, 0, 0, 0.12)',
-            '--sendbird-dark-shadow-04': '0 9px 15px -7px rgba(0, 0, 0, 0.04), 0 9px 46px 8px rgba(0, 0, 0, 0.08), 0 24px 38px 3px rgba(0, 0, 0, 0.12)',
-
-            '--sendbird-dark-shadow-message-input': '0 1px 5px 0 rgba(33, 34, 66, 0.12), 0 0 1px 0 rgba(33, 34, 66, 0.16), 0 2px 1px 0 rgba(33, 34, 66, 0.08), 0 1px 5px 0 rgba(0, 0, 0, 0.12)',
-
-            '--sendbird-light-primary-500': '#4d2aa6',
-            '--sendbird-light-primary-400': '#6440C4',
-            '--sendbird-light-primary-300': '#7B53EF',
-            '--sendbird-light-primary-200': '#9E8CF5',
-            '--sendbird-light-primary-100': '#E2DFFF',
-
-            '--sendbird-light-secondary-500': '#007A7A',
-            '--sendbird-light-secondary-400': '#189A8D',
-            '--sendbird-light-secondary-300': '#2EBA9F',
-            '--sendbird-light-secondary-200': '#6FD6BE',
-            '--sendbird-light-secondary-100': '#AEF2DC',
-
-            '--sendbird-light-information-100': '#b2d9ff',
-
-            '--sendbird-light-error-500': '#A30E2D',
-            '--sendbird-light-error-400': '#C11F41',
-            '--sendbird-light-error-300': '#E53157',
-            '--sendbird-light-error-200': '#FF6183',
-            '--sendbird-light-error-100': '#FFABBD',
-
-            '--sendbird-light-background-700': '#000000',
-            '--sendbird-light-background-600': '#161616',
-            '--sendbird-light-background-500': '#2C2C2C',
-            '--sendbird-light-background-400': '#393939',
-            '--sendbird-light-background-300': '#A8A8A8',
-            '--sendbird-light-background-200': '#D9D9D9',
-            '--sendbird-light-background-100': '#F0F0F0',
-            '--sendbird-light-background-50': ' #FFFFFF',
-
-            '--sendbird-light-overlay': 'rgba(0, 0, 0, 0.32)',
-
-            '--sendbird-light-onlight-01': 'rgba(0, 0, 0, 0.88)',
-            '--sendbird-light-onlight-02': 'rgba(0, 0, 0, 0.50)',
-            '--sendbird-light-onlight-03': 'rgba(0, 0, 0, 0.38)',
-            '--sendbird-light-onlight-04': 'rgba(0, 0, 0, 0.12)',
-
-            '--sendbird-light-ondark-01': 'rgba(255, 255, 255, 0.88)',
-            '--sendbird-light-ondark-02': 'rgba(255, 255, 255, 0.50)',
-            '--sendbird-light-ondark-03': 'rgba(255, 255, 255, 0.38)',
-            '--sendbird-light-ondark-04': 'rgba(255, 255, 255, 0.12)',
-
-            '--sendbird-light-shadow-01': '0 1px 5px 0 rgba(33, 34, 66, 0.04), 0 0 3px 0 rgba(0, 0, 0, 0.08), 0 2px 1px 0 rgba(0, 0, 0, 0.12)',
-            '--sendbird-light-shadow-02': '0 3px 5px -3px rgba(33, 34, 66, 0.04), 0 3px 14px 2px rgba(0, 0, 0, 0.08), 0 8px 10px 1px rgba(0, 0, 0, 0.12)',
-            '--sendbird-light-shadow-03': '0 6px 10px -5px rgba(0, 0, 0, 0.04), 0 6px 30px 5px rgba(0, 0, 0, 0.08), 0 16px 24px 2px rgba(0, 0, 0, 0.12)',
-            '--sendbird-light-shadow-04': '0 9px 15px -7px rgba(0, 0, 0, 0.04), 0 9px 46px 8px rgba(0, 0, 0, 0.08), 0 24px 38px 3px rgba(0, 0, 0, 0.12)',
-
-            '--sendbird-light-shadow-message-input': '0 1px 5px 0 rgba(33, 34, 66, 0.12), 0 0 1px 0 rgba(33, 34, 66, 0.16), 0 2px 1px 0 rgba(33, 34, 66, 0.08), 0 1px 5px 0 rgba(0, 0, 0, 0.12)',
-          },
-          ...overrides,
-        },
-      });
+      const variables = {
+        ...DEFAULT_COLOR_SET,
+        ...mapColorKeys(overrides),
+      };
+      cssVars({ variables });
     }
   }, [overrides]);
 };

--- a/src/lib/utils/__tests__/colorMapper.spec.ts
+++ b/src/lib/utils/__tests__/colorMapper.spec.ts
@@ -1,0 +1,116 @@
+import { mapColorKeys } from '../colorMapper';
+
+const mockColorSet = {
+  primary: {
+    numeric: {
+      '--sendbird-light-primary-500': '#00487c',
+      '--sendbird-light-primary-400': '#4bb3fd',
+      '--sendbird-light-primary-300': '#3e6680',
+      '--sendbird-light-primary-200': '#0496ff',
+      '--sendbird-light-primary-100': '#027bce',
+    },
+    descriptiveText: {
+      '--sendbird-light-primary-extra-dark': '#00487c',
+      '--sendbird-light-primary-dark': '#4bb3fd',
+      '--sendbird-light-primary-main': '#3e6680',
+      '--sendbird-light-primary-light': '#0496ff',
+      '--sendbird-light-primary-extra-light': '#027bce',
+    },
+  },
+  onlight: {
+    numeric: {
+      '--sendbird-dark-onlight-01': 'rgba(0, 0, 0, 0.88)',
+      '--sendbird-dark-onlight-02': 'rgba(0, 0, 0, 0.50)',
+      '--sendbird-dark-onlight-03': 'rgba(0, 0, 0, 0.38)',
+      '--sendbird-dark-onlight-04': 'rgba(0, 0, 0, 0.12)',
+      '--sendbird-light-onlight-01': 'rgba(0, 0, 0, 0.88)',
+      '--sendbird-light-onlight-02': 'rgba(0, 0, 0, 0.50)',
+      '--sendbird-light-onlight-03': 'rgba(0, 0, 0, 0.38)',
+      '--sendbird-light-onlight-04': 'rgba(0, 0, 0, 0.12)',
+    },
+    descriptiveText: {
+      '--sendbird-dark-onlight-text-high-emphasis': 'rgba(0, 0, 0, 0.88)',
+      '--sendbird-dark-onlight-text-mid-emphasis': 'rgba(0, 0, 0, 0.50)',
+      '--sendbird-dark-onlight-text-low-emphasis': 'rgba(0, 0, 0, 0.38)',
+      '--sendbird-dark-onlight-text-disabled': 'rgba(0, 0, 0, 0.12)',
+      '--sendbird-light-onlight-text-high-emphasis': 'rgba(0, 0, 0, 0.88)',
+      '--sendbird-light-onlight-text-mid-emphasis': 'rgba(0, 0, 0, 0.50)',
+      '--sendbird-light-onlight-text-low-emphasis': 'rgba(0, 0, 0, 0.38)',
+      '--sendbird-light-onlight-text-disabled': 'rgba(0, 0, 0, 0.12)',
+    },
+  },
+  ondark: {
+    numeric: {
+      '--sendbird-dark-ondark-01': 'rgba(255, 255, 255, 0.88)',
+      '--sendbird-dark-ondark-02': 'rgba(255, 255, 255, 0.50)',
+      '--sendbird-dark-ondark-03': 'rgba(255, 255, 255, 0.38)',
+      '--sendbird-dark-ondark-04': 'rgba(255, 255, 255, 0.12)',
+      '--sendbird-light-ondark-01': 'rgba(255, 255, 255, 0.88)',
+      '--sendbird-light-ondark-02': 'rgba(255, 255, 255, 0.50)',
+      '--sendbird-light-ondark-03': 'rgba(255, 255, 255, 0.38)',
+      '--sendbird-light-ondark-04': 'rgba(255, 255, 255, 0.12)',
+    },
+    descriptiveText: {
+      '--sendbird-dark-ondark-text-high-emphasis': 'rgba(255, 255, 255, 0.88)',
+      '--sendbird-dark-ondark-text-mid-emphasis': 'rgba(255, 255, 255, 0.50)',
+      '--sendbird-dark-ondark-text-low-emphasis': 'rgba(255, 255, 255, 0.38)',
+      '--sendbird-dark-ondark-text-disabled': 'rgba(255, 255, 255, 0.12)',
+      '--sendbird-light-ondark-text-high-emphasis': 'rgba(255, 255, 255, 0.88)',
+      '--sendbird-light-ondark-text-mid-emphasis': 'rgba(255, 255, 255, 0.50)',
+      '--sendbird-light-ondark-text-low-emphasis': 'rgba(255, 255, 255, 0.38)',
+      '--sendbird-light-ondark-text-disabled': 'rgba(255, 255, 255, 0.12)',
+    },
+  },
+  overlay: {
+    numeric: {
+      '--sendbird-dark-overlay-01': 'rgba(0, 0, 0, 0.55)',
+      '--sendbird-dark-overlay-02': 'rgba(0, 0, 0, 0.32)',
+      '--sendbird-light-overlay-01': 'rgba(0, 0, 0, 0.55)',
+      '--sendbird-light-overlay-02': 'rgba(0, 0, 0, 0.32)',
+    },
+    descriptiveText: {
+      '--sendbird-dark-overlay-dark': 'rgba(0, 0, 0, 0.55)',
+      '--sendbird-dark-overlay-light': 'rgba(0, 0, 0, 0.32)',
+      '--sendbird-light-overlay-dark': 'rgba(0, 0, 0, 0.55)',
+      '--sendbird-light-overlay-light': 'rgba(0, 0, 0, 0.32)',
+    },
+  },
+};
+describe('mapColorKeys', () => {
+  it('should convert multiple keys correctly', () => {
+    const input = mockColorSet.primary.descriptiveText;
+    const expected = mockColorSet.primary.numeric;
+    expect(mapColorKeys(input)).toEqual(expected);
+  });
+  it('should not change keys without a match', () => {
+    const input = {
+      '--sendbird-light-primary-unknown': '#abcdef',
+    };
+    const expected = {
+      '--sendbird-light-primary-unknown': '#abcdef',
+    };
+    expect(mapColorKeys(input)).toEqual(expected);
+  });
+
+  it('should handle keys with multiple matching parts correctly', () => {
+    const input = {
+      '--sendbird-dark-primary-extra-light': '#654321',
+      '--sendbird-dark-primary-light': '#abcdef',
+    };
+    const expected = {
+      '--sendbird-dark-primary-100': '#654321',
+      '--sendbird-dark-primary-200': '#abcdef',
+    };
+    expect(mapColorKeys(input)).toEqual(expected);
+  });
+
+  it('should not convert the numeric format of keys but keep as-is', () => {
+    expect(mapColorKeys(mockColorSet.primary.numeric)).toEqual(mockColorSet.primary.numeric);
+  });
+
+  it('should convert correctly onLight / onDark / overlay to text-emphasis format', () => {
+    expect(mapColorKeys(mockColorSet.onlight.descriptiveText)).toEqual(mockColorSet.onlight.numeric);
+    expect(mapColorKeys(mockColorSet.ondark.descriptiveText)).toEqual(mockColorSet.ondark.numeric);
+    expect(mapColorKeys(mockColorSet.overlay.descriptiveText)).toEqual(mockColorSet.overlay.numeric);
+  });
+});

--- a/src/lib/utils/colorMapper.ts
+++ b/src/lib/utils/colorMapper.ts
@@ -41,6 +41,35 @@ const colorMappingMap = new Map<string, string>(
   Object.entries(colorMapping).map(([key, value]) => [value, key]),
 );
 
+/**
+ * Converts descriptive color keys to their numeric equivalents.
+ *
+ * This function takes a set of CSS variable keys and transforms
+ * descriptive color keys (e.g. 'extra-light', 'main') into their
+ * numeric equivalents(e.g. 100, 200, ..., 500) as defined in the colorMapping object.
+ *
+ * e.g.
+ * Input:
+ * {
+ *   '--sendbird-light-primary-extra-dark': '#00487c',
+ *   '--sendbird-light-primary-dark': '#4bb3fd',
+ *   '--sendbird-light-primary-main': '#3e6680',
+ *   '--sendbird-light-primary-light': '#0496ff',
+ *   '--sendbird-light-primary-extra-light': '#027bce',
+ * }
+ *
+ * Output:
+ * {
+ *   '--sendbird-light-primary-500': '#00487c',
+ *   '--sendbird-light-primary-400': '#4bb3fd',
+ *   '--sendbird-light-primary-300': '#3e6680',
+ *   '--sendbird-light-primary-200': '#0496ff',
+ *   '--sendbird-light-primary-100': '#027bce',
+ * }
+ *
+ * @param {ColorSet} colorSet - The input object containing CSS variables with descriptive keys.
+ * @returns {ColorSet} The transformed object with numeric keys.
+ */
 export const mapColorKeys = (colorSet: ColorSet): ColorSet => {
   const mappedColors: ColorSet = {};
 

--- a/src/lib/utils/colorMapper.ts
+++ b/src/lib/utils/colorMapper.ts
@@ -34,6 +34,13 @@ const colorMappingOrder = Object
   .values(colorMapping)
   .sort((a, b) => b.length - a.length);
 
+/**
+ * Convert colorMapping to a Map for quick lookup in mapColorKeys
+ */
+const colorMappingMap = new Map<string, string>(
+  Object.entries(colorMapping).map(([key, value]) => [value, key]),
+);
+
 export const mapColorKeys = (colorSet: ColorSet): ColorSet => {
   const mappedColors: ColorSet = {};
 
@@ -45,11 +52,8 @@ export const mapColorKeys = (colorSet: ColorSet): ColorSet => {
       // e.g., '-extra-dark$'
       const regex = new RegExp(`-${mappingValue}$`);
       if (regex.test(key)) {
-        // Find the corresponding numeric key for the mapping value
-        const numericKey = Object.entries(colorMapping).find((
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          [_, value]) => value === mappingValue,
-        )?.[0];
+        // Find the corresponding numeric key for the mapping value using Map
+        const numericKey = colorMappingMap.get(mappingValue);
         if (numericKey) {
           // Replace the descriptive text with the numeric key
           descriptiveKey = key.replace(regex, `-${numericKey}`);

--- a/src/lib/utils/colorMapper.ts
+++ b/src/lib/utils/colorMapper.ts
@@ -1,0 +1,64 @@
+export type ColorSet = Record<string, string>;
+
+/**
+ * Mapping object to convert numeric keys to descriptive text
+ * [(legacy) numeric key]: [(new) descriptive text]
+ */
+const colorMapping: Record<string, string> = {
+  // Primary / Secondary / Error / Information
+  100: 'extra-light',
+  200: 'light',
+  300: 'main',
+  400: 'dark',
+  500: 'extra-dark',
+  // Overlay
+  'overlay-01': 'overlay-dark',
+  'overlay-02': 'overlay-light',
+  // OnLight
+  'onlight-01': 'onlight-text-high-emphasis',
+  'onlight-02': 'onlight-text-mid-emphasis',
+  'onlight-03': 'onlight-text-low-emphasis',
+  'onlight-04': 'onlight-text-disabled',
+  // OnDark
+  'ondark-01': 'ondark-text-high-emphasis',
+  'ondark-02': 'ondark-text-mid-emphasis',
+  'ondark-03': 'ondark-text-low-emphasis',
+  'ondark-04': 'ondark-text-disabled',
+};
+
+/**
+ * Order of mappings to ensure longer keys are matched first
+ * e.g. In --sendbird-dark-background-extra-dark, 'extra-dark' should be matched instead of 'dark'
+ */
+const colorMappingOrder = Object
+  .values(colorMapping)
+  .sort((a, b) => b.length - a.length);
+
+export const mapColorKeys = (colorSet: ColorSet): ColorSet => {
+  const mappedColors: ColorSet = {};
+
+  Object.entries(colorSet).forEach(([key, value]) => {
+    let descriptiveKey = key;
+
+    for (const mappingValue of colorMappingOrder) {
+      // Prepare a regex to match the mapping value at the end of the key
+      // e.g., '-extra-dark$'
+      const regex = new RegExp(`-${mappingValue}$`);
+      if (regex.test(key)) {
+        // Find the corresponding numeric key for the mapping value
+        const numericKey = Object.entries(colorMapping).find((
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          [_, value]) => value === mappingValue,
+        )?.[0];
+        if (numericKey) {
+          // Replace the descriptive text with the numeric key
+          descriptiveKey = key.replace(regex, `-${numericKey}`);
+          break;
+        }
+      }
+    }
+    mappedColors[descriptiveKey] = value;
+  });
+
+  return mappedColors;
+};

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -129,7 +129,7 @@ export default function App(props: AppProps) {
       dateLocale={dateLocale }
       userListQuery={userListQuery}
       config={config}
-      colorSet={colorSet }
+      colorSet={colorSet}
       disableMarkAsDelivered={disableMarkAsDelivered}
       renderUserProfile={renderUserProfile}
       imageCompression={imageCompression}


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-3254 

### Change Description
![image](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/f41c7370-7137-439f-9320-ab0399246c8d)

Users who want to customize the color set can use below new more descriptive color name instead of `001` / `002` ... `005`. I added a color map parsing util function; `mapColorKeys` to ,a the new & existing color name but we'll be still using the existing names. Refer to [this Slack thread](https://sendbird.slack.com/archives/G01290GCDCN/p1716881782621069) for more detailed discussion.
 
1. Primary, Secondary, Error, information 
```
Primary-500 -> Primary-extra dark
Primary-400 -> Primary-dark
Primary-300 -> Primary-main
Primary-200 -> Primary-light
Primary-100 -> Primary-extra light

Secondary-500 -> Secondary-extra dark
Secondary-400 -> Secondary-dark
Secondary-300 -> Secondary-main
Secondary-200 -> Secondary-light
Secondary-100 -> Secondary-extra light
```

2. Background 100~700: No changes

3. Overlay
```
Overlay-01 -> Overlay-dark
Overlay-02 -> Overlay-light
```
4. OnLight & OnDark
```
// On Light
On Light-01 -> Onlight-text-high-emphasis
On Light-02 -> Onlight-text-mid-emphasis
On Light-03 -> Onlight-text-low-emphasis
On Light-04 -> Onlight-text-disabled
// On Dark
On Dark -01 -> Ondark-text-high-emphasis
On Dark -02 -> Ondark-text-mid-emphasis
On Dark -03 -> Ondark-text-low-emphasis
On Dark -04 -> Ondark-text-disabled
```