### PR TITLE
chore: improve ESM <-> CJS compatibility with rollup interop: "compat"

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -34,6 +34,7 @@ export default {
       chunkFileNames: 'chunks/bundle-[hash].js',
       format: "cjs",
       sourcemap: true,
+      interop: "compat",
     },
   ],
   external: [


### PR DESCRIPTION
https://sendbird.atlassian.net/browse/CLNP-4373

Aims to enhance the compatibility between ESM and CJS by updating the Rollup configuration to include  `interop: "compat"` setting for the CommonJS output. 
This change ensures better interoperability and resolves potential issues when using the @sendbird/chat SDK in mixed module environments (ESM <-> CJS).

### Checklist
- [x] verified that no lines throw errors:
```
const chatSDK = require('path-to-chat-sdk');

console.log(chatSDK);
console.log(chatSDK.default);

if (chatSDK.default) {
  chatSDK.default.init();
} else {
  chatSDK.init();
}
``` 
- [x] no errors during the build step