### PR TITLE
release v3.14.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog - v3
 
+## [v3.14.13] (July 18, 2024)
+
+### Features
+- **Address RTL UI Feedback**
+  - Fixed an issue where the `htmlTextDirection` prop didn't work when using `SendbirdProvider`, but only worked in the App module.
+  - Updated the paper plane icon to point left instead of right in RTL mode.
+  - Repositioned buttons in the modal footer to the right side instead of the left in RTL mode.
+
+- **Message Menu Customization in Threads**
+  - Added `renderMessageMenu` and `renderEmojiMenu` props to the `<ParentMessageInfo />`, `<ThreadListItem />`, and `<ThreadListItemContent />` components.
+  - **Example usage:**
+    ```tsx
+    <Thread
+      renderMessage={(props) => (
+        <ThreadListItem {...props} renderMessageMenu={(props) => (
+          <MessageMenu {...props} renderMenuItems={({ items }) => (
+            <>
+              <items.CopyMenuItem />
+              <items.DeleteMenuItem />
+            </>
+          )} />
+        )} />
+      )}
+    />
+    ```
+
+### Fixes
+- **Deprecation Marks on Channel & ChannelList Modules**
+  - Marked `Channel`, `ChannelProvider`, `ChannelList`, and `ChannelListProvider` as deprecated.
+
+### Chore
+- **Improve Stability of `useMenuItems`**
+  - Improved the stability of the `useMenuItems` hook.
+  - Exported `ChannelListQueryParamsType`.
+  - Moved the `renderUserListItem` prop to the Provider from the UI component.
+  - Exported the `ChannelSettingsMenuItem` component.
+
+
 ## [v3.14.12] (July 3, 2024)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixes
 - **Deprecation Marks on Channel & ChannelList Modules**
   - Marked `Channel`, `ChannelProvider`, `ChannelList`, and `ChannelListProvider` as deprecated.
+  - For migration guidance, please refer to the [Group Channel Migration Guide](https://sendbird.com/docs/chat/uikit/v3/react/introduction/group-channel-migration-guide#1-group-channel-migration-guide).
 
 ### Chore
 - **Improve Stability of `useMenuItems`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - **Address RTL UI Feedback**
   - Fixed an issue where the `htmlTextDirection` prop didn't work when using `SendbirdProvider`, but only worked in the App module.
   - Updated the paper plane icon to point left instead of right in RTL mode.
-  - Repositioned buttons in the modal footer to the right side instead of the left in RTL mode.
 
 - **Message Menu Customization in Threads**
   - Added `renderMessageMenu` and `renderEmojiMenu` props to the `<ParentMessageInfo />`, `<ThreadListItem />`, and `<ThreadListItemContent />` components.
@@ -37,6 +36,7 @@
   - Exported `ChannelListQueryParamsType`.
   - Moved the `renderUserListItem` prop to the Provider from the UI component.
   - Exported the `ChannelSettingsMenuItem` component.
+- Added `interop: "compat"` setting for the CommonJS output in Rollup Config to enhance the compatibility between ESM and CJS.
 
 
 ## [v3.14.12] (July 3, 2024)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.14.12",
+  "version": "3.14.13",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.14.13] (July 18, 2024)

### Features
- **Address RTL UI Feedback**
  - Fixed an issue where the `htmlTextDirection` prop didn't work when using `SendbirdProvider`, but only worked in the App module.
  - Updated the paper plane icon to point left instead of right in RTL mode.

- **Message Menu Customization in Threads**
  - Added `renderMessageMenu` and `renderEmojiMenu` props to the `<ParentMessageInfo />`, `<ThreadListItem />`, and `<ThreadListItemContent />` components.
  - **Example usage:**
    ```tsx
    <Thread
      renderMessage={(props) => (
        <ThreadListItem {...props} renderMessageMenu={(props) => (
          <MessageMenu {...props} renderMenuItems={({ items }) => (
            <>
              <items.CopyMenuItem />
              <items.DeleteMenuItem />
            </>
          )} />
        )} />
      )}
    />
    ```

### Fixes
- **Deprecation Marks on Channel & ChannelList Modules**
  - Marked `Channel`, `ChannelProvider`, `ChannelList`, and `ChannelListProvider` as deprecated.
  - For migration guidance, please refer to the [Group Channel Migration Guide](https://sendbird.com/docs/chat/uikit/v3/react/introduction/group-channel-migration-guide#1-group-channel-migration-guide).

### Chore
- **Improve Stability of `useMenuItems`**
  - Improved the stability of the `useMenuItems` hook.
  - Exported `ChannelListQueryParamsType`.
  - Moved the `renderUserListItem` prop to the Provider from the UI component.
  - Exported the `ChannelSettingsMenuItem` component.
- Added `interop: "compat"` setting for the CommonJS output in Rollup Config to enhance the compatibility between ESM and CJS.
