### PR TITLE
fix: child message width should fit content

### DIFF
--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -291,10 +291,10 @@
   flex-direction: column;
   position: relative;
   width: fit-content;
+  align-items: flex-end;
 
   .sendbird-message-content__middle__message-item-body {
     box-sizing: border-box;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
Fixes [AC-1080](https://sendbird.atlassian.net/browse/AC-1080)

### Changelogs
- Fixed a bug where replied child message width does not fit content


### Before
<img width="521" alt="Screenshot 2024-07-31 at 3 29 59 PM" src="https://github.com/user-attachments/assets/6a5536dc-ab1d-4d62-8e00-0ea85d3dcc88">
<img width="484" alt="Screenshot 2024-07-31 at 3 30 55 PM" src="https://github.com/user-attachments/assets/73caed02-7d6b-41c7-991c-34fb357d8f41">

### After
<img width="511" alt="Screenshot 2024-07-31 at 3 29 46 PM" src="https://github.com/user-attachments/assets/1cebbbb5-ecab-47d5-81d9-f8f91b435648">
<img width="520" alt="Screenshot 2024-07-31 at 3 31 01 PM" src="https://github.com/user-attachments/assets/c9ffa703-1fb8-4b0d-9b79-a986305146af">


[AC-1080]: https://sendbird.atlassian.net/browse/AC-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ