### PR TITLE
fix: add MessageBody to module exports

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -197,6 +197,7 @@ export default {
   'ui/MentionUserLabel': 'src/ui/MentionUserLabel/index.tsx',
   'ui/MentionLabel': 'src/ui/MentionLabel/index.tsx',
   'ui/MessageContent': 'src/ui/MessageContent/index.tsx',
+  'ui/MessageBody': 'src/ui/MessageContent/MessageBody/index.tsx',
   // MessageInput is a special case - shouldbe turned into a module
   'ui/MessageInput': 'src/ui/MessageInput/index.tsx',
   'ui/MessageInput/hooks/usePaste': 'src/ui/MessageInput/hooks/usePaste/index.ts',

--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -197,7 +197,7 @@ export default {
   'ui/MentionUserLabel': 'src/ui/MentionUserLabel/index.tsx',
   'ui/MentionLabel': 'src/ui/MentionLabel/index.tsx',
   'ui/MessageContent': 'src/ui/MessageContent/index.tsx',
-  'ui/MessageBody': 'src/ui/MessageContent/MessageBody/index.tsx',
+  'ui/MessageContent/MessageBody': 'src/ui/MessageContent/MessageBody/index.tsx',
   // MessageInput is a special case - shouldbe turned into a module
   'ui/MessageInput': 'src/ui/MessageInput/index.tsx',
   'ui/MessageInput/hooks/usePaste': 'src/ui/MessageInput/hooks/usePaste/index.ts',


### PR DESCRIPTION
For `renderMessageBody` to be a viable option to extend upon the default message types, would like to be able to import `MessageBody` when using the library.

> * `MessageContent` is not customizable with three new optional properties:
>   * `renderSenderProfile`, `renderMessageBody`, and `renderMessageHeader`
>   * How to use?
>     ```tsx
>     import Channel from '@sendbird/uikit-react/Channel'
>     import { useSendbirdStateContext } from '@sendbird/uikit-react/useSendbirdStateContext'
>     import { useChannelContext } from '@sendbird/uikit-react/Channel/context'
>     import MessageContent from '@sendbird/uikit-react/ui/MessageContent'
> 
>     const CustomChannel = () => {
>       const { config } = useSendbirdStateContext();
>       const { userId } = config;
>       const { currentGroupChannel } = useChannelContext();
>       return (
>         <Channel
>           ...
>           renderMessage={({ message }) => {
>             return (
>               <MessageContent
>                 userId={userId}
>                 channel={currentGroupChannel}
>                 message={message}
>                 ...
>                 renderMessageBody={(props: MessageBodyProps) => (
>                   <MessageBody {...props}/>
>                 )}
>               />
>             )
>           }}
>         />
>       )
>     }
>     ```
