### PR TITLE
refactor: Apply message menu to the Thread module

### DIFF
--- a/src/modules/GroupChannel/index.tsx
+++ b/src/modules/GroupChannel/index.tsx
@@ -6,7 +6,7 @@ import GroupChannelUI, { GroupChannelUIProps } from './components/GroupChannelUI
 export interface GroupChannelProps extends GroupChannelProviderProps, GroupChannelUIProps { }
 export const GroupChannel = (props: GroupChannelProps) => {
   return (
-    <GroupChannelProvider {...props}>
+    <GroupChannelProvider {...props} >
       <GroupChannelUI {...props} />
     </GroupChannelProvider>
   );

--- a/src/modules/Thread/components/ParentMessageInfo/index.scss
+++ b/src/modules/Thread/components/ParentMessageInfo/index.scss
@@ -86,19 +86,9 @@
   height: 100%;
 }
 
+.sendbird-parent-message-info__reaction-menu,
 .sendbird-parent-message-info__context-menu {
-  position: absolute;
-  top: 6px;
-  right: 12px;
-  display: none;
-}
-.sendbird-parent-message-info__context-menu.use-reaction {
-  right: 44px;
-}
-.sendbird-parent-message-info__reaction-menu {
-  position: absolute;
-  top: 6px;
-  right: 12px;
+  position: relative;
   display: none;
 }
 
@@ -112,11 +102,19 @@
 }
 
 // display menus
+.sendbird-parent-message-info__menu-container,
 .sendbird-parent-message-info:hover .sendbird-parent-message-info__context-menu,
 .sendbird-parent-message-info:hover .sendbird-parent-message-info__reaction-menu,
 .sendbird-parent-message-info__context-menu.sendbird-mouse-hover,
 .sendbird-parent-message-info__reaction-menu.sendbird-mouse-hover {
   display: inline-flex;
+}
+
+.sendbird-parent-message-info__menu-container {
+  flex-direction: row;
+  position: absolute;
+  top: 6px;
+  right: 12px;
 }
 
 // background color

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -311,10 +311,10 @@ export default function ParentMessageInfo({
         />
       </div>
       {/* context menu */}
-      <div className='sendbird-parent-message-info__menu-container'>
-        {!isMobile && (
-          <>
-            {renderMessageMenu({
+      {!isMobile && (
+        <div className='sendbird-parent-message-info__menu-container'>
+          {
+            renderMessageMenu({
               className: classnames('sendbird-parent-message-info__context-menu', isReactionEnabled && 'use-reaction', isMenuMounted && 'sendbird-mouse-hover'),
               channel: currentChannel,
               message: parentMessage,
@@ -327,21 +327,19 @@ export default function ParentMessageInfo({
                 onMoveToParentMessage?.({ message: parentMessage, channel: currentChannel });
               },
               deleteMessage: deleteMessage,
-            })}
-          </>
-        )}
-        {(isReactionEnabled && !isMobile) && (
-          <>
-            {renderEmojiMenu({
+            })
+          }
+          {isReactionEnabled && (
+            renderEmojiMenu({
               className: classnames('sendbird-parent-message-info__reaction-menu', isMenuMounted && 'sendbird-mouse-hover'),
               message: parentMessage,
               userId: userId,
               emojiContainer: emojiContainer,
               toggleReaction: toggleReaction,
-            })}
-          </>
-        )}
-      </div>
+            })
+          )}
+        </div>
+      )}
       {showRemove && (
         <RemoveMessage
           onCancel={() => setShowRemove(false)}

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useMemo, useState, useRef, useEffect, useLayoutEffect, ReactNode } from 'react';
 import format from 'date-fns/format';
 import type { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
 
@@ -21,6 +21,8 @@ import { SendableMessageType } from '../../../../utils';
 import { User } from '@sendbird/chat';
 import { getCaseResolvedReplyType } from '../../../../lib/utils/resolvedReplyType';
 import { classnames } from '../../../../utils/utils';
+import type { MessageMenuProps } from '../../../../ui/MessageMenu';
+import type { MessageEmojiMenuProps } from '../../../../ui/MessageItemReactionMenu';
 
 export interface ThreadListItemProps {
   className?: string;
@@ -30,6 +32,8 @@ export interface ThreadListItemProps {
   hasSeparator?: boolean;
   renderCustomSeparator?: (props: { message: SendableMessageType }) => React.ReactElement;
   handleScroll?: () => void;
+  renderEmojiMenu?: (props: MessageEmojiMenuProps) => ReactNode;
+  renderMessageMenu?: (props: MessageMenuProps) => ReactNode;
 }
 
 export default function ThreadListItem({
@@ -40,6 +44,8 @@ export default function ThreadListItem({
   hasSeparator,
   renderCustomSeparator,
   handleScroll,
+  renderEmojiMenu,
+  renderMessageMenu,
 }: ThreadListItemProps): React.ReactElement {
   const { stores, config } = useSendbirdStateContext();
   const { isOnline, userMention, logger, groupChannel } = config;
@@ -247,6 +253,8 @@ export default function ThreadListItem({
         showFileViewer={setShowFileViewer}
         toggleReaction={toggleReaction}
         showEdit={setShowEdit}
+        renderEmojiMenu={renderEmojiMenu}
+        renderMessageMenu={renderMessageMenu}
       />
       {/* modal */}
       {showRemove && (

--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -363,15 +363,13 @@ export default function ThreadListItemContent({
         {(!isByMe && !isMobile) && (
           <div className={`sendbird-thread-list-item-content-menu ${supposedHoverClassName}`}>
             {isReactionEnabledInChannel && (
-              <>
-                {renderEmojiMenu({
-                  className: 'sendbird-thread-list-item-content-menu__reaction-menu',
-                  message: message as SendableMessageType,
-                  userId: userId,
-                  emojiContainer: emojiContainer,
-                  toggleReaction: toggleReaction,
-                })}
-              </>
+              renderEmojiMenu({
+                className: 'sendbird-thread-list-item-content-menu__reaction-menu',
+                message: message as SendableMessageType,
+                userId: userId,
+                emojiContainer: emojiContainer,
+                toggleReaction: toggleReaction,
+              })
             )}
             {renderMessageMenu({
               className: 'sendbird-thread-list-item-content-menu__normal-menu',

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -78,7 +78,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
     parentMessage,
     parentMessageState,
     renderParentMessageInfo,
-    renderParentMessageInfoPlaceholder, // nil, loading, invalid
+    renderParentMessageInfoPlaceholder,
   });
   const MemorizedThreadList = useMemorizedThreadList({
     threadListState,

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 
 import './index.scss';
 
@@ -21,7 +21,7 @@ import { SendableMessageType } from '../../../../utils';
 
 export interface ThreadUIProps {
   renderHeader?: () => React.ReactElement;
-  renderParentMessageInfo?: () => React.ReactElement;
+  renderParentMessageInfo?: () => ReactNode;
   renderMessage?: (props: {
     message: SendableMessageType,
     chainTop: boolean,
@@ -39,7 +39,7 @@ export interface ThreadUIProps {
 
 const ThreadUI: React.FC<ThreadUIProps> = ({
   renderHeader,
-  renderParentMessageInfo,
+  renderParentMessageInfo = () => <ParentMessageInfo className="sendbird-thread-ui__parent-message-info" />,
   renderMessage,
   renderMessageInput,
   renderCustomSeparator,
@@ -153,13 +153,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
         onScroll={onScroll}
       >
         <MessageProvider message={parentMessage} isByMe={isByMe}>
-          {
-            MemorizedParentMessageInfo || (
-              <ParentMessageInfo
-                className="sendbird-thread-ui__parent-message-info"
-              />
-            )
-          }
+          {MemorizedParentMessageInfo}
         </MessageProvider>
         {
           replyCount > 0 && (

--- a/src/modules/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
+++ b/src/modules/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 import { ParentMessageStateTypes } from '../../types';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
@@ -7,8 +7,8 @@ import { SendableMessageType } from '../../../../utils';
 export interface UseMemorizedParentMessageInfoProps {
   parentMessage: SendableMessageType;
   parentMessageState: ParentMessageStateTypes;
-  renderParentMessageInfo?: () => React.ReactElement;
-  renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
+  renderParentMessageInfo?: () => ReactNode;
+  renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => ReactNode;
 }
 
 const useMemorizedParentMessageInfo = ({
@@ -16,7 +16,7 @@ const useMemorizedParentMessageInfo = ({
   parentMessageState,
   renderParentMessageInfo,
   renderParentMessageInfoPlaceholder,
-}: UseMemorizedParentMessageInfoProps): ReactElement => useMemo(() => {
+}: UseMemorizedParentMessageInfoProps) => useMemo(() => {
   if (parentMessageState === ParentMessageStateTypes.NIL
     || parentMessageState === ParentMessageStateTypes.LOADING
     || parentMessageState === ParentMessageStateTypes.INVALID

--- a/src/modules/Thread/index.tsx
+++ b/src/modules/Thread/index.tsx
@@ -5,63 +5,17 @@ import {
   ThreadProviderProps,
 } from './context/ThreadProvider';
 import ThreadUI, { ThreadUIProps } from './components/ThreadUI';
+import { classnames } from '../../utils/utils';
 
 export interface ThreadProps extends ThreadProviderProps, ThreadUIProps {
   className?: string;
 }
 
 const Thread = (props: ThreadProps) => {
-  const {
-    // props
-    className,
-    // ThreadProviderProps
-    channelUrl,
-    message,
-    onHeaderActionClick,
-    onMoveToParentMessage,
-    isMultipleFilesMessageEnabled,
-    // onBeforeSend~~~Message
-    onBeforeSendUserMessage,
-    onBeforeSendFileMessage,
-    onBeforeSendVoiceMessage,
-    onBeforeSendMultipleFilesMessage,
-    // ThreadUIProps
-    renderHeader,
-    renderParentMessageInfo,
-    renderMessage,
-    renderMessageInput,
-    renderCustomSeparator,
-    renderParentMessageInfoPlaceholder,
-    renderThreadListPlaceHolder,
-    renderFileUploadIcon,
-    renderVoiceMessageIcon,
-    renderSendMessageIcon,
-  } = props;
   return (
-    <div className={`sendbird-thread ${className}`}>
-      <ThreadProvider
-        channelUrl={channelUrl}
-        message={message}
-        onHeaderActionClick={onHeaderActionClick}
-        onMoveToParentMessage={onMoveToParentMessage}
-        onBeforeSendUserMessage={onBeforeSendUserMessage}
-        onBeforeSendFileMessage={onBeforeSendFileMessage}
-        onBeforeSendVoiceMessage={onBeforeSendVoiceMessage}
-        onBeforeSendMultipleFilesMessage={onBeforeSendMultipleFilesMessage}
-        isMultipleFilesMessageEnabled={isMultipleFilesMessageEnabled}
-      >
-        <ThreadUI
-          renderHeader={renderHeader}
-          renderParentMessageInfo={renderParentMessageInfo}
-          renderMessage={renderMessage}
-          renderMessageInput={renderMessageInput}
-          renderCustomSeparator={renderCustomSeparator}
-          renderParentMessageInfoPlaceholder={renderParentMessageInfoPlaceholder}
-          renderThreadListPlaceHolder={renderThreadListPlaceHolder}
-          renderFileUploadIcon={renderFileUploadIcon}
-          renderVoiceMessageIcon={renderVoiceMessageIcon}
-          renderSendMessageIcon={renderSendMessageIcon}
-        />
+    <div className={classnames('sendbird-thread', props?.className ?? '')}>
+      <ThreadProvider {...props} >
+        <ThreadUI {...props} />
       </ThreadProvider>
     </div>
   );


### PR DESCRIPTION
[CLNP-4083](https://sendbird.atlassian.net/browse/CLNP-4083)

## ChangeLog
* Supported message menu customization in Thread
  * Added `renderMessageMenu` and `renderEmojiMenu` props to the `<ParentMessageInfo />`, `<ThreadListItem />`, and `<ThreadListItemContent />` components.
How to use?
```tsx
<Thread
  renderMessage={(props) => <ThreadListItem {...props} renderMessageMenu={(props) => (
    // render your custom message menu here
    <MessageMenu {...props} renderMenuItems={({ items }) => (
      <>
        <items.CopyMenuItem />
        <items.DeleteMenuItem />
      </>
    )} />
  )} />}
/>
```

[CLNP-4083]: https://sendbird.atlassian.net/browse/CLNP-4083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ