### PR TITLE
[CLNP-3259] refactor: enable ChannelSetting > MenuItem customization

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -57,14 +57,17 @@ export default {
   // ChannelSettings
   ChannelSettings: 'src/modules/ChannelSettings/index.tsx',
   'ChannelSettings/context': 'src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx',
-  'ChannelSettings/components/ModerationPanel': 'src/modules/ChannelSettings/components/ModerationPanel/index.tsx',
   'ChannelSettings/components/ChannelProfile': 'src/modules/ChannelSettings/components/ChannelProfile/index.tsx',
   'ChannelSettings/components/ChannelSettingsUI': 'src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx',
   'ChannelSettings/components/ChannelSettingsHeader': 'src/modules/ChannelSettings/components/ChannelSettingsUI/ChannelSettingsHeader.tsx',
+  'ChannelSettings/components/ChannelSettingMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx',
+  'ChannelSettings/hooks/useMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx',
   'ChannelSettings/components/EditDetailsModal': 'src/modules/ChannelSettings/components/EditDetailsModal/index.tsx',
   'ChannelSettings/components/LeaveChannel': 'src/modules/ChannelSettings/components/LeaveChannel/index.tsx',
   'ChannelSettings/components/UserListItem': 'src/modules/ChannelSettings/components/UserListItem/index.tsx',
+  // legacy - not using it internally
   'ChannelSettings/components/UserPanel': 'src/modules/ChannelSettings/components/UserPanel/index.tsx',
+  'ChannelSettings/components/ModerationPanel': 'src/modules/ChannelSettings/components/ModerationPanel/index.tsx',
 
   // Channel - legacy
   Channel: 'src/modules/Channel/index.tsx',

--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -65,7 +65,7 @@ export default {
   'ChannelSettings/components/EditDetailsModal': 'src/modules/ChannelSettings/components/EditDetailsModal/index.tsx',
   'ChannelSettings/components/LeaveChannel': 'src/modules/ChannelSettings/components/LeaveChannel/index.tsx',
   'ChannelSettings/components/UserListItem': 'src/modules/ChannelSettings/components/UserListItem/index.tsx',
-  // legacy - not using it internally
+  // legacy - not using below internally
   'ChannelSettings/components/UserPanel': 'src/modules/ChannelSettings/components/UserPanel/index.tsx',
   'ChannelSettings/components/ModerationPanel': 'src/modules/ChannelSettings/components/ModerationPanel/index.tsx',
 

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuItem.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuItem.tsx
@@ -1,0 +1,81 @@
+import React, {
+  MouseEvent,
+  ReactNode,
+  useState,
+} from 'react';
+import Icon, { IconTypes } from '../../../../ui/Icon';
+import { classnames } from '../../../../utils/utils';
+
+interface Props {
+  renderLeft: () => ReactNode;
+  renderMiddle: () => ReactNode;
+  renderRight?: (props: MenuItemActionProps) => ReactNode;
+  renderAccordion?: () => ReactNode;
+  className?: string;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+}
+
+export const MenuItem = ({
+  renderLeft,
+  renderMiddle,
+  renderRight = (props) => <MenuItemAction {...props} />,
+  renderAccordion,
+  className,
+  onClick,
+  onKeyDown,
+}: Props) => {
+  const useAccordian = typeof renderAccordion === 'function';
+  const [accordianOpened, setAccordianOpened] = useState<boolean>(false);
+
+  return (
+    <>
+      <div
+        className={classnames('sendbird-channel-settings__panel-item', className)}
+        onClick={(e) => {
+          onClick?.(e);
+          if (useAccordian) setAccordianOpened((value) => !value);
+        }}
+        onKeyDown={(e) => {
+          onKeyDown?.(e);
+          if (useAccordian) setAccordianOpened((value) => !value);
+        }}
+      >
+        {renderLeft()}
+        {renderMiddle()}
+        {renderRight({
+          useAccordian,
+          accordianOpened,
+        })}
+      </div>
+      {accordianOpened && renderAccordion?.()}
+    </>
+  );
+};
+
+export interface MenuItemActionProps {
+  useAccordian: boolean;
+  accordianOpened: boolean;
+  children?: ReactNode;
+}
+export const MenuItemAction = ({
+  useAccordian,
+  accordianOpened,
+  children,
+}: MenuItemActionProps) => {
+
+  return useAccordian
+    ? <Icon
+        type={IconTypes.CHEVRON_RIGHT}
+        className={[
+          'sendbird-accordion__panel-icon-right',
+          'sendbird-accordion__panel-icon--chevron',
+          (accordianOpened ? 'sendbird-accordion__panel-icon--open' : ''),
+        ].join(' ')}
+        height="24px"
+        width="24px"
+      />
+    : children;
+};
+
+export default MenuItem;

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
@@ -2,8 +2,8 @@ import '../ModerationPanel/admin-panel.scss';
 
 import React from 'react';
 
-import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
-import Icon, { IconColors } from '../../../../ui/Icon';
+import Label from '../../../../ui/Label';
+import Icon from '../../../../ui/Icon';
 import { isOperator } from '../../../Channel/context/utils';
 
 import MenuItem from './MenuItem';
@@ -23,23 +23,8 @@ const MenuListByRole = ({ menuItems }: { menuItems: ReturnType<typeof useMenuIte
             key={key}
             onClick={item.onClick}
             onKeyDown={item.onKeyDown}
-            renderLeft={() => (
-              <Icon
-                type={item.icon}
-                fillColor={IconColors.PRIMARY}
-                width={24}
-                height={24}
-                className="sendbird-channel-settings__accordion-icon"
-              />
-            )}
-            renderMiddle={() => (
-              <Label
-                type={LabelTypography.SUBTITLE_1}
-                color={LabelColors.ONBACKGROUND_1}
-              >
-                {item.label}
-              </Label>
-            )}
+            renderLeft={() => <Icon {...item.icon} />}
+            renderMiddle={() => <Label {...item.label} />}
             renderRight={item.rightComponent}
             renderAccordion={item.accordionComponent}
           />

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
@@ -1,0 +1,52 @@
+import '../ModerationPanel/admin-panel.scss';
+
+import React from 'react';
+
+import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
+import Icon, { IconColors } from '../../../../ui/Icon';
+import { isOperator } from '../../../Channel/context/utils';
+
+import MenuItem from './MenuItem';
+import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
+import useMenuItems from './hooks/useMenuItems';
+
+const MenuListByRole = ({ menuItems }: { menuItems: ReturnType<typeof useMenuItems> }) => {
+  const { channel } = useChannelSettingsContext();
+  const menuItemsByRole = isOperator(channel) ? menuItems.operator : menuItems.nonOperator;
+
+  return (
+    <div className="sendbird-channel-settings__operator">
+      {Object.entries(menuItemsByRole).map(([key, item]) => {
+        if (item.hideMenu) return null;
+        return (
+          <MenuItem
+            key={key}
+            onClick={item.onClick}
+            onKeyDown={item.onKeyDown}
+            renderLeft={() => (
+              <Icon
+                type={item.icon}
+                fillColor={IconColors.PRIMARY}
+                width={24}
+                height={24}
+                className="sendbird-channel-settings__accordion-icon"
+              />
+            )}
+            renderMiddle={() => (
+              <Label
+                type={LabelTypography.SUBTITLE_1}
+                color={LabelColors.ONBACKGROUND_1}
+              >
+                {item.label}
+              </Label>
+            )}
+            renderRight={item.rightComponent}
+            renderAccordion={item.accordionComponent}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default MenuListByRole;

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
@@ -6,9 +6,10 @@ import BannedUserList from '../../ModerationPanel/BannedUserList';
 import MutedMemberList from '../../ModerationPanel/MutedMemberList';
 
 import { LocalizationContext } from '../../../../../lib/LocalizationContext';
-import { IconTypes } from '../../../../../ui/Icon';
+import { IconColors, IconTypes, IconProps } from '../../../../../ui/Icon';
 import Badge from '../../../../../ui/Badge';
 import { Toggle } from '../../../../../ui/Toggle';
+import { LabelColors, LabelTypography, type LabelProps } from '../../../../../ui/Label';
 import { useChannelSettingsContext } from '../../../context/ChannelSettingsProvider';
 
 import { MenuItemAction, type MenuItemActionProps } from '../MenuItem';
@@ -20,8 +21,8 @@ const kFormatter = (num: number): string | number => {
 };
 
 type MenuItem = {
-  icon: typeof IconTypes[keyof typeof IconTypes];
-  label: string;
+  icon: IconProps;
+  label: LabelProps;
   rightComponent?: (props: MenuItemActionProps) => React.ReactNode;
   accordionComponent?: () => React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -38,6 +39,17 @@ type MenuItems = {
   nonOperator: MenuItemsByRole;
 };
 
+const commonIconProps = {
+  fillColor: IconColors.PRIMARY,
+  width: 24,
+  height: 24,
+  className: 'sendbird-channel-settings__accordion-icon',
+};
+
+const commonLabelProps = {
+  type: LabelTypography.SUBTITLE_1,
+  color: LabelColors.ONBACKGROUND_1,
+};
 export const useMenuItems = (): MenuItems => {
   const [frozen, setFrozen] = useState(false);
   const { stringSet } = useContext(LocalizationContext);
@@ -53,13 +65,13 @@ export const useMenuItems = (): MenuItems => {
   return useMemo(() => ({
     operator: {
       operators: {
-        icon: IconTypes.OPERATOR,
-        label: stringSet.CHANNEL_SETTING__OPERATORS__TITLE,
+        icon: { ...commonIconProps, type: IconTypes.OPERATOR },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__OPERATORS__TITLE },
         accordionComponent: () => <OperatorList />,
       },
       allUsers: {
-        icon: IconTypes.MEMBERS,
-        label: stringSet.CHANNEL_SETTING__MEMBERS__TITLE,
+        icon: { ...commonIconProps, type: IconTypes.MEMBERS },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__MEMBERS__TITLE },
         rightComponent: (props) => (
           <div className="sendbird-channel-settings__members">
             <Badge count={channel?.memberCount ? kFormatter(channel.memberCount) : ''}/>
@@ -71,19 +83,19 @@ export const useMenuItems = (): MenuItems => {
         accordionComponent: () => <MemberList />,
       },
       mutedUsers: {
-        icon: IconTypes.MUTE,
-        label: stringSet.CHANNEL_SETTING__MUTED_MEMBERS__TITLE,
+        icon: { ...commonIconProps, type: IconTypes.MUTE },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__MUTED_MEMBERS__TITLE },
         accordionComponent: () => <MutedMemberList />,
       },
       bannedUsers: {
-        icon: IconTypes.BAN,
-        label: stringSet.CHANNEL_SETTING__BANNED_MEMBERS__TITLE,
+        icon: { ...commonIconProps, type: IconTypes.BAN },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__BANNED_MEMBERS__TITLE },
         accordionComponent: () => <BannedUserList />,
       },
       freezeChannel: {
         hideMenu: channel?.isBroadcast,
-        icon: IconTypes.FREEZE,
-        label: stringSet.CHANNEL_SETTING__FREEZE_CHANNEL,
+        icon: { ...commonIconProps, type: IconTypes.FREEZE },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__FREEZE_CHANNEL },
         rightComponent: () => <Toggle
           className="sendbird-channel-settings__frozen-icon"
           checked={frozen}
@@ -103,8 +115,8 @@ export const useMenuItems = (): MenuItems => {
     },
     nonOperator: {
       allUsers: {
-        icon: IconTypes.MEMBERS,
-        label: stringSet.CHANNEL_SETTING__MEMBERS__TITLE,
+        icon: { ...commonIconProps, type: IconTypes.MEMBERS },
+        label: { ...commonLabelProps, children: stringSet.CHANNEL_SETTING__MEMBERS__TITLE },
         rightComponent: (props) => (
           <div className="sendbird-channel-settings__members">
             <Badge count={channel?.memberCount ? kFormatter(channel.memberCount) : ''}/>

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useEffect, useContext, useState } from 'react';
+
+import OperatorList from '../../ModerationPanel/OperatorList';
+import MemberList from '../../ModerationPanel/MemberList';
+import BannedUserList from '../../ModerationPanel/BannedUserList';
+import MutedMemberList from '../../ModerationPanel/MutedMemberList';
+
+import { LocalizationContext } from '../../../../../lib/LocalizationContext';
+import { IconTypes } from '../../../../../ui/Icon';
+import Badge from '../../../../../ui/Badge';
+import { Toggle } from '../../../../../ui/Toggle';
+import { useChannelSettingsContext } from '../../../context/ChannelSettingsProvider';
+
+import { MenuItemAction, type MenuItemActionProps } from '../MenuItem';
+
+const kFormatter = (num: number): string | number => {
+  return Math.abs(num) > 999
+    ? `${(Math.abs(num) / 1000).toFixed(1)}K`
+    : num;
+};
+
+type MenuItem = {
+  icon: typeof IconTypes[keyof typeof IconTypes];
+  label: string;
+  rightComponent?: (props: MenuItemActionProps) => React.ReactNode;
+  accordionComponent?: () => React.ReactNode;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  hideMenu?: boolean;
+};
+
+type MenuItemsByRole = {
+  [key: string]: MenuItem;
+};
+
+type MenuItems = {
+  operator: MenuItemsByRole;
+  nonOperator: MenuItemsByRole;
+};
+
+export const useMenuItems = (): MenuItems => {
+  const [frozen, setFrozen] = useState(false);
+  const { stringSet } = useContext(LocalizationContext);
+  const { channel } = useChannelSettingsContext();
+
+  // work around for
+  // https://sendbird.slack.com/archives/G01290GCDCN/p1595922832000900
+  // SDK bug - after frozen/unfrozen myRole becomes "none"
+  useEffect(() => {
+    setFrozen(channel?.isFrozen ?? false);
+  }, [channel?.isFrozen]);
+
+  return useMemo(() => ({
+    operator: {
+      operators: {
+        icon: IconTypes.OPERATOR,
+        label: stringSet.CHANNEL_SETTING__OPERATORS__TITLE,
+        accordionComponent: () => <OperatorList />,
+      },
+      allUsers: {
+        icon: IconTypes.MEMBERS,
+        label: stringSet.CHANNEL_SETTING__MEMBERS__TITLE,
+        rightComponent: (props) => (
+          <div className="sendbird-channel-settings__members">
+            <Badge count={channel?.memberCount ? kFormatter(channel.memberCount) : ''}/>
+            <MenuItemAction
+              {...props}
+            />
+          </div>
+        ),
+        accordionComponent: () => <MemberList />,
+      },
+      mutedUsers: {
+        icon: IconTypes.MUTE,
+        label: stringSet.CHANNEL_SETTING__MUTED_MEMBERS__TITLE,
+        accordionComponent: () => <MutedMemberList />,
+      },
+      bannedUsers: {
+        icon: IconTypes.BAN,
+        label: stringSet.CHANNEL_SETTING__BANNED_MEMBERS__TITLE,
+        accordionComponent: () => <BannedUserList />,
+      },
+      freezeChannel: {
+        hideMenu: channel?.isBroadcast,
+        icon: IconTypes.FREEZE,
+        label: stringSet.CHANNEL_SETTING__FREEZE_CHANNEL,
+        rightComponent: () => <Toggle
+          className="sendbird-channel-settings__frozen-icon"
+          checked={frozen}
+          onChange={() => {
+            if (frozen) {
+              channel?.unfreeze().then(() => {
+                setFrozen((prev) => !prev);
+              });
+            } else {
+              channel?.freeze().then(() => {
+                setFrozen((prev) => !prev);
+              });
+            }
+          }}
+        />,
+      },
+    },
+    nonOperator: {
+      allUsers: {
+        icon: IconTypes.MEMBERS,
+        label: stringSet.CHANNEL_SETTING__MEMBERS__TITLE,
+        rightComponent: (props) => (
+          <div className="sendbird-channel-settings__members">
+            <Badge count={channel?.memberCount ? kFormatter(channel.memberCount) : ''}/>
+            <MenuItemAction
+              {...props}
+            />
+          </div>
+        ),
+        accordionComponent: () => <MemberList />,
+      },
+    } }), [channel?.url, frozen]);
+};
+
+export default useMenuItems;

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -12,26 +12,31 @@ import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
 import ChannelProfile from '../ChannelProfile';
-import ModerationPanel from '../ModerationPanel';
 import LeaveChannelModal from '../LeaveChannel';
-import UserPanel from '../UserPanel';
 import { deleteNullish } from '../../../../utils/utils';
+import MenuItem from './MenuItem';
+import MenuListByRole from './MenuListByRole';
+import useMenuItems from './hooks/useMenuItems';
 
+interface ModerationPanelProps {
+  menuItems: ReturnType<typeof useMenuItems>;
+}
 export interface ChannelSettingsUIProps {
   renderHeader?: (props: ChannelSettingsHeaderProps) => React.ReactElement;
   renderChannelProfile?: () => React.ReactElement;
-  renderModerationPanel?: () => React.ReactElement;
+  renderModerationPanel?: (props: ModerationPanelProps) => React.ReactElement;
   renderLeaveChannel?: () => React.ReactElement;
   renderPlaceholderError?: () => React.ReactElement;
   renderPlaceholderLoading?: () => React.ReactElement;
 }
 
 const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
+  const menuItems = useMenuItems();
   const {
-    renderHeader = (p: ChannelSettingsHeaderProps) => <ChannelSettingsHeader {...p} />,
+    renderHeader = (props: ChannelSettingsHeaderProps) => <ChannelSettingsHeader {...props} />,
     renderLeaveChannel,
     renderChannelProfile,
-    renderModerationPanel,
+    renderModerationPanel = (props: ModerationPanelProps) => <MenuListByRole {...props} />,
     renderPlaceholderError,
     renderPlaceholderLoading,
   } = deleteNullish(props);
@@ -64,40 +69,33 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
       {renderHeader(headerProps)}
       <div className="sendbird-channel-settings__scroll-area">
         {renderChannelProfile?.() || <ChannelProfile />}
-        {renderModerationPanel?.() || (channel?.myRole === 'operator' ? <ModerationPanel /> : <UserPanel />)}
+        {renderModerationPanel?.({ menuItems })}
         {renderLeaveChannel?.() || (
-          <div
-            className={[
-              'sendbird-channel-settings__panel-item',
-              'sendbird-channel-settings__leave-channel',
-              !isOnline ? 'sendbird-channel-settings__panel-item__disabled' : '',
-            ].join(' ')}
-            role="button"
+          <MenuItem
+            className={!isOnline ? 'sendbird-channel-settings__panel-item__disabled' : ''}
             onKeyDown={() => {
-              if (!isOnline) {
-                return;
-              }
+              if (!isOnline) return;
               setShowLeaveChannelModal(true);
             }}
             onClick={() => {
-              if (!isOnline) {
-                return;
-              }
+              if (!isOnline) return;
               setShowLeaveChannelModal(true);
             }}
-            tabIndex={0}
-          >
-            <Icon
-              className={['sendbird-channel-settings__panel-icon-left', 'sendbird-channel-settings__panel-icon__leave'].join(' ')}
-              type={IconTypes.LEAVE}
-              fillColor={IconColors.ERROR}
-              height="24px"
-              width="24px"
-            />
-            <Label type={LabelTypography.SUBTITLE_1} color={LabelColors.ONBACKGROUND_1}>
-              {stringSet.CHANNEL_SETTING__LEAVE_CHANNEL__TITLE}
-            </Label>
-          </div>
+            renderLeft={() => (
+              <Icon
+                className={['sendbird-channel-settings__panel-icon-left', 'sendbird-channel-settings__panel-icon__leave'].join(' ')}
+                type={IconTypes.LEAVE}
+                fillColor={IconColors.ERROR}
+                height="24px"
+                width="24px"
+              />
+            )}
+            renderMiddle={() => (
+              <Label type={LabelTypography.SUBTITLE_1} color={LabelColors.ONBACKGROUND_1}>
+                {stringSet.CHANNEL_SETTING__LEAVE_CHANNEL__TITLE}
+              </Label>
+            )}
+          />
         )}
         {showLeaveChannelModal && (
           <LeaveChannelModal

--- a/src/modules/ChannelSettings/components/ModerationPanel/admin-panel.scss
+++ b/src/modules/ChannelSettings/components/ModerationPanel/admin-panel.scss
@@ -33,12 +33,14 @@
 }
 
 .sendbird-channel-settings-accordion__footer {
-  padding-top: 16px;
+  padding: 16px 12px;
   display: flex;
   justify-content: left;
-  padding-left: 12px;
   .sendbird-button:nth-child(2) {
     margin-left: 8px;
+  }
+  @include themed() {
+    border-bottom: 1px solid t(on-bg-4);
   }
 }
 

--- a/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
@@ -30,6 +30,11 @@ const kFormatter = (num: number): string | number => {
     : num;
 };
 
+/**
+ * @deprecated
+ * `ModerationPanel` is deprecated.
+ * Use `@sendbird/ChannelSettings/components/ChannelSettingMenuList` instead.
+ */
 export default function ModerationPanel(): ReactElement {
   const [frozen, setFrozen] = useState(false);
 

--- a/src/modules/ChannelSettings/components/UserPanel/index.tsx
+++ b/src/modules/ChannelSettings/components/UserPanel/index.tsx
@@ -74,4 +74,9 @@ const UserPanel: React.FC = () => {
   );
 };
 
+/**
+ * @deprecated
+ * `UserPanel` is deprecated.
+ * Use `@sendbird/ChannelSettings/components/ChannelSettingMenuList` instead.
+ */
 export default UserPanel;

--- a/src/ui/Label/index.tsx
+++ b/src/ui/Label/index.tsx
@@ -6,7 +6,7 @@ import { changeTypographyToClassName, changeColorToClassName } from './utils';
 import getStringSet from './stringSet';
 import { ObjectValues } from '../../utils/typeHelpers/objectValues';
 
-type LabelProps = {
+export type LabelProps = {
   className?: string | string[];
   type?: ObjectValues<typeof Typography>;
   color?: ObjectValues<typeof Colors>;


### PR DESCRIPTION
Addresses [CLNP-3259](https://sendbird.atlassian.net/browse/CLNP-3259)
This change addresses the need to easily add new settings and show/hide existing settings in the Channel Settings UI.

## Background history of this change
Check the comments from [CLNP-2384](https://sendbird.atlassian.net/browse/CLNP-2384)
- Ability to add new settings:
  - The previous implementation made it impossible to reuse existing menus because some components were not exported.
  - This meant it was only an option when completely changing the settings.
- Ability to show/hide existing settings:
  - Concerns were raised about guiding users to control visibility using CSS, which is not a best practice and considered hacky.
  - Using CSS overrides for visibility can lead to issues with internal changes such as class name or structure modifications, potentially causing problems for customers.

## Changes Made
Added some new components and hooks to make the menu items in the ChannelSettingsUI more modular and customizable.

#### New Files
- `useMenuItems.tsx`: A custom hook that returns menu items based on the user’s role(operator & non-operator), allowing easy configuration of the items shown in the ChannelSettingsUI.
- `MenuItem.tsx`: A component representing an individual menu item, designed to be reusable and customizable.
- `MenuListByRole.tsx`: A component that renders a list of menu items based on the user’s role (operator or non-operator), making it easier to manage which items are shown for different roles.

## Example Usage
To customize the moderation panel with selected menu items:
```
import React from 'react';
import ChannelSettingsUI from '@sendbird-uikit/ChannelSettings/components/ChannelSettingsUI';
import useMenuItems from '@sendbird-uikit/ChannelSettings/hooks/useMenuList';

const CustomChannelSettings = () => {
  const menuItems = useMenuItems();

  const renderCustomModerationPanel = () => {
    // Create a new object by selecting only the desired menu items.
    const customMenuItems = {
      operator: {
        operators: menuItems.operator.operators, // Keep the operators menu
        allUsers: menuItems.operator.allUsers, // Keep the all users menu
        // Add or remove other menu items as needed.
      },
      nonOperator: {
        allUsers: menuItems.nonOperator.allUsers, // Keep the all users menu
        // Add or remove other menu items as needed.
      },
    };

    return <MenuListByRole menuItems={customMenuItems} />;
  };

  return (
    <ChannelSettingsUI renderModerationPanel={renderCustomModerationPanel} />
  );
};

export default CustomChannelSettings;
```

[CLNP-3259]: https://sendbird.atlassian.net/browse/CLNP-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLNP-2384]: https://sendbird.atlassian.net/browse/CLNP-2384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ