### PR TITLE
refactor: Support customizing message menu on mobile

### DIFF
--- a/src/ui/MessageMenu/index.scss
+++ b/src/ui/MessageMenu/index.scss
@@ -10,6 +10,7 @@
   cursor: pointer;
   white-space: nowrap;
   padding: 8px 16px;
+  display: flex;
 
   &.disable {
     cursor: not-allowed;
@@ -26,4 +27,11 @@
       background-color: t(bg--1-4);
     }
   }
+}
+
+.sendbird-menu-item>* {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }

--- a/src/ui/MessageMenu/items.tsx
+++ b/src/ui/MessageMenu/items.tsx
@@ -44,9 +44,10 @@ export interface MenuItemProps {
   disabled?: boolean;
   tabIndex?: number;
   testID?: string;
-  onClick?: (e: MouseEvent<HTMLLIElement>) => void;
+  onClick?: (e: MouseEvent<HTMLLIElement | HTMLDivElement>) => void;
   children: ReactNode;
 }
+
 export const MenuItem = ({
   className,
   disabled,

--- a/src/ui/MobileMenu/MobileContextMenu.tsx
+++ b/src/ui/MobileMenu/MobileContextMenu.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import type { BaseMenuProps } from './types';
 import type { FileMessage, UserMessage } from '@sendbird/chat/message';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
 
-import ContextMenu, { MenuItems, MenuItem } from '../ContextMenu';
+import ContextMenu, { MenuItems } from '../ContextMenu';
+import { MenuItem, PrebuildMenuItemPropsType } from '../MessageMenu/items';
 
 import {
   isFailedMessage,
@@ -17,7 +19,6 @@ import {
 import { useLocalization } from '../../lib/LocalizationContext';
 import Icon, { IconTypes, IconColors } from '../Icon';
 import Label, { LabelColors, LabelTypography } from '../Label';
-import { GroupChannel } from '@sendbird/chat/groupChannel';
 
 const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMenuProps): React.ReactElement => {
   const {
@@ -36,22 +37,18 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
     onReplyInThread,
     isOpenedFromThread = false,
     onDownloadClick = null,
+    renderMenuItems,
   } = props;
   const isByMe = message?.sender?.userId === userId;
   const { stringSet } = useLocalization();
+
+  // Menu Items condition
   const showMenuItemCopy: boolean = isUserMessage(message as UserMessage);
   const showMenuItemEdit: boolean = (isUserMessage(message as UserMessage) && isSentMessage(message) && isByMe);
   const showMenuItemResend: boolean = (isFailedMessage(message) && message?.isResendable && isByMe);
-
   const showMenuItemDelete: boolean = !isPendingMessage(message) && isByMe;
   const showMenuItemDeleteByState = isByMe && (deleteMenuState === undefined || deleteMenuState !== 'HIDE');
   const showMenuItemDeleteFinal = showMenuItemDeleteByState && showMenuItemDelete;
-
-  const disableDelete = (
-    (deleteMenuState !== undefined && deleteMenuState === 'DISABLE')
-    || (message?.threadInfo?.replyCount ?? 0) > 0
-  );
-
   const showMenuItemDownload: boolean = !isPendingMessage(message) && isFileMessage(message)
     && !(isVoiceMessage(message) && ((channel as GroupChannel)?.isSuper || (channel as GroupChannel)?.isBroadcast));
   const showMenuItemReply: boolean = (replyType === 'QUOTE_REPLY')
@@ -63,6 +60,228 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
     && !isPendingMessage(message)
     && !isThreadMessage(message)
     && channel?.isGroupChannel();
+  const disableDelete = (
+    (deleteMenuState !== undefined && deleteMenuState === 'DISABLE')
+    || (message?.threadInfo?.replyCount ?? 0) > 0
+  );
+
+  const Copy = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+        copyToClipboard((message as UserMessage)?.message);
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={LabelColors.ONBACKGROUND_1}
+          >
+            {stringSet?.MESSAGE_MENU__COPY}
+          </Label>
+          <Icon
+            type={IconTypes.COPY}
+            fillColor={IconColors.PRIMARY}
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Reply = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+        setQuoteMessage?.(message);
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={
+              (message?.parentMessageId ?? 0) > 0
+                ? LabelColors.ONBACKGROUND_4
+                : LabelColors.ONBACKGROUND_1
+            }
+          >
+            {stringSet.MESSAGE_MENU__REPLY}
+          </Label>
+          <Icon
+            type={IconTypes.REPLY}
+            fillColor={
+              (message?.parentMessageId ?? 0) > 0
+                ? IconColors.ON_BACKGROUND_4
+                : IconColors.PRIMARY
+            }
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Thread = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+        onReplyInThread?.({ message });
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={LabelColors.ONBACKGROUND_1}
+          >
+            {stringSet.MESSAGE_MENU__THREAD}
+          </Label>
+          <Icon
+            type={IconTypes.THREAD}
+            fillColor={IconColors.PRIMARY}
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Edit = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+        showEdit?.(true);
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={LabelColors.ONBACKGROUND_1}
+          >
+            {stringSet.MESSAGE_MENU__EDIT}
+          </Label>
+          <Icon
+            type={IconTypes.EDIT}
+            fillColor={IconColors.PRIMARY}
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Resend = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+        resendMessage?.(message);
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={LabelColors.ONBACKGROUND_1}
+          >
+            {stringSet.MESSAGE_MENU__RESEND}
+          </Label>
+          <Icon
+            type={IconTypes.REFRESH}
+            fillColor={IconColors.PRIMARY}
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Delete = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        if (isFailedMessage(message)) {
+          hideMenu();
+          deleteMessage?.(message);
+        } else if (!disableDelete) {
+          hideMenu();
+          showRemove?.(true);
+        }
+      }}
+    >
+      {props?.children ?? (
+        <>
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={
+              disableDelete
+                ? LabelColors.ONBACKGROUND_4
+                : LabelColors.ONBACKGROUND_1
+            }
+          >
+            {stringSet.MESSAGE_MENU__DELETE}
+          </Label>
+          <Icon
+            type={IconTypes.DELETE}
+            fillColor={
+              disableDelete
+                ? IconColors.ON_BACKGROUND_4
+                : IconColors.PRIMARY
+            }
+            width="24px"
+            height="24px"
+          />
+        </>
+      )}
+    </MenuItem>
+  );
+  const Download = (props: PrebuildMenuItemPropsType) => (
+    <MenuItem
+      {...props}
+      onClick={() => {
+        hideMenu();
+      }}
+    >
+      {props?.children ?? (
+        <a
+          className="sendbird-message__contextmenu--hyperlink"
+          rel="noopener noreferrer"
+          href={fileMessage?.url}
+          target="_blank"
+          onClick={onDownloadClick}
+        >
+          <Label
+            type={LabelTypography.SUBTITLE_1}
+            color={LabelColors.ONBACKGROUND_1}
+          >
+            {stringSet.MESSAGE_MENU__SAVE}
+          </Label>
+          <Icon
+            type={IconTypes.DOWNLOAD}
+            fillColor={IconColors.PRIMARY}
+            width="24px"
+            height="24px"
+          />
+        </a>
+      )}
+    </MenuItem>
+  );
+  const prebuildItems = {
+    Copy,
+    Reply,
+    Thread,
+    Edit,
+    Resend,
+    Delete,
+    Download,
+  };
 
   const fileMessage = message as FileMessage;
   return (
@@ -75,197 +294,19 @@ const MobileContextMenu: React.FunctionComponent<BaseMenuProps> = (props: BaseMe
           parentContainRef={parentRef}
           closeDropdown={hideMenu}
         >
-          {showMenuItemCopy && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-copy"
-              onClick={() => {
-                hideMenu();
-                copyToClipboard((message as UserMessage)?.message);
-              }}
-              testID="ui_mobile_message_item_menu_copy"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={LabelColors.ONBACKGROUND_1}
-              >
-                {stringSet?.MESSAGE_MENU__COPY}
-              </Label>
-              <Icon
-                type={IconTypes.COPY}
-                fillColor={IconColors.PRIMARY}
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemReply && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-reply"
-              onClick={() => {
-                hideMenu();
-                setQuoteMessage?.(message);
-              }}
-              disable={(message?.parentMessageId ?? 0) > 0}
-              testID="ui_mobile_message_item_menu_reply"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={
-                  (message?.parentMessageId ?? 0) > 0
-                    ? LabelColors.ONBACKGROUND_4
-                    : LabelColors.ONBACKGROUND_1
-                }
-              >
-                {stringSet.MESSAGE_MENU__REPLY}
-              </Label>
-              <Icon
-                type={IconTypes.REPLY}
-                fillColor={
-                  (message?.parentMessageId ?? 0) > 0
-                    ? IconColors.ON_BACKGROUND_4
-                    : IconColors.PRIMARY
-                }
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemThread && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-reply"
-              onClick={() => {
-                hideMenu();
-                onReplyInThread?.({ message });
-              }}
-              testID="ui_mobile_message_item_menu_thread"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={LabelColors.ONBACKGROUND_1}
-              >
-                {stringSet.MESSAGE_MENU__THREAD}
-              </Label>
-              <Icon
-                type={IconTypes.THREAD}
-                fillColor={IconColors.PRIMARY}
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemEdit && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-edit"
-              onClick={() => {
-                hideMenu();
-                showEdit?.(true);
-              }}
-              testID="ui_mobile_message_item_menu_edit"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={LabelColors.ONBACKGROUND_1}
-              >
-                {stringSet.MESSAGE_MENU__EDIT}
-              </Label>
-              <Icon
-                type={IconTypes.EDIT}
-                fillColor={IconColors.PRIMARY}
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemResend && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-resend"
-              onClick={() => {
-                hideMenu();
-                resendMessage?.(message);
-              }}
-              testID="ui_mobile_message_item_menu_resend"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={LabelColors.ONBACKGROUND_1}
-              >
-                {stringSet.MESSAGE_MENU__RESEND}
-              </Label>
-              <Icon
-                type={IconTypes.REFRESH}
-                fillColor={IconColors.PRIMARY}
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemDeleteFinal && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-delete"
-              onClick={() => {
-                if (isFailedMessage(message)) {
-                  hideMenu();
-                  deleteMessage?.(message);
-                } else if (!disableDelete) {
-                  hideMenu();
-                  showRemove?.(true);
-                }
-              }}
-              disable={disableDelete}
-              testID="ui_mobile_message_item_menu_delete"
-            >
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={
-                  disableDelete
-                    ? LabelColors.ONBACKGROUND_4
-                    : LabelColors.ONBACKGROUND_1
-                }
-              >
-                {stringSet.MESSAGE_MENU__DELETE}
-              </Label>
-              <Icon
-                type={IconTypes.DELETE}
-                fillColor={
-                  disableDelete
-                    ? IconColors.ON_BACKGROUND_4
-                    : IconColors.PRIMARY
-                }
-                width="24px"
-                height="24px"
-              />
-            </MenuItem>
-          )}
-          {showMenuItemDownload && (
-            <MenuItem
-              className="sendbird-message__mobile-context-menu-item menu-item-save"
-              onClick={() => {
-                hideMenu();
-              }}
-              testID="ui_mobile_message_item_menu_download_file"
-            >
-              <a
-                className="sendbird-message__contextmenu--hyperlink"
-                rel="noopener noreferrer"
-                href={fileMessage?.url}
-                target="_blank"
-                onClick={onDownloadClick}
-              >
-                <Label
-                  type={LabelTypography.SUBTITLE_1}
-                  color={LabelColors.ONBACKGROUND_1}
-                >
-                  {stringSet.MESSAGE_MENU__SAVE}
-                </Label>
-                <Icon
-                  type={IconTypes.DOWNLOAD}
-                  fillColor={IconColors.PRIMARY}
-                  width="24px"
-                  height="24px"
-                />
-              </a>
-            </MenuItem>
-          )}
+          {
+            renderMenuItems?.({ close: hideMenu, prebuildItems }) ?? (
+              <>
+                {showMenuItemCopy && (<Copy />)}
+                {showMenuItemReply && (<Reply />)}
+                {showMenuItemThread && (<Thread />)}
+                {showMenuItemEdit && (<Edit />)}
+                {showMenuItemResend && (<Resend />)}
+                {showMenuItemDeleteFinal && (<Delete />)}
+                {showMenuItemDownload && (<Download />)}
+              </>
+            )
+          }
         </MenuItems>
       )}
     />

--- a/src/ui/MobileMenu/bottomSheetMenuItem.tsx
+++ b/src/ui/MobileMenu/bottomSheetMenuItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { MenuItemProps } from '../MessageMenu/items';
+import { classnames } from '../../utils/utils';
+
+export const BottomSheetMenuItem = ({
+  className,
+  disabled = false,
+  tabIndex = 0,
+  testID,
+  onClick,
+  children,
+}: MenuItemProps) => {
+  return (
+    <div
+      className={classnames('sendbird-message__bottomsheet--action', className)}
+      role="menuitem"
+      tabIndex={tabIndex}
+      aria-disabled={disabled}
+      onClick={onClick}
+      data-testid={testID}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/ui/MobileMenu/types.ts
+++ b/src/ui/MobileMenu/types.ts
@@ -1,9 +1,10 @@
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, ReactNode } from 'react';
 import type { EmojiContainer } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { OpenChannel } from '@sendbird/chat/openChannel';
 import { CoreMessageType, SendableMessageType } from '../../utils';
 import { ReplyType } from '../../types';
+import { RenderMenuItemsParams } from '../MessageMenu/messageMenu';
 
 // Fixme@v4 - deleteMessageOption type, rethink options
 export type DeleteMenuStates = 'DISABLE' | 'HIDE' | 'ACTIVE';
@@ -28,6 +29,7 @@ export interface BaseMenuProps {
   onReplyInThread?: (props: { message: SendableMessageType }) => void;
   isOpenedFromThread?: boolean;
   onDownloadClick?: (e: MouseEvent) => Promise<void>;
+  renderMenuItems?: (params: RenderMenuItemsParams) => ReactNode;
 }
 
 export interface MobileBottomSheetProps extends BaseMenuProps {


### PR DESCRIPTION
[CLNP-3379](https://sendbird.atlassian.net/browse/CLNP-3379)

* Added `renderMenuItems` to `MobileBottomSheet` and `MobileContextMenu` components.
  Now you can use the pre-build menu items to make a custom message menu via `renderMobileMenuOnLongPress` of `MessageContent` component

[CLNP-3379]: https://sendbird.atlassian.net/browse/CLNP-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ