### PR TITLE
[CLNP-4581][CLNP-4582] fix: direction of some icons in RTL

### DIFF
--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/channel-settings-ui.scss
@@ -83,6 +83,10 @@
 
   .sendbird-channel-settings__panel-icon-left {
     left: 16px;
+    /*rtl:raw:
+    &.sendbird-channel-settings__panel-icon__leave {
+      transform: rotate(180deg);
+    }*/
   }
   .sendbird-channel-settings__panel-icon-right {
     right: 16px;

--- a/src/ui/ChannelAvatar/index.scss
+++ b/src/ui/ChannelAvatar/index.scss
@@ -10,4 +10,10 @@
   @include themed() {
     background-color: t(secondary-3);
   }
+  /*rtl:raw:
+  .sendbird-icon {
+    &.sendbird-icon-broadcast {
+      transform: rotateY(180deg);
+    }
+  }*/
 }


### PR DESCRIPTION
Fixes 
- https://sendbird.atlassian.net/browse/CLNP-4582 : leave channel icon
- https://sendbird.atlassian.net/browse/CLNP-4581 : broadcast channel icon

**Before**
<img width="1142" alt="Screenshot 2024-07-29 at 10 34 24 PM" src="https://github.com/user-attachments/assets/2d2d0580-c95c-4c56-8b96-fafc80243557">

**After**
<img width="1067" alt="Screenshot 2024-07-29 at 10 30 43 PM" src="https://github.com/user-attachments/assets/06306ae7-df8a-46e9-a7ce-2756e7a61189">
