### PR TITLE
[CLNP-3674] feat: RTL(Right To Left) display support

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,15 @@ export default {
   },
   viteFinal: (config) => {
     return mergeConfig(config, {
+      css: {
+        postcss: {
+          plugins: [
+            require('postcss-rtlcss')({
+              mode: 'override',
+            }),
+          ],
+        },
+      },
       plugins: [svgr({ include: '**/*.svg' })],
     });
   },

--- a/apps/testing/src/utils/paramsBuilder.ts
+++ b/apps/testing/src/utils/paramsBuilder.ts
@@ -29,6 +29,7 @@ export const useConfigParams = (initParams: InitialParams): ParamsAsProps => {
     allowProfileEdit: parseValue(searchParams.get('enableProfileEdit')) ?? true,
     isMultipleFilesMessageEnabled: parseValue(searchParams.get('enableMultipleFilesMessage')) ?? true,
     enableLegacyChannelModules: parseValue(searchParams.get('enableLegacyChannelModules')) ?? false,
+    htmlTextDirection: parseValue(searchParams.get('htmlTextDirection')) ?? 'ltr',
     uikitOptions: {},
   } as ParamsAsProps;
 

--- a/apps/testing/vite.config.ts
+++ b/apps/testing/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import vitePluginSvgr from 'vite-plugin-svgr';
+import postcssRtl from "postcss-rtlcss";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), vitePluginSvgr({ include: '**/*.svg' })],
+  css: {
+    postcss: {
+      plugins: [postcssRtl({ mode: 'override' })],
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "jsdom": "^20.0.0",
     "plop": "^2.5.3",
     "postcss": "^8.3.5",
+    "postcss-rtlcss": "^5.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^4.9.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ import scss from "rollup-plugin-scss";
 import postcss from "rollup-plugin-postcss";
 import replace from "@rollup/plugin-replace";
 import autoprefixer from "autoprefixer";
+import postcssRtl from "postcss-rtlcss";
 import copy from "rollup-plugin-copy";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import {visualizer} from "rollup-plugin-visualizer";
@@ -57,7 +58,7 @@ export default {
           const result = scss.renderSync({ file: id });
           resolvecss({ code: result.css.toString() });
         }),
-      plugins: [autoprefixer],
+      plugins: [autoprefixer, postcssRtl({ mode: 'override' })],
       sourceMap: false,
       extract: "dist/index.css",
       extensions: [".sass", ".scss", ".css"],

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -49,7 +49,7 @@ import {
   SendbirdProviderUtils,
 } from './types';
 import { GlobalModalProvider, ModalRoot } from '../hooks/useModal';
-import { RenderUserProfileProps, UserListQuery } from '../types';
+import { HTMLTextDirection, RenderUserProfileProps, UserListQuery } from '../types';
 import PUBSUB_TOPICS, { SBUGlobalPubSub, SBUGlobalPubSubTopicPayloadUnion } from './pubSub/topics';
 import { EmojiManager } from './emojiManager';
 import { uikitConfigStorage } from './utils/uikitConfigStorage';
@@ -101,6 +101,7 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
   allowProfileEdit?: boolean;
   disableMarkAsDelivered?: boolean;
   breakpoint?: string | boolean;
+  htmlTextDirection?: HTMLTextDirection;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onUserProfileMessage?: (channel: GroupChannel) => void;
   uikitOptions?: UIKitOptions;
@@ -175,6 +176,7 @@ const SendbirdSDK = ({
   customExtensionParams,
   isMultipleFilesMessageEnabled = false,
   eventHandlers,
+  htmlTextDirection = 'ltr',
 }: SendbirdProviderProps): React.ReactElement => {
   const { logLevel = '', userMention = {}, isREMUnitEnabled = false, pubSub: customPubSub } = config;
   const { isMobile } = useMediaQueryContext();
@@ -393,6 +395,7 @@ const SendbirdSDK = ({
           isTypingIndicatorEnabledOnChannelList: configs.groupChannel.channelList.enableTypingIndicator,
           isMessageReceiptStatusEnabledOnChannelList: configs.groupChannel.channelList.enableMessageReceiptStatus,
           showSearchIcon: sdkInitialized && configsWithAppAttr(sdk).groupChannel.setting.enableMessageSearch,
+          htmlTextDirection,
         },
         eventHandlers,
         emojiManager,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,7 @@ import { SBUConfig } from '@sendbird/uikit-tools';
 import { Module, ModuleNamespaces } from '@sendbird/chat/lib/__definition';
 
 import type {
+  HTMLTextDirection,
   RenderUserProfileProps,
   ReplyType,
   UserListQuery,
@@ -71,6 +72,7 @@ export interface SendBirdStateConfig {
   appId: string;
   accessToken?: string;
   theme: string;
+  htmlTextDirection: HTMLTextDirection;
   pubSub: SBUGlobalPubSub;
   logger: Logger;
   setCurrentTheme: (theme: 'light' | 'dark') => void;

--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -19,6 +19,7 @@ export const AppLayout = (props: AppLayoutProps) => {
     currentChannel,
     setCurrentChannel,
     enableLegacyChannelModules,
+    htmlTextDirection,
   } = props;
 
   const globalStore = useSendbirdStateContext();
@@ -61,6 +62,7 @@ export const AppLayout = (props: AppLayoutProps) => {
               threadTargetMessage={threadTargetMessage}
               setThreadTargetMessage={setThreadTargetMessage}
               enableLegacyChannelModules={enableLegacyChannelModules}
+              htmlTextDirection={htmlTextDirection}
             />
           )
           : (
@@ -87,6 +89,7 @@ export const AppLayout = (props: AppLayoutProps) => {
               startingPoint={startingPoint}
               setStartingPoint={setStartingPoint}
               enableLegacyChannelModules={enableLegacyChannelModules}
+              htmlTextDirection={htmlTextDirection}
             />
           )
       }

--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -9,6 +9,7 @@ import { MobileLayout } from './MobileLayout';
 import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import { SendableMessageType } from '../../utils';
 import { getCaseResolvedReplyType } from '../../lib/utils/resolvedReplyType';
+import useApplyTextDirection from './hooks/useApplyTextDirection';
 
 export const AppLayout = (props: AppLayoutProps) => {
   const {
@@ -32,6 +33,8 @@ export const AppLayout = (props: AppLayoutProps) => {
   const [highlightedMessage, setHighlightedMessage] = useState<number | null>(null);
   const [startingPoint, setStartingPoint] = useState<number | null>(null);
   const { isMobile } = useMediaQueryContext();
+
+  useApplyTextDirection(htmlTextDirection);
 
   /**
    * Below configs can be set via Dashboard UIKit config setting but as a lower priority than App props.
@@ -62,7 +65,6 @@ export const AppLayout = (props: AppLayoutProps) => {
               threadTargetMessage={threadTargetMessage}
               setThreadTargetMessage={setThreadTargetMessage}
               enableLegacyChannelModules={enableLegacyChannelModules}
-              htmlTextDirection={htmlTextDirection}
             />
           )
           : (
@@ -89,7 +91,6 @@ export const AppLayout = (props: AppLayoutProps) => {
               startingPoint={startingPoint}
               setStartingPoint={setStartingPoint}
               enableLegacyChannelModules={enableLegacyChannelModules}
-              htmlTextDirection={htmlTextDirection}
             />
           )
       }

--- a/src/modules/App/DesktopLayout.tsx
+++ b/src/modules/App/DesktopLayout.tsx
@@ -39,6 +39,7 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
     threadTargetMessage,
     setThreadTargetMessage,
     enableLegacyChannelModules,
+    htmlTextDirection,
   } = props;
 
   const updateFocusedChannel = (channel: GroupChannelClass) => {
@@ -109,7 +110,7 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
   };
 
   return (
-    <div className="sendbird-app__wrap">
+    <div className="sendbird-app__wrap" dir={htmlTextDirection}>
       <div className="sendbird-app__channellist-wrap">
         {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}
       </div>

--- a/src/modules/App/DesktopLayout.tsx
+++ b/src/modules/App/DesktopLayout.tsx
@@ -13,6 +13,7 @@ import MessageSearchPannel from '../MessageSearch';
 import Thread from '../Thread';
 import { SendableMessageType } from '../../utils';
 import { classnames } from '../../utils/utils';
+import { APP_LAYOUT_ROOT } from './const';
 
 export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayoutProps) => {
   const {
@@ -39,7 +40,6 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
     threadTargetMessage,
     setThreadTargetMessage,
     enableLegacyChannelModules,
-    htmlTextDirection,
   } = props;
 
   const updateFocusedChannel = (channel: GroupChannelClass) => {
@@ -110,7 +110,7 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
   };
 
   return (
-    <div className="sendbird-app__wrap" dir={htmlTextDirection}>
+    <div className="sendbird-app__wrap" id={APP_LAYOUT_ROOT}>
       <div className="sendbird-app__channellist-wrap">
         {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}
       </div>

--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -17,6 +17,7 @@ import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import uuidv4 from '../../utils/uuid';
 import { ALL, useVoicePlayerContext } from '../../hooks/VoicePlayer';
 import { SendableMessageType } from '../../utils';
+import { APP_LAYOUT_ROOT } from './const';
 
 enum PANELS {
   CHANNEL_LIST = 'CHANNEL_LIST',
@@ -44,7 +45,6 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
     highlightedMessage,
     setHighlightedMessage,
     enableLegacyChannelModules,
-    htmlTextDirection,
   } = props;
   const [panel, setPanel] = useState(PANELS.CHANNEL_LIST);
 
@@ -166,7 +166,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
   };
 
   return (
-    <div className="sb_mobile" dir={htmlTextDirection}>
+    <div className="sb_mobile" id={APP_LAYOUT_ROOT}>
       {panel === PANELS.CHANNEL_LIST && (
         <div className="sb_mobile__panelwrap">
           {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}

--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -44,6 +44,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
     highlightedMessage,
     setHighlightedMessage,
     enableLegacyChannelModules,
+    htmlTextDirection,
   } = props;
   const [panel, setPanel] = useState(PANELS.CHANNEL_LIST);
 
@@ -165,7 +166,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
   };
 
   return (
-    <div className="sb_mobile">
+    <div className="sb_mobile" dir={htmlTextDirection}>
       {panel === PANELS.CHANNEL_LIST && (
         <div className="sb_mobile__panelwrap">
           {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}

--- a/src/modules/App/const.ts
+++ b/src/modules/App/const.ts
@@ -1,0 +1,1 @@
+export const APP_LAYOUT_ROOT = 'sendbird-app__layout';

--- a/src/modules/App/hooks/useApplyTextDirection.ts
+++ b/src/modules/App/hooks/useApplyTextDirection.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { MODAL_ROOT } from '../../../hooks/useModal';
+import { EMOJI_MENU_ROOT_ID, MENU_ROOT_ID } from '../../../ui/ContextMenu';
+import { HTMLTextDirection } from '../../../types';
+import { APP_LAYOUT_ROOT } from '../const';
+
+const ELEMENT_IDS = [
+  MODAL_ROOT,
+  EMOJI_MENU_ROOT_ID,
+  MENU_ROOT_ID,
+  APP_LAYOUT_ROOT,
+];
+
+/**
+ * This hook sets the direction (dir) attribute for specified elements.
+ *
+ * @param {HTMLTextDirection} direction - The direction to set ('ltr' or 'rtl').
+ *
+ * Note:
+ * This is necessary because elements such as modal, emoji reaction list, and dropdown
+ * are at the same level as the Sendbird app root element. They need to have the 'dir'
+ * attribute set explicitly to ensure proper directionality based on the app's language setting.
+ */
+const useApplyTextDirection = (direction: HTMLTextDirection) => {
+  useEffect(() => {
+    ELEMENT_IDS.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) {
+        element.dir = direction;
+      }
+    });
+  }, [direction]);
+};
+
+export default useApplyTextDirection;

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -44,6 +44,7 @@ export interface AppProps {
   isMessageGroupingEnabled?: AppLayoutProps['isMessageGroupingEnabled'];
   disableAutoSelect?: AppLayoutProps['disableAutoSelect'];
   onProfileEditSuccess?: AppLayoutProps['onProfileEditSuccess'];
+  htmlTextDirection?: AppLayoutProps['htmlTextDirection'];
 
   /**
    * The default value is false.
@@ -100,6 +101,7 @@ export default function App(props: AppProps) {
     isUserIdUsedForNickname = true,
     enableLegacyChannelModules = false,
     uikitOptions,
+    htmlTextDirection = 'ltr',
     // The below configs are duplicates of the Dashboard UIKit Configs.
     // Since their default values will be set in the Sendbird component,
     // we don't need to set them here.
@@ -167,6 +169,7 @@ export default function App(props: AppProps) {
         isReactionEnabled={isReactionEnabled}
         replyType={replyType}
         showSearchIcon={showSearchIcon}
+        htmlTextDirection={htmlTextDirection}
       />
     </Sendbird>
   );

--- a/src/modules/App/types.ts
+++ b/src/modules/App/types.ts
@@ -6,6 +6,7 @@ import {
   UserListQuery,
   RenderUserProfileProps,
   SendBirdProviderConfig,
+  HTMLTextDirection,
 } from '../../types';
 import { CustomExtensionParams, SBUEventHandlers, SendbirdChatInitParams } from '../../lib/types';
 import { SendableMessageType } from '../../utils';
@@ -13,6 +14,7 @@ import { SendableMessageType } from '../../utils';
 export interface AppLayoutProps {
   isReactionEnabled?: boolean;
   replyType?: 'NONE' | 'QUOTE_REPLY' | 'THREAD';
+  htmlTextDirection?: HTMLTextDirection;
   isMessageGroupingEnabled?: boolean;
   isMultipleFilesMessageEnabled?: boolean;
   allowProfileEdit?: boolean;

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
@@ -78,9 +78,11 @@
   }
   .sendbird-channel-settings__panel-icon-right {
     right: 16px;
+    /*rtl:raw:
+    transform: rotate(180deg);*/
   }
   .sendbird-channel-settings__panel-icon--open {
-    transform: rotate(90deg);
+    transform: rotate(90deg) /*rtl:rotate(270deg)*/;
   }
   .sendbird-channel-settings__panel-icon--chevron {
     path {

--- a/src/modules/ChannelSettings/components/UserPanel/user-panel.scss
+++ b/src/modules/ChannelSettings/components/UserPanel/user-panel.scss
@@ -32,5 +32,10 @@
   .sendbird-channel-settings-accordion__footer {
     padding-left: 14px;
     padding-top: 14px;
+    padding-bottom: 14px;
+    @include themed() {
+      background-color: t(bg-0);
+      border-bottom: 1px solid t(on-bg-4);
+    }
   }
 }

--- a/src/stories/apps/GroupChannelApp.stories.tsx
+++ b/src/stories/apps/GroupChannelApp.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof App> = {
         'isMessageReceiptStatusEnabledOnChannelList',
         'isMessageGroupingEnabled',
         'disableAutoSelect',
+        'htmlTextDirection',
       ],
     },
   },
@@ -136,6 +137,12 @@ const meta: Meta<typeof App> = {
         'A property that determines whether to automatically select another channel when the currently selected channel is deleted, or the user exits the channel, causing it to be deselected in the channel list.',
       control: 'boolean',
     },
+    htmlTextDirection: {
+      type: 'string',
+      description: 'A property that sets the text direction of the HTML. `ltr` is for left-to-right, and `rtl` is for right-to-left.',
+      control: 'radio',
+      options: ['ltr', 'rtl'],
+    }
   },
 };
 export default meta;
@@ -169,4 +176,5 @@ Default.args = {
   isMessageReceiptStatusEnabledOnChannelList: true,
   isMessageGroupingEnabled: true,
   disableAutoSelect: false,
+  htmlTextDirection: 'ltr',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,3 +91,5 @@ export enum MessageContentMiddleContainerType {
   DEFAULT = 'default',
   WIDE = 'wide',
 }
+
+export type HTMLTextDirection = 'ltr' | 'rtl';

--- a/src/ui/Accordion/index.scss
+++ b/src/ui/Accordion/index.scss
@@ -59,9 +59,11 @@
 }
 .sendbird-accordion__panel-icon-right {
   right: 16px;
+  /*rtl:raw:
+  transform: rotate(180deg);*/
 }
 .sendbird-accordion__panel-icon--open {
-  transform: rotate(90deg);
+  transform: rotate(90deg) /*rtl:rotate(270deg)*/;
 }
 .sendbird-accordion__panel-icon--chevron {
   path {

--- a/src/ui/ContextMenu/MenuItems.tsx
+++ b/src/ui/ContextMenu/MenuItems.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { classnames } from '../../utils/utils';
-import { MENU_OBSERVING_CLASS_NAME } from '.';
+import { MENU_OBSERVING_CLASS_NAME, MENU_ROOT_ID } from '.';
 
 interface MenuItemsProps {
   id?: string;
@@ -105,7 +105,7 @@ export default class MenuItems extends React.Component<MenuItemsProps, MenuItems
   };
 
   render(): ReactElement {
-    const portalElement = document.getElementById('sendbird-dropdown-portal');
+    const portalElement = document.getElementById(MENU_ROOT_ID);
     if (!portalElement)
       return <></>;
 

--- a/src/ui/ContextMenu/index.scss
+++ b/src/ui/ContextMenu/index.scss
@@ -17,7 +17,6 @@
   z-index: 99999;
   position: absolute;
   top: 100%;
-  left: 0;
   min-width: 140px;
   margin: 0px;
   padding: 8px 0px;

--- a/src/ui/ContextMenu/index.tsx
+++ b/src/ui/ContextMenu/index.tsx
@@ -69,7 +69,6 @@ export const MenuRoot = (): ReactElement => (
   <div id={MENU_ROOT_ID} className={MENU_ROOT_ID} />
 );
 
-// For the test environment
 export const EMOJI_MENU_ROOT_ID = 'sendbird-emoji-list-portal';
 export const EmojiReactionListRoot = (): ReactElement => <div id={EMOJI_MENU_ROOT_ID} />;
 

--- a/src/ui/FileViewer/index.scss
+++ b/src/ui/FileViewer/index.scss
@@ -127,6 +127,8 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
   top: calc(50% - 16px);
 }
 
+// Fliping the arrow icons for RTL is not necessary
+/*rtl:begin:ignore*/
 .sendbird-file-viewer-arrow--left {
   left: 14px;
 }
@@ -135,3 +137,4 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
   right: 14px;
   transform: rotate(180deg);
 }
+/*rtl:end:ignore*/

--- a/src/ui/MessageSearchItem/index.scss
+++ b/src/ui/MessageSearchItem/index.scss
@@ -71,7 +71,7 @@
   }
   .sendbird-message-search-item__left {
     @include themed() {
-      border-left: 4px solid t(primary-3);
+      border-inline-start: 4px solid t(primary-3);
     }
   }
 }

--- a/src/ui/ThreadReplies/index.scss
+++ b/src/ui/ThreadReplies/index.scss
@@ -88,4 +88,6 @@
 .sendbird-ui-thread-replies__icon {
   position: relative;
   display: inline-flex;
+  /*rtl:raw:
+  transform: rotate(180deg);*/
 }

--- a/src/ui/Toggle/index.scss
+++ b/src/ui/Toggle/index.scss
@@ -4,22 +4,24 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-
   box-sizing: border-box;
   cursor: pointer;
 }
+
 .sendbird-input-toggle-button--checked {
   @include themed() {
     background-color: t(primary-3);
     border: 1px solid t(primary-3);
   }
 }
+
 .sendbird-input-toggle-button--unchecked {
   @include themed() {
     background-color: t(bg-3);
     border: 1px solid t(bg-3);
   }
 }
+
 .sendbird-input-toggle-button--disabled {
   cursor: not-allowed;
   @include themed() {
@@ -43,49 +45,58 @@
 }
 
 /* Manage animation and position by status */
-@keyframes sendbirdMoveToRight {
+@keyframes sendbirdMoveToEnd {
   0% {
-    right: 60%;
+    inset-inline-end: 60%;
   }
   100% {
-    right: 10%;
+    inset-inline-end: 10%;
   }
 }
-@keyframes sendbirdMoveToLeft {
+
+@keyframes sendbirdMoveToStart {
   0% {
-    right: 10%;
+    inset-inline-end: 10%;
   }
   100% {
-    right: 60%;
+    inset-inline-end: 60%;
   }
 }
+
 // normal - animation
 .sendbird-input-toggle-button--turned-on .sendbird-input-toggle-button__inner-dot {
-  animation-name: sendbirdMoveToRight;
+  animation-name: sendbirdMoveToEnd;
 }
+
 .sendbird-input-toggle-button--turned-off .sendbird-input-toggle-button__inner-dot {
-  animation-name: sendbirdMoveToLeft;
+  animation-name: sendbirdMoveToStart;
 }
+
 // normal - position
 .sendbird-input-toggle-button--unchecked .sendbird-input-toggle-button__inner-dot {
-  right: 60%;
+  inset-inline-end: 60%;
 }
+
 .sendbird-input-toggle-button--checked .sendbird-input-toggle-button__inner-dot {
-  right: 10%;
+  inset-inline-end: 10%;
 }
+
 .sendbird-input-toggle-button--reversed {
   // reverse - animation
   .sendbird-input-toggle-button--turned-on .sendbird-input-toggle-button__inner-dot {
-    animation-name: sendbirdMoveToLeft;
+    animation-name: sendbirdMoveToStart;
   }
+
   .sendbird-input-toggle-button--turned-off .sendbird-input-toggle-button__inner-dot {
-    animation-name: sendbirdMoveToRight;
+    animation-name: sendbirdMoveToEnd;
   }
+
   // reverse - position
   &.sendbird-input-toggle-button--unchecked .sendbird-input-toggle-button__inner-dot {
-    right: 10%;
+    inset-inline-end: 10%;
   }
+
   &.sendbird-input-toggle-button--checked .sendbird-input-toggle-button__inner-dot {
-    right: 60%;
+    inset-inline-end: 60%;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,6 +2710,7 @@ __metadata:
     jsdom: ^20.0.0
     plop: ^2.5.3
     postcss: ^8.3.5
+    postcss-rtlcss: ^5.3.0
     react: ^18.2.0
     react-dom: ^18.2.0
     rollup: ^4.9.2
@@ -12966,6 +12967,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-rtlcss@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "postcss-rtlcss@npm:5.3.0"
+  dependencies:
+    rtlcss: 4.1.1
+  peerDependencies:
+    postcss: ^8.4.21
+  checksum: bd9bd09dc3b45b65db83dc8a0189701d1039b712916484bcb6afb7465a8343eafb0c09464c4d9079f016847e699a5724454e75855fb21fe72aa1b2b415f888ac
+  languageName: node
+  linkType: hard
+
 "postcss-safe-parser@npm:^4.0.2":
   version: 4.0.2
   resolution: "postcss-safe-parser@npm:4.0.2"
@@ -13063,7 +13075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.5, postcss@npm:^8.4.38":
+"postcss@npm:^8.3.5, postcss@npm:^8.4.21, postcss@npm:^8.4.38":
   version: 8.4.38
   resolution: "postcss@npm:8.4.38"
   dependencies:
@@ -14040,6 +14052,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: fe19998a00401e7c2a41171e7d42af549176c6abfb6b20c4d0f401c973a3c7ad368605a722194bb21fe32775563eac06b53c9d96b24ef3d0ac95f69c5a3b67c8
+  languageName: node
+  linkType: hard
+
+"rtlcss@npm:4.1.1":
+  version: 4.1.1
+  resolution: "rtlcss@npm:4.1.1"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+    postcss: ^8.4.21
+    strip-json-comments: ^3.1.1
+  bin:
+    rtlcss: bin/rtlcss.js
+  checksum: dcf37d76265b5c84d610488afa68a2506d008f95feac968b35ccae9aa49e7019ae0336a80363303f8f8bbf60df3ecdeb60413548b049114a24748319b68aefde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-3543 

I added `htmlTextDirection` prop(The original element attribute name is `dir` but I chose to be more elaborate in our app) to SendbirdProvider to support Right To Left(RTL) text direction display for the middle east customers. 
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dir