### PR TITLE
revert: dialog footer button position in RTL mode Dialog

### DIFF
--- a/src/ui/Modal/index.scss
+++ b/src/ui/Modal/index.scss
@@ -57,8 +57,6 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
-    /*rtl:raw:
-    justify-content: flex-start;*/
     @include mobile() {
       position: sticky;
       bottom: 24px;


### PR DESCRIPTION
Dropped a changed added by #1173 since we internally decided not to make this change. 
https://sendbird.slack.com/archives/C076TB1AN7K/p1721266348343959?thread_ts=1721045636.638979&cid=C076TB1AN7K