### PR TITLE
fix: Fix child message width broken with reactions

### DIFF
--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -295,7 +295,14 @@
 
   .sendbird-message-content__middle__message-item-body {
     box-sizing: border-box;
+    &.reactions {
+      width: 100%;
+      align-self: unset;
+    }
   }
+}
+.sendbird-message-content__middle__body-container:has(.sendbird-message-content__middle__message-item-body.reactions) {
+  align-items: unset;
 }
 
 .sendbird-message-content-reactions {

--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -297,7 +297,6 @@
     box-sizing: border-box;
     &.reactions {
       width: 100%;
-      align-self: unset;
     }
   }
 }


### PR DESCRIPTION
Fixes https://sendbird.slack.com/archives/G01290GCDCN/p1722563778502959?thread_ts=1722407758.659719&cid=G01290GCDCN

### Changelogs
- Fixed a bug where child message width is broken when emojis are added