### PR TITLE
chore: Improve stability about useMenuItems

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -57,11 +57,12 @@ export default {
   // ChannelSettings
   ChannelSettings: 'src/modules/ChannelSettings/index.tsx',
   'ChannelSettings/context': 'src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx',
+  'ChannelSettings/hooks/useMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx',
   'ChannelSettings/components/ChannelProfile': 'src/modules/ChannelSettings/components/ChannelProfile/index.tsx',
   'ChannelSettings/components/ChannelSettingsUI': 'src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx',
   'ChannelSettings/components/ChannelSettingsHeader': 'src/modules/ChannelSettings/components/ChannelSettingsUI/ChannelSettingsHeader.tsx',
   'ChannelSettings/components/ChannelSettingMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx',
-  'ChannelSettings/hooks/useMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx',
+  'ChannelSettings/components/ChannelSettingsMenuItem': 'src/modules/ChannelSettings/components/ChannelSettingsUI/MenuItem.tsx',
   'ChannelSettings/components/EditDetailsModal': 'src/modules/ChannelSettings/components/EditDetailsModal/index.tsx',
   'ChannelSettings/components/LeaveChannel': 'src/modules/ChannelSettings/components/LeaveChannel/index.tsx',
   'ChannelSettings/components/UserListItem': 'src/modules/ChannelSettings/components/UserListItem/index.tsx',

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
@@ -1,9 +1,8 @@
 import '../ModerationPanel/admin-panel.scss';
 import '../UserPanel/user-panel.scss';
 
-import React, { type ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 
-import type { UserListItemProps } from '../../../../ui/UserListItem';
 import Label from '../../../../ui/Label';
 import Icon from '../../../../ui/Icon';
 import { isOperator } from '../../../Channel/context/utils';
@@ -14,11 +13,9 @@ import useMenuItems from './hooks/useMenuItems';
 
 interface MenuListByRoleProps {
   menuItems: ReturnType<typeof useMenuItems>;
-  renderUserListItem?: (props: UserListItemProps) => ReactNode;
 }
 export const MenuListByRole = ({
   menuItems,
-
 }: MenuListByRoleProps) => {
   const { channel } = useChannelSettingsContext();
   const menuItemsByRole = isOperator(channel) ? menuItems.operator : menuItems.nonOperator;

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
@@ -57,7 +57,7 @@ interface UseMenuItemsParams {
   renderUserListItem?: (props: UserListItemProps) => ReactNode;
 }
 export const useMenuItems = (props?: UseMenuItemsParams): MenuItems => {
-  const { renderUserListItem } = props;
+  const { renderUserListItem = undefined } = props ?? {};
   const [frozen, setFrozen] = useState(false);
   const { stringSet } = useContext(LocalizationContext);
   const { channel } = useChannelSettingsContext();

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useContext, useState, ReactNode } from 'react';
+import React, { useMemo, useEffect, useContext, useState } from 'react';
 
 import OperatorList from '../../ModerationPanel/OperatorList';
 import MemberList from '../../ModerationPanel/MemberList';
@@ -7,7 +7,6 @@ import MutedMemberList from '../../ModerationPanel/MutedMemberList';
 
 import { LocalizationContext } from '../../../../../lib/LocalizationContext';
 
-import type { UserListItemProps } from '../../../../../ui/UserListItem';
 import { IconColors, IconTypes, IconProps } from '../../../../../ui/Icon';
 import Badge from '../../../../../ui/Badge';
 import { Toggle } from '../../../../../ui/Toggle';
@@ -53,14 +52,10 @@ const commonLabelProps = {
   color: LabelColors.ONBACKGROUND_1,
 };
 
-interface UseMenuItemsParams {
-  renderUserListItem?: (props: UserListItemProps) => ReactNode;
-}
-export const useMenuItems = (props?: UseMenuItemsParams): MenuItems => {
-  const { renderUserListItem = undefined } = props ?? {};
+export const useMenuItems = (): MenuItems => {
   const [frozen, setFrozen] = useState(false);
   const { stringSet } = useContext(LocalizationContext);
-  const { channel } = useChannelSettingsContext();
+  const { channel, renderUserListItem } = useChannelSettingsContext();
 
   // work around for
   // https://sendbird.slack.com/archives/G01290GCDCN/p1595922832000900

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -29,11 +29,15 @@ export interface ChannelSettingsUIProps {
   renderLeaveChannel?: () => React.ReactElement;
   renderPlaceholderError?: () => React.ReactElement;
   renderPlaceholderLoading?: () => React.ReactElement;
+  /**
+   * @deprecated This prop is deprecated and will be removed in future releases.
+   * Please use the `renderUserListItem` prop of the `ChannelSettingsProvider` instead.
+   */
   renderUserListItem?: (props: UserListItemProps) => ReactNode;
 }
 
 const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
-  const menuItems = useMenuItems({ renderUserListItem: props?.renderUserListItem });
+  const { channel, invalidChannel, onCloseClick, loading } = useChannelSettingsContext();
   const {
     renderHeader = (props: ChannelSettingsHeaderProps) => <ChannelSettingsHeader {...props} />,
     renderLeaveChannel,
@@ -42,9 +46,9 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
     renderPlaceholderError,
     renderPlaceholderLoading,
   } = deleteNullish(props);
+  const menuItems = useMenuItems();
 
   const state = useSendbirdStateContext();
-  const { channel, invalidChannel, onCloseClick, loading } = useChannelSettingsContext();
   const [showLeaveChannelModal, setShowLeaveChannelModal] = useState(false);
 
   const isOnline = state?.config?.isOnline;

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { GroupChannel, GroupChannelUpdateParams } from '@sendbird/chat/groupChannel';
 
+import type { UserListItemProps } from '../../../ui/UserListItem';
+import type { RenderUserProfileProps } from '../../../types';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
-import { RenderUserProfileProps } from '../../../types';
 import { UserProfileProvider } from '../../../lib/UserProfileContext';
 import uuidv4 from '../../../utils/uuid';
 import { useAsyncRequest } from '../../../hooks/useAsyncRequest';
@@ -24,21 +25,7 @@ type OverrideInviteUserType = {
   channel: GroupChannel;
 };
 
-export type ChannelSettingsContextProps = {
-  children?: React.ReactElement;
-  channelUrl: string;
-  className?: string;
-  onCloseClick?(): void;
-  onLeaveChannel?(): void;
-  overrideInviteUser?(params: OverrideInviteUserType): void;
-  onChannelModified?(channel: GroupChannel): void;
-  onBeforeUpdateChannel?(currentTitle: string, currentImg: File, data: string): GroupChannelUpdateParams;
-  queries?: ChannelSettingsQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
-  disableUserProfile?: boolean;
-};
-
-interface ChannelSettingsProviderInterface {
+interface CommonChannelSettingsProps {
   channelUrl: string;
   onCloseClick?(): void;
   onLeaveChannel?(): void;
@@ -46,6 +33,15 @@ interface ChannelSettingsProviderInterface {
   onChannelModified?(channel: GroupChannel): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File | null, data: string | undefined): GroupChannelUpdateParams;
   queries?: ChannelSettingsQueries;
+  renderUserListItem?: (props: UserListItemProps) => ReactNode;
+}
+export interface ChannelSettingsContextProps extends CommonChannelSettingsProps {
+  children?: React.ReactElement;
+  className?: string;
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  disableUserProfile?: boolean;
+}
+interface ChannelSettingsProviderInterface extends CommonChannelSettingsProps {
   setChannelUpdateId(uniqId: string): void;
   forceUpdateUI(): void;
   channel: GroupChannel | null;
@@ -67,6 +63,7 @@ const ChannelSettingsProvider = ({
   queries,
   renderUserProfile,
   disableUserProfile,
+  renderUserListItem,
 }: ChannelSettingsContextProps) => {
   const { config, stores } = useSendbirdStateContext();
   const { sdkStore } = stores;
@@ -129,6 +126,7 @@ const ChannelSettingsProvider = ({
         channel,
         loading,
         invalidChannel: Boolean(error),
+        renderUserListItem,
       }}
     >
       <UserProfileProvider

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -17,7 +17,7 @@ import { PartialRequired } from '../../../utils/typeHelpers/partialRequired';
 
 type OnCreateChannelClickParams = { users: Array<string>; onClose: () => void; channelType: CHANNEL_TYPE };
 type ChannelListDataSource = ReturnType<typeof useGroupChannelList>;
-type ChannelListQueryParamsType = Omit<GroupChannelCollectionParams, 'filter'> & GroupChannelFilterParams;
+export type ChannelListQueryParamsType = Omit<GroupChannelCollectionParams, 'filter'> & GroupChannelFilterParams;
 
 interface ContextBaseType {
   // Required


### PR DESCRIPTION
- Improve stability about useMenuItems
- Export the ChannelListQueryParamsType
- Move the renderUserListItem props to the Provider from UI comp
- Export the component `ChannelSettingsMenuItem`