### PR TITLE
fix: accordion chevron direction in RTL

### DIFF
--- a/src/ui/Accordion/index.scss
+++ b/src/ui/Accordion/index.scss
@@ -59,9 +59,11 @@
 }
 .sendbird-accordion__panel-icon-right {
   right: 16px;
+  /*rtl:raw:
+  transform: rotate(180deg);*/
 }
 .sendbird-accordion__panel-icon--open {
-  transform: rotate(90deg);
+  transform: rotate(90deg) /*rtl:rotate(270deg)*/;
 }
 .sendbird-accordion__panel-icon--chevron {
   path {


### PR DESCRIPTION
I found one more after #1147 merged 😅

**as-is** 
<img width="300" alt="Screenshot 2024-06-25 at 9 45 12 AM" src="https://github.com/sendbird/sendbird-uikit-react/assets/10060731/1e3f4311-e525-4cc0-a1de-97c6df26bf9c">

**to-be**
<img width="300" alt="Screenshot 2024-06-25 at 9 45 06 AM" src="https://github.com/sendbird/sendbird-uikit-react/assets/10060731/ceee400a-3465-4b44-9b2b-bf19abfd77f0">