### PR TITLE
fix: Remove the deprecation mark of renderUserListItem from the ChannelSettingsProps

### DIFF
--- a/src/modules/ChannelSettings/index.tsx
+++ b/src/modules/ChannelSettings/index.tsx
@@ -8,7 +8,7 @@ import {
   ChannelSettingsContextProps,
 } from './context/ChannelSettingsProvider';
 
-interface ChannelSettingsProps extends Omit<ChannelSettingsUIProps, 'renderUserListItem'>, ChannelSettingsContextProps { }
+interface ChannelSettingsProps extends ChannelSettingsContextProps, Omit<ChannelSettingsUIProps, 'renderUserListItem'> { }
 
 const ChannelSettings: React.FC<ChannelSettingsProps> = (props: ChannelSettingsProps) => {
   return (

--- a/src/modules/ChannelSettings/index.tsx
+++ b/src/modules/ChannelSettings/index.tsx
@@ -8,8 +8,7 @@ import {
   ChannelSettingsContextProps,
 } from './context/ChannelSettingsProvider';
 
-interface ChannelSettingsProps extends ChannelSettingsUIProps, ChannelSettingsContextProps {
-}
+interface ChannelSettingsProps extends Omit<ChannelSettingsUIProps, 'renderUserListItem'>, ChannelSettingsContextProps { }
 
 const ChannelSettings: React.FC<ChannelSettingsProps> = (props: ChannelSettingsProps) => {
   return (


### PR DESCRIPTION
[Issue reported](https://sendbird.slack.com/archives/C06H8UN4A13/p1721359735095629?thread_ts=1716256655.710659&cid=C06H8UN4A13)

- Omit renderUserListItem of ChannelSettingsUIProps from the ChannelSettingsProps