### PR TITLE
[CLNP-3692] Apply postcss-rtlcss plugin for RTL support

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,15 @@ export default {
   },
   viteFinal: (config) => {
     return mergeConfig(config, {
+      css: {
+        postcss: {
+          plugins: [
+            require('postcss-rtlcss')({
+              mode: 'override',
+            }),
+          ],
+        },
+      },
       plugins: [svgr({ include: '**/*.svg' })],
     });
   },

--- a/apps/testing/vite.config.ts
+++ b/apps/testing/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import vitePluginSvgr from 'vite-plugin-svgr';
+import postcssRtl from "postcss-rtlcss";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), vitePluginSvgr({ include: '**/*.svg' })],
+  css: {
+    postcss: {
+      plugins: [postcssRtl({ mode: 'override' })],
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "jsdom": "^20.0.0",
     "plop": "^2.5.3",
     "postcss": "^8.3.5",
+    "postcss-rtlcss": "^5.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^4.9.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ import scss from "rollup-plugin-scss";
 import postcss from "rollup-plugin-postcss";
 import replace from "@rollup/plugin-replace";
 import autoprefixer from "autoprefixer";
+import postcssRtl from "postcss-rtlcss";
 import copy from "rollup-plugin-copy";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import {visualizer} from "rollup-plugin-visualizer";
@@ -57,7 +58,7 @@ export default {
           const result = scss.renderSync({ file: id });
           resolvecss({ code: result.css.toString() });
         }),
-      plugins: [autoprefixer],
+      plugins: [autoprefixer, postcssRtl({ mode: 'override' })],
       sourceMap: false,
       extract: "dist/index.css",
       extensions: [".sass", ".scss", ".css"],

--- a/src/modules/App/AppLayout.tsx
+++ b/src/modules/App/AppLayout.tsx
@@ -9,6 +9,7 @@ import { MobileLayout } from './MobileLayout';
 import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import { SendableMessageType } from '../../utils';
 import { getCaseResolvedReplyType } from '../../lib/utils/resolvedReplyType';
+import useApplyTextDirection from './hooks/useApplyTextDirection';
 
 export const AppLayout = (props: AppLayoutProps) => {
   const {
@@ -32,6 +33,8 @@ export const AppLayout = (props: AppLayoutProps) => {
   const [highlightedMessage, setHighlightedMessage] = useState<number | null>(null);
   const [startingPoint, setStartingPoint] = useState<number | null>(null);
   const { isMobile } = useMediaQueryContext();
+
+  useApplyTextDirection(htmlTextDirection);
 
   /**
    * Below configs can be set via Dashboard UIKit config setting but as a lower priority than App props.
@@ -62,7 +65,6 @@ export const AppLayout = (props: AppLayoutProps) => {
               threadTargetMessage={threadTargetMessage}
               setThreadTargetMessage={setThreadTargetMessage}
               enableLegacyChannelModules={enableLegacyChannelModules}
-              htmlTextDirection={htmlTextDirection}
             />
           )
           : (
@@ -89,7 +91,6 @@ export const AppLayout = (props: AppLayoutProps) => {
               startingPoint={startingPoint}
               setStartingPoint={setStartingPoint}
               enableLegacyChannelModules={enableLegacyChannelModules}
-              htmlTextDirection={htmlTextDirection}
             />
           )
       }

--- a/src/modules/App/DesktopLayout.tsx
+++ b/src/modules/App/DesktopLayout.tsx
@@ -13,6 +13,7 @@ import MessageSearchPannel from '../MessageSearch';
 import Thread from '../Thread';
 import { SendableMessageType } from '../../utils';
 import { classnames } from '../../utils/utils';
+import { APP_LAYOUT_ROOT } from './const';
 
 export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayoutProps) => {
   const {
@@ -39,7 +40,6 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
     threadTargetMessage,
     setThreadTargetMessage,
     enableLegacyChannelModules,
-    htmlTextDirection,
   } = props;
 
   const updateFocusedChannel = (channel: GroupChannelClass) => {
@@ -110,7 +110,7 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
   };
 
   return (
-    <div className="sendbird-app__wrap" dir={htmlTextDirection}>
+    <div className="sendbird-app__wrap" id={APP_LAYOUT_ROOT}>
       <div className="sendbird-app__channellist-wrap">
         {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}
       </div>

--- a/src/modules/App/MobileLayout.tsx
+++ b/src/modules/App/MobileLayout.tsx
@@ -17,6 +17,7 @@ import useSendbirdStateContext from '../../hooks/useSendbirdStateContext';
 import uuidv4 from '../../utils/uuid';
 import { ALL, useVoicePlayerContext } from '../../hooks/VoicePlayer';
 import { SendableMessageType } from '../../utils';
+import { APP_LAYOUT_ROOT } from './const';
 
 enum PANELS {
   CHANNEL_LIST = 'CHANNEL_LIST',
@@ -44,7 +45,6 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
     highlightedMessage,
     setHighlightedMessage,
     enableLegacyChannelModules,
-    htmlTextDirection,
   } = props;
   const [panel, setPanel] = useState(PANELS.CHANNEL_LIST);
 
@@ -166,7 +166,7 @@ export const MobileLayout: React.FC<MobileLayoutProps> = (props: MobileLayoutPro
   };
 
   return (
-    <div className="sb_mobile" dir={htmlTextDirection}>
+    <div className="sb_mobile" id={APP_LAYOUT_ROOT}>
       {panel === PANELS.CHANNEL_LIST && (
         <div className="sb_mobile__panelwrap">
           {enableLegacyChannelModules ? <ChannelList {...channelListProps} /> : <GroupChannelList {...channelListProps} />}

--- a/src/modules/App/const.ts
+++ b/src/modules/App/const.ts
@@ -1,0 +1,1 @@
+export const APP_LAYOUT_ROOT = 'sendbird-app__layout';

--- a/src/modules/App/hooks/useApplyTextDirection.ts
+++ b/src/modules/App/hooks/useApplyTextDirection.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { MODAL_ROOT } from '../../../hooks/useModal';
+import { EMOJI_REACTION_LIST_PORTAL_ROOT, DROPDOWN_PORTAL_ROOT } from '../../../ui/ContextMenu';
+import { HTMLTextDirection } from '../../../types';
+import { APP_LAYOUT_ROOT } from '../const';
+
+const ELEMENT_IDS = [
+  MODAL_ROOT,
+  EMOJI_REACTION_LIST_PORTAL_ROOT,
+  DROPDOWN_PORTAL_ROOT,
+  APP_LAYOUT_ROOT,
+];
+
+/**
+ * This hook sets the direction (dir) attribute for specified elements.
+ *
+ * @param {HTMLTextDirection} direction - The direction to set ('ltr' or 'rtl').
+ *
+ * Note:
+ * This is necessary because elements such as modal, emoji reaction list, and dropdown
+ * are at the same level as the Sendbird app root element. They need to have the 'dir'
+ * attribute set explicitly to ensure proper directionality based on the app's language setting.
+ */
+const useApplyTextDirection = (direction: HTMLTextDirection) => {
+  useEffect(() => {
+    ELEMENT_IDS.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) {
+        element.dir = direction;
+      }
+    });
+  }, [direction]);
+};
+
+export default useApplyTextDirection;

--- a/src/ui/ContextMenu/EmojiListItems.tsx
+++ b/src/ui/ContextMenu/EmojiListItems.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 
 import SortByRow from '../SortByRow';
 import { Nullable } from '../../types';
+import { EMOJI_REACTION_LIST_PORTAL_ROOT } from './index';
 
 const defaultParentRect = { x: 0, y: 0, left: 0, top: 0, height: 0 };
 type SpaceFromTrigger = { x: number, y: number };
@@ -86,7 +87,7 @@ export const EmojiListItems = ({
     }
   }, []);
 
-  const rootElement = document.getElementById('sendbird-emoji-list-portal');
+  const rootElement = document.getElementById(EMOJI_REACTION_LIST_PORTAL_ROOT);
   if (rootElement) {
     return (
       createPortal(

--- a/src/ui/ContextMenu/MenuItems.tsx
+++ b/src/ui/ContextMenu/MenuItems.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { createPortal } from 'react-dom';
+import { DROPDOWN_PORTAL_ROOT } from './index';
 
 interface MenuItemsProps {
   className?: string;
@@ -102,7 +103,7 @@ export default class MenuItems extends React.Component<MenuItemsProps, MenuItems
   };
 
   render(): ReactElement {
-    const portalElement = document.getElementById('sendbird-dropdown-portal');
+    const portalElement = document.getElementById(DROPDOWN_PORTAL_ROOT);
     if (!portalElement)
       return <></>;
 

--- a/src/ui/ContextMenu/index.scss
+++ b/src/ui/ContextMenu/index.scss
@@ -17,7 +17,6 @@
   z-index: 99999;
   position: absolute;
   top: 100%;
-  left: 0;
   min-width: 140px;
   margin: 0px;
   padding: 8px 0px;

--- a/src/ui/ContextMenu/index.tsx
+++ b/src/ui/ContextMenu/index.tsx
@@ -60,15 +60,17 @@ export const MenuItem = ({
   );
 };
 
+export const DROPDOWN_PORTAL_ROOT = 'sendbird-dropdown-portal';
 export const MenuRoot = (): ReactElement => (
   <div
-    id="sendbird-dropdown-portal"
-    className="sendbird-dropdown-portal"
+    id={DROPDOWN_PORTAL_ROOT}
+    className={DROPDOWN_PORTAL_ROOT}
   />
 );
 
+export const EMOJI_REACTION_LIST_PORTAL_ROOT = 'sendbird-emoji-list-portal';
 // For the test environment
-export const EmojiReactionListRoot = (): ReactElement => <div id="sendbird-emoji-list-portal" />;
+export const EmojiReactionListRoot = (): ReactElement => <div id={EMOJI_REACTION_LIST_PORTAL_ROOT} />;
 
 type MenuDisplayingFunc = () => void;
 export interface ContextMenuProps {

--- a/src/ui/FileViewer/index.scss
+++ b/src/ui/FileViewer/index.scss
@@ -127,6 +127,8 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
   top: calc(50% - 16px);
 }
 
+// Fliping the arrow icons for RTL is not necessary
+/*rtl:begin:ignore*/
 .sendbird-file-viewer-arrow--left {
   left: 14px;
 }
@@ -135,3 +137,4 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
   right: 14px;
   transform: rotate(180deg);
 }
+/*rtl:end:ignore*/

--- a/src/ui/Toggle/index.scss
+++ b/src/ui/Toggle/index.scss
@@ -4,22 +4,24 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-
   box-sizing: border-box;
   cursor: pointer;
 }
+
 .sendbird-input-toggle-button--checked {
   @include themed() {
     background-color: t(primary-3);
     border: 1px solid t(primary-3);
   }
 }
+
 .sendbird-input-toggle-button--unchecked {
   @include themed() {
     background-color: t(bg-3);
     border: 1px solid t(bg-3);
   }
 }
+
 .sendbird-input-toggle-button--disabled {
   cursor: not-allowed;
   @include themed() {
@@ -43,49 +45,58 @@
 }
 
 /* Manage animation and position by status */
-@keyframes sendbirdMoveToRight {
+@keyframes sendbirdMoveToEnd {
   0% {
-    right: 60%;
+    inset-inline-end: 60%;
   }
   100% {
-    right: 10%;
+    inset-inline-end: 10%;
   }
 }
-@keyframes sendbirdMoveToLeft {
+
+@keyframes sendbirdMoveToStart {
   0% {
-    right: 10%;
+    inset-inline-end: 10%;
   }
   100% {
-    right: 60%;
+    inset-inline-end: 60%;
   }
 }
+
 // normal - animation
 .sendbird-input-toggle-button--turned-on .sendbird-input-toggle-button__inner-dot {
-  animation-name: sendbirdMoveToRight;
+  animation-name: sendbirdMoveToEnd;
 }
+
 .sendbird-input-toggle-button--turned-off .sendbird-input-toggle-button__inner-dot {
-  animation-name: sendbirdMoveToLeft;
+  animation-name: sendbirdMoveToStart;
 }
+
 // normal - position
 .sendbird-input-toggle-button--unchecked .sendbird-input-toggle-button__inner-dot {
-  right: 60%;
+  inset-inline-end: 60%;
 }
+
 .sendbird-input-toggle-button--checked .sendbird-input-toggle-button__inner-dot {
-  right: 10%;
+  inset-inline-end: 10%;
 }
+
 .sendbird-input-toggle-button--reversed {
   // reverse - animation
   .sendbird-input-toggle-button--turned-on .sendbird-input-toggle-button__inner-dot {
-    animation-name: sendbirdMoveToLeft;
+    animation-name: sendbirdMoveToStart;
   }
+
   .sendbird-input-toggle-button--turned-off .sendbird-input-toggle-button__inner-dot {
-    animation-name: sendbirdMoveToRight;
+    animation-name: sendbirdMoveToEnd;
   }
+
   // reverse - position
   &.sendbird-input-toggle-button--unchecked .sendbird-input-toggle-button__inner-dot {
-    right: 10%;
+    inset-inline-end: 10%;
   }
+
   &.sendbird-input-toggle-button--checked .sendbird-input-toggle-button__inner-dot {
-    right: 60%;
+    inset-inline-end: 60%;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,6 +2710,7 @@ __metadata:
     jsdom: ^20.0.0
     plop: ^2.5.3
     postcss: ^8.3.5
+    postcss-rtlcss: ^5.3.0
     react: ^18.2.0
     react-dom: ^18.2.0
     rollup: ^4.9.2
@@ -12966,6 +12967,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-rtlcss@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "postcss-rtlcss@npm:5.3.0"
+  dependencies:
+    rtlcss: 4.1.1
+  peerDependencies:
+    postcss: ^8.4.21
+  checksum: bd9bd09dc3b45b65db83dc8a0189701d1039b712916484bcb6afb7465a8343eafb0c09464c4d9079f016847e699a5724454e75855fb21fe72aa1b2b415f888ac
+  languageName: node
+  linkType: hard
+
 "postcss-safe-parser@npm:^4.0.2":
   version: 4.0.2
   resolution: "postcss-safe-parser@npm:4.0.2"
@@ -13063,7 +13075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.5, postcss@npm:^8.4.38":
+"postcss@npm:^8.3.5, postcss@npm:^8.4.21, postcss@npm:^8.4.38":
   version: 8.4.38
   resolution: "postcss@npm:8.4.38"
   dependencies:
@@ -14040,6 +14052,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: fe19998a00401e7c2a41171e7d42af549176c6abfb6b20c4d0f401c973a3c7ad368605a722194bb21fe32775563eac06b53c9d96b24ef3d0ac95f69c5a3b67c8
+  languageName: node
+  linkType: hard
+
+"rtlcss@npm:4.1.1":
+  version: 4.1.1
+  resolution: "rtlcss@npm:4.1.1"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+    postcss: ^8.4.21
+    strip-json-comments: ^3.1.1
+  bin:
+    rtlcss: bin/rtlcss.js
+  checksum: dcf37d76265b5c84d610488afa68a2506d008f95feac968b35ccae9aa49e7019ae0336a80363303f8f8bbf60df3ecdeb60413548b049114a24748319b68aefde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Applied [postcss-rtlcss plugin](https://github.com/elchininet/postcss-rtlcss) for the better RTL support without tedious manual CSS style modifications. 

### What has been done? 
- [x] Added plugin configuration to storybook/main.ts - Allows testing of RTL support during development.
- [x] Added plugin configuration to rollup.config.js - Ensures build artifacts support RTL languages.
- [x] Created useHTMLTextDirection custom hook - Applies the dir attribute to modal and dropdown portal components for correct RTL rendering.

### Why postcss-rtlcss Plugin?
postcss-rtlcss automates the conversion of LTR CSS to RTL, ensuring consistency and reducing manual errors.
It automates CSS transformation by converting LTR styles to RTL, ensuring proper alignment and display in RTL mode.

You can play around in here https://elchininet.github.io/postcss-rtlcss/ to see what kind of modifications could be made by this plugin. 