### PR TITLE
fix: Recreates the GroupChannelCollection when channelListQueryParams change

### DIFF
--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -48,7 +48,7 @@ export interface GroupChannelListContextType extends ContextBaseType, ChannelLis
 }
 export interface GroupChannelListProviderProps
   extends PartialRequired<ContextBaseType, 'onChannelSelect' | 'onChannelCreated'>,
-    Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'renderUserProfile' | 'disableUserProfile'> {
+  Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'renderUserProfile' | 'disableUserProfile'> {
   children?: React.ReactNode;
 }
 
@@ -102,6 +102,11 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
       if (!selectedChannelUrl) onChannelSelect(groupChannels[0] ?? null);
     }
   }, [disableAutoSelect, stores.sdkStore.initialized, initialized, selectedChannelUrl]);
+
+  // Recreates the GroupChannelCollection when `channelListQueryParams` change
+  useEffect(() => {
+    refresh();
+  }, [channelListQueryParams]);
 
   const [typingChannelUrls, setTypingChannelUrls] = useState<string[]>([]);
   useGroupChannelHandler(sdk, {

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -106,7 +106,12 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
   // Recreates the GroupChannelCollection when `channelListQueryParams` change
   useEffect(() => {
     refresh();
-  }, [channelListQueryParams]);
+  }, [
+    Object.keys(channelListQueryParams ?? {})
+      .sort()
+      .map((key: string) => `${key}=${encodeURIComponent(JSON.stringify(channelListQueryParams[key]))}`)
+      .join('&')
+  ]);
 
   const [typingChannelUrls, setTypingChannelUrls] = useState<string[]>([]);
   useGroupChannelHandler(sdk, {

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -107,10 +107,9 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
   useEffect(() => {
     refresh();
   }, [
-    Object.keys(channelListQueryParams ?? {})
-      .sort()
+    Object.keys(channelListQueryParams ?? {}).sort()
       .map((key: string) => `${key}=${encodeURIComponent(JSON.stringify(channelListQueryParams[key]))}`)
-      .join('&')
+      .join('&'),
   ]);
 
   const [typingChannelUrls, setTypingChannelUrls] = useState<string[]>([]);


### PR DESCRIPTION
[CLNP-4233](https://sendbird.atlassian.net/browse/CLNP-4233)

### Issue
When customers used channelListQueryParams in GroupChannelList, the channel list was not refreshed with the new query parameters when their values were changed.

### Fix
The channel list now refreshes when the values of channelListQueryParams are changed.

[CLNP-4233]: https://sendbird.atlassian.net/browse/CLNP-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ