### PR TITLE
feat: deprecate uikitOption.groupChannel.enableReactionsSupergroup

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -362,7 +362,6 @@ const SendbirdSDK = ({
             enableOgtag: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableOgtag,
             enableTypingIndicator: configs.groupChannel.channel.enableTypingIndicator,
             enableReactions: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactions,
-            enableReactionsSupergroup: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactionsSupergroup,
             enableMention: configs.groupChannel.channel.enableMention,
             replyType: configs.groupChannel.channel.replyType,
             threadReplySelectType: configs.groupChannel.channel.threadReplySelectType,
@@ -374,6 +373,7 @@ const SendbirdSDK = ({
             showSuggestedRepliesFor: configs.groupChannel.channel.showSuggestedRepliesFor,
             suggestedRepliesDirection: configs.groupChannel.channel.suggestedRepliesDirection,
             enableMarkdownForUserMessage: configs.groupChannel.channel.enableMarkdownForUserMessage,
+            enableReactionsSupergroup: undefined as never,
           },
           groupChannelList: {
             enableTypingIndicator: configs.groupChannel.channelList.enableTypingIndicator,

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -373,7 +373,7 @@ const SendbirdSDK = ({
             showSuggestedRepliesFor: configs.groupChannel.channel.showSuggestedRepliesFor,
             suggestedRepliesDirection: configs.groupChannel.channel.suggestedRepliesDirection,
             enableMarkdownForUserMessage: configs.groupChannel.channel.enableMarkdownForUserMessage,
-            enableReactionsSupergroup: undefined as never,
+            enableReactionsSupergroup: sdkInitialized && configsWithAppAttr(sdk).groupChannel.channel.enableReactionsSupergroup as never,
           },
           groupChannelList: {
             enableTypingIndicator: configs.groupChannel.channelList.enableTypingIndicator,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,7 +103,7 @@ export interface SendBirdStateConfig {
     /**
      * @deprecated Currently, this feature is turned off by default. If you wish to use this feature, contact us: {@link https://dashboard.sendbird.com/settings/contact_us?category=feedback_and_feature_requests&product=UIKit}
      */
-    enableReactionsSupergroup: SBUConfig['groupChannel']['channel']['enableReactionsSupergroup'];
+    enableReactionsSupergroup: never;
     enableMention: SBUConfig['groupChannel']['channel']['enableMention'];
     replyType: SBUConfig['groupChannel']['channel']['replyType'];
     threadReplySelectType: SBUConfig['groupChannel']['channel']['threadReplySelectType'];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,6 +100,9 @@ export interface SendBirdStateConfig {
     enableOgtag: SBUConfig['groupChannel']['channel']['enableOgtag'];
     enableTypingIndicator: SBUConfig['groupChannel']['channel']['enableTypingIndicator'];
     enableReactions: SBUConfig['groupChannel']['channel']['enableReactions'];
+    /**
+     * @deprecated Currently, this feature is turned off by default. If you wish to use this feature, contact us: {@link https://dashboard.sendbird.com/settings/contact_us?category=feedback_and_feature_requests&product=UIKit}
+     */
     enableReactionsSupergroup: SBUConfig['groupChannel']['channel']['enableReactionsSupergroup'];
     enableMention: SBUConfig['groupChannel']['channel']['enableMention'];
     replyType: SBUConfig['groupChannel']['channel']['replyType'];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,10 +100,6 @@ export interface SendBirdStateConfig {
     enableOgtag: SBUConfig['groupChannel']['channel']['enableOgtag'];
     enableTypingIndicator: SBUConfig['groupChannel']['channel']['enableTypingIndicator'];
     enableReactions: SBUConfig['groupChannel']['channel']['enableReactions'];
-    /**
-     * @deprecated Currently, this feature is turned off by default. If you wish to use this feature, contact us: {@link https://dashboard.sendbird.com/settings/contact_us?category=feedback_and_feature_requests&product=UIKit}
-     */
-    enableReactionsSupergroup: never;
     enableMention: SBUConfig['groupChannel']['channel']['enableMention'];
     replyType: SBUConfig['groupChannel']['channel']['replyType'];
     threadReplySelectType: SBUConfig['groupChannel']['channel']['threadReplySelectType'];
@@ -115,6 +111,10 @@ export interface SendBirdStateConfig {
     showSuggestedRepliesFor: SBUConfig['groupChannel']['channel']['showSuggestedRepliesFor'];
     suggestedRepliesDirection: SBUConfig['groupChannel']['channel']['suggestedRepliesDirection'];
     enableMarkdownForUserMessage: SBUConfig['groupChannel']['channel']['enableMarkdownForUserMessage'];
+    /**
+     * @deprecated Currently, this feature is turned off by default. If you wish to use this feature, contact us: {@link https://dashboard.sendbird.com/settings/contact_us?category=feedback_and_feature_requests&product=UIKit}
+     */
+    enableReactionsSupergroup: never;
   },
   groupChannelList: {
     enableTypingIndicator: SBUConfig['groupChannel']['channelList']['enableTypingIndicator'];


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-3581

- A deprecation warning from `uikit-tools`
![Screenshot 2024-07-01 at 4 47 53 PM](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/6ec590be-473d-428a-b211-7f9a1e076bb5)

- from `lib/types.ts`
![Screenshot 2024-07-01 at 4 36 31 PM](https://github.com/sendbird/sendbird-uikit-react/assets/10060731/29417520-3025-41ce-96d9-0acd1b0e2cef)
