### PR TITLE
fix: Display feedback modal on button click in mobile

### DIFF
--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -194,6 +194,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     && !!message?.myFeedbackStatus
     && message.myFeedbackStatus !== SbFeedbackStatus.NOT_APPLICABLE;
   const isFeedbackEnabled = !!config?.groupChannel?.enableFeedback && isFeedbackMessage;
+  const hasFeedback = message?.myFeedback?.rating;
 
   /**
    * For TemplateMessage, do not display:
@@ -232,8 +233,8 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     setShowFeedbackModal(false);
   };
 
-  const openFeedbackFormOrMenu = () => {
-    if (isMobile) {
+  const openFeedbackFormOrMenu = (hasFeedback = false) => {
+    if (isMobile && hasFeedback) {
       setShowFeedbackOptionsMenu(true);
     } else {
       setShowFeedbackModal(true);
@@ -468,7 +469,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
             <FeedbackIconButton
               isSelected={message?.myFeedback?.rating === FeedbackRating.GOOD}
               onClick={async () => {
-                if (!message?.myFeedback?.rating) {
+                if (!hasFeedback) {
                   try {
                     await message.submitFeedback({
                       rating: FeedbackRating.GOOD,
@@ -479,7 +480,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
                     setFeedbackFailedText(stringSet.FEEDBACK_FAILED_SUBMIT);
                   }
                 } else {
-                  openFeedbackFormOrMenu();
+                  openFeedbackFormOrMenu(true);
                 }
               }}
               disabled={!!message?.myFeedback && message.myFeedback.rating !== FeedbackRating.GOOD}
@@ -493,7 +494,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
             <FeedbackIconButton
               isSelected={message?.myFeedback?.rating === FeedbackRating.BAD}
               onClick={async () => {
-                if (!message?.myFeedback?.rating) {
+                if (!hasFeedback) {
                   try {
                     await message.submitFeedback({
                       rating: FeedbackRating.BAD,
@@ -504,7 +505,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
                     setFeedbackFailedText(stringSet.FEEDBACK_FAILED_SUBMIT);
                   }
                 } else {
-                  openFeedbackFormOrMenu();
+                  openFeedbackFormOrMenu(true);
                 }
               }}
               disabled={!!message?.myFeedback && message.myFeedback.rating !== FeedbackRating.BAD}


### PR DESCRIPTION
Fixes [AC-3370](https://sendbird.atlassian.net/browse/AC-3370)

### Changelogs
- Fixed a bug where feedback modal not being displayed on feedback button click in mobile view

### Discussion
https://sendbird.slack.com/archives/C0585965FFA/p1721798651897159?thread_ts=1719659850.599669&cid=C0585965FFA

### After fix
[Testing App (7).webm](https://github.com/user-attachments/assets/7720d18d-4f48-453e-a638-33638bb8b4ba)
No change in desktop view behaviour
[Testing App (8).webm](https://github.com/user-attachments/assets/b8c87b40-af65-4320-a751-755578356acc)


[AC-3370]: https://sendbird.atlassian.net/browse/AC-3370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ