### PR TITLE
fix: OG message's thumbnail width in OpenChannel

### DIFF
--- a/src/ui/OpenchannelOGMessage/__tests__/__snapshots__/OpenchannelOGMessage.spec.js.snap
+++ b/src/ui/OpenchannelOGMessage/__tests__/__snapshots__/OpenchannelOGMessage.spec.js.snap
@@ -130,11 +130,11 @@ exports[`ui/OpenchannelOGMessage should do a snapshot test of the OpenchannelOGM
         >
           <div
             class="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image sendbird-image-renderer"
-            style="width: 100%; min-width: min(400px, 400px); max-width: 400px;"
+            style="width: 100%; min-width: min(400px, 334px); max-width: 400px;"
           >
             <div
               class="sendbird-image-renderer__image"
-              style="width: 100%; min-width: min(400px, 400px); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url(https://static.sendbird.com/sample/profiles/profile_12_512px.png);"
+              style="width: 100%; min-width: min(400px, 334px); max-width: 400px; position: absolute; background-repeat: no-repeat; background-position: center; background-size: cover; background-image: url(https://static.sendbird.com/sample/profiles/profile_12_512px.png);"
             />
             <img
               alt="test"

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -378,6 +378,7 @@ export default function OpenChannelOGMessage({
                         className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image"
                         url={defaultImage.url || ''}
                         alt={defaultImage.alt || ''}
+                        width="334px"
                         height="189px"
                         defaultComponent={(
                           <div className="sendbird-openchannel-og-message__bottom__og-tag__thumbnail__image--placeholder">


### PR DESCRIPTION
fond issue in: [CLNP-4638](https://sendbird.atlassian.net/browse/CLNP-4638)

#### Before
<img width="777" alt="image" src="https://github.com/user-attachments/assets/d0913c71-830a-4945-92b9-7c18da32d7aa">

#### After
<img width="777" alt="image" src="https://github.com/user-attachments/assets/c8184727-7f05-49cc-959a-307d29e9f3cb">


[CLNP-4638]: https://sendbird.atlassian.net/browse/CLNP-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ