### PR TITLE
fix: Fixed markdown message in channel preview

### DIFF
--- a/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
@@ -11,7 +11,7 @@ import { useLocalization } from '../../../../lib/LocalizationContext';
 import { useMediaQueryContext } from '../../../../lib/MediaQueryContext';
 import { noop } from '../../../../utils/utils';
 import { CoreMessageType, isVoiceMessage } from '../../../../utils';
-import { getChannelUnreadMessageCount, getLastMessage, getLastMessageCreatedAt, getTotalMembers } from './utils';
+import { getChannelUnreadMessageCount, getLastMessageText, getLastMessageCreatedAt, getTotalMembers } from './utils';
 
 import { TypingIndicatorText } from '../../../GroupChannel/components/TypingIndicator';
 import { GroupChannelPreviewActionProps } from '../GroupChannelPreviewAction';
@@ -57,7 +57,7 @@ export const GroupChannelListItemView = ({
   const { dateLocale, stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
   const isMentionEnabled = config.groupChannel.enableMention;
-  const lastMessage = getLastMessage(channel, stringSet);
+  const lastMessage = getLastMessageText(channel, stringSet);
   const previewLastMessage = config.groupChannel.enableMarkdownForUserMessage
     ? getChannelPreviewMessage(lastMessage)
     : lastMessage;

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/GroupChannelListItemView.tsx
@@ -24,6 +24,7 @@ import MentionUserLabel from '../../../../ui/MentionUserLabel';
 import MessageStatus from '../../../../ui/MessageStatus';
 import Modal from '../../../../ui/Modal';
 import TextButton from '../../../../ui/TextButton';
+import { getChannelPreviewMessage } from '../../../Message/utils/tokens/tokenize';
 
 export interface GroupChannelListItemBasicProps {
   tabIndex: number;
@@ -56,6 +57,10 @@ export const GroupChannelListItemView = ({
   const { dateLocale, stringSet } = useLocalization();
   const { isMobile } = useMediaQueryContext();
   const isMentionEnabled = config.groupChannel.enableMention;
+  const lastMessage = getLastMessage(channel, stringSet);
+  const previewLastMessage = config.groupChannel.enableMarkdownForUserMessage
+    ? getChannelPreviewMessage(lastMessage)
+    : lastMessage;
 
   const [showMobileLeave, setShowMobileLeave] = useState(false);
   const onLongPress = useLongPress(
@@ -161,7 +166,7 @@ export const GroupChannelListItemView = ({
               )}
               {!isTyping
                 && !isVoiceMessage(channel.lastMessage as FileMessage | null)
-                && getLastMessage(channel, stringSet)}
+                && previewLastMessage}
               {!isTyping
                 && isVoiceMessage(channel.lastMessage as FileMessage | null)
                 && stringSet.VOICE_MESSAGE}

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/__tests__/GroupChannelListItem.spec.js
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/__tests__/GroupChannelListItem.spec.js
@@ -1,5 +1,5 @@
 import {
-  getLastMessage,
+  getLastMessageText,
   getChannelTitle,
   getTotalMembers,
   getChannelUnreadMessageCount,
@@ -86,28 +86,28 @@ describe('GroupChannelListItem', () => {
       }
     };
     expect(
-      getLastMessage(channel, LabelStringSet)
+      getLastMessageText(channel, LabelStringSet)
     ).toBe('');
     expect(
-      getLastMessage(channel2, LabelStringSet)
+      getLastMessageText(channel2, LabelStringSet)
     ).toBe('');
     expect(
-      getLastMessage(channel3, LabelStringSet)
+      getLastMessageText(channel3, LabelStringSet)
     ).toBe(text);
     expect(
-      getLastMessage(channel4, LabelStringSet)
+      getLastMessageText(channel4, LabelStringSet)
     ).toBe(LabelStringSet.CHANNEL_PREVIEW_LAST_MESSAGE_FILE_TYPE_GENERAL);
     expect(
-      getLastMessage(channel5, LabelStringSet)
+      getLastMessageText(channel5, LabelStringSet)
     ).toBe(LabelStringSet.CHANNEL_PREVIEW_LAST_MESSAGE_FILE_TYPE_PHOTO);
     expect(
-      getLastMessage(channel6, LabelStringSet)
+      getLastMessageText(channel6, LabelStringSet)
     ).toBe(LabelStringSet.CHANNEL_PREVIEW_LAST_MESSAGE_FILE_TYPE_GIF);
     expect(
-      getLastMessage(mfmGifChannel, LabelStringSet)
+      getLastMessageText(mfmGifChannel, LabelStringSet)
     ).toBe(LabelStringSet.CHANNEL_PREVIEW_LAST_MESSAGE_FILE_TYPE_PHOTO);
     expect(
-        getLastMessage(mfmPhotoChannel, LabelStringSet)
+        getLastMessageText(mfmPhotoChannel, LabelStringSet)
     ).toBe(LabelStringSet.CHANNEL_PREVIEW_LAST_MESSAGE_FILE_TYPE_PHOTO);
   });
 

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/index.scss
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/index.scss
@@ -122,7 +122,9 @@
 
       .sendbird-channel-preview__content__lower__last-message {
         overflow: hidden;
-        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
       }
 
       .sendbird-channel-preview__content__lower__unread-message-count {

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
@@ -5,6 +5,7 @@ import isThisYear from 'date-fns/isThisYear';
 import isYesterday from 'date-fns/isYesterday';
 import { isAudio, isGif, isImage, isTemplateMessage, isVideo, isVoiceMessageMimeType } from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
+import { getChannelPreviewMessage } from '../../../Message/utils/tokens/tokenize';
 
 export const getChannelTitle = (channel?: GroupChannel, currentUserId?: string, stringSet = LabelStringSet) => {
   if (!channel?.name && !channel?.members) {
@@ -79,6 +80,8 @@ const getPrettyLastMessage = (message = null, stringSet = LabelStringSet) => {
   return message.message ?? '';
 };
 
-export const getLastMessage = (channel?: GroupChannel, stringSet = LabelStringSet) => channel?.lastMessage ? getPrettyLastMessage(channel?.lastMessage, stringSet) : '';
+export const getLastMessage = (channel?: GroupChannel, stringSet = LabelStringSet) => {
+  return channel?.lastMessage ? getPrettyLastMessage(channel?.lastMessage, stringSet) : '';
+};
 
 export const getChannelUnreadMessageCount = (channel?: GroupChannel) => channel?.unreadMessageCount ? channel.unreadMessageCount : 0;

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
@@ -5,7 +5,6 @@ import isThisYear from 'date-fns/isThisYear';
 import isYesterday from 'date-fns/isYesterday';
 import { isAudio, isGif, isImage, isTemplateMessage, isVideo, isVoiceMessageMimeType } from '../../../../utils';
 import { LabelStringSet } from '../../../../ui/Label';
-import { getChannelPreviewMessage } from '../../../Message/utils/tokens/tokenize';
 
 export const getChannelTitle = (channel?: GroupChannel, currentUserId?: string, stringSet = LabelStringSet) => {
   if (!channel?.name && !channel?.members) {

--- a/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/utils.ts
@@ -79,7 +79,7 @@ const getPrettyLastMessage = (message = null, stringSet = LabelStringSet) => {
   return message.message ?? '';
 };
 
-export const getLastMessage = (channel?: GroupChannel, stringSet = LabelStringSet) => {
+export const getLastMessageText = (channel?: GroupChannel, stringSet = LabelStringSet) => {
   return channel?.lastMessage ? getPrettyLastMessage(channel?.lastMessage, stringSet) : '';
 };
 

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -9,6 +9,7 @@ import {
   TokenParams,
   UndeterminedToken,
 } from './types';
+import { UserMessage } from '@sendbird/chat/message';
 
 /**
  * /\[(.*?)\]\((.*?)\) is for url.
@@ -200,6 +201,26 @@ export function tokenizeMessage({
   );
   const result = combineNearbyStrings(partialsWithUrlsAndMentions);
   return result;
+}
+
+export function getChannelPreviewMessage(messageText: string): string {
+  const partialResult = [{
+    type: TOKEN_TYPES.undetermined,
+    value: messageText,
+  }];
+  const tokens = splitTokensWithMarkdowns(partialResult);
+  const result = markDownTokenResolver(tokens);
+  return result;
+}
+
+function markDownTokenResolver(tokens: Token[]): string {
+  const result = tokens.map((token) => {
+    if (token.type === TOKEN_TYPES.markdown) {
+      return markDownTokenResolver(tokenizeMarkdown({ messageText: (token as MarkdownToken).groups[1] }));
+    }
+    return token.value;
+  });
+  return result.join('');
 }
 
 export function tokenizeMarkdown({

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -208,11 +208,10 @@ export function getChannelPreviewMessage(messageText: string): string {
     value: messageText,
   }];
   const tokens = splitTokensWithMarkdowns(partialResult);
-  const result = markDownTokenResolver(tokens);
-  return result;
+  return markDownTokenResolver(tokens);
 }
 
-function markDownTokenResolver(tokens: Token[]): string {
+export function markDownTokenResolver(tokens: Token[]): string {
   const result = tokens.map((token) => {
     if (token.type === TOKEN_TYPES.markdown) {
       return markDownTokenResolver(tokenizeMarkdown({ messageText: (token as MarkdownToken).groups[1] }));

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -9,7 +9,6 @@ import {
   TokenParams,
   UndeterminedToken,
 } from './types';
-import { UserMessage } from '@sendbird/chat/message';
 
 /**
  * /\[(.*?)\]\((.*?)\) is for url.


### PR DESCRIPTION
Fixes [CLNP-4063](https://sendbird.atlassian.net/browse/CLNP-4063)

### Changelogs
- Fixed a bug where markdown messages are incorrectly displayed in channel preview

<img width="695" alt="Screenshot 2024-08-05 at 12 34 49 PM" src="https://github.com/user-attachments/assets/6273e660-145e-424f-932a-292079e74588">


### Disabled
<img width="1008" alt="Screenshot 2024-08-01 at 3 16 11 PM" src="https://github.com/user-attachments/assets/360376e9-bc70-4fba-ab47-2fa9699bcb55">
<img width="449" alt="Screenshot 2024-08-01 at 3 19 25 PM" src="https://github.com/user-attachments/assets/3614b659-59d2-4c33-ab50-87d57f5f7c43">

### Enabled
<img width="1014" alt="Screenshot 2024-08-01 at 3 10 04 PM" src="https://github.com/user-attachments/assets/3c2e0f23-7dde-4a62-9c69-07225f9cc890">
<img width="434" alt="Screenshot 2024-08-01 at 3 19 33 PM" src="https://github.com/user-attachments/assets/f990e6ee-f7cf-4202-9d92-41f3d1561cf7">


[CLNP-4063]: https://sendbird.atlassian.net/browse/CLNP-4063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ