### PR TITLE
fix: rename onUserProfileMessage to onStartDirectMessage

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -104,13 +104,18 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
   breakpoint?: string | boolean;
   htmlTextDirection?: HTMLTextDirection;
   forceLeftToRightMessageLayout?: boolean;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
-  onUserProfileMessage?: (channel: GroupChannel) => void;
   uikitOptions?: UIKitOptions;
   isUserIdUsedForNickname?: boolean;
   sdkInitParams?: SendbirdChatInitParams;
   customExtensionParams?: CustomExtensionParams;
   isMultipleFilesMessageEnabled?: boolean;
+  // UserProfile
+  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  onStartDirectMessage?: (channel: GroupChannel) => void;
+  /**
+   * @deprecated Please use `onStartDirectMessage` instead. It's renamed.
+   */
+  onUserProfileMessage?: (channel: GroupChannel) => void;
 
   // Customer provided callbacks
   eventHandlers?: SBUEventHandlers;
@@ -171,7 +176,8 @@ const SendbirdSDK = ({
   allowProfileEdit = false,
   disableMarkAsDelivered = false,
   renderUserProfile,
-  onUserProfileMessage,
+  onUserProfileMessage: _onUserProfileMessage,
+  onStartDirectMessage: _onStartDirectMessage,
   breakpoint = false,
   isUserIdUsedForNickname = true,
   sdkInitParams,
@@ -181,6 +187,7 @@ const SendbirdSDK = ({
   htmlTextDirection = 'ltr',
   forceLeftToRightMessageLayout = false,
 }: SendbirdProviderProps): React.ReactElement => {
+  const onStartDirectMessage = _onStartDirectMessage ?? _onUserProfileMessage;
   const { logLevel = '', userMention = {}, isREMUnitEnabled = false, pubSub: customPubSub } = config;
   const { isMobile } = useMediaQueryContext();
   const [logger, setLogger] = useState(LoggerFactory(logLevel as LogLevel));
@@ -332,7 +339,8 @@ const SendbirdSDK = ({
         config: {
           disableMarkAsDelivered,
           renderUserProfile,
-          onUserProfileMessage,
+          onStartDirectMessage,
+          onUserProfileMessage: onStartDirectMessage, // legacy of onStartDirectMessage
           allowProfileEdit,
           isOnline,
           userId,

--- a/src/lib/UserProfileContext.tsx
+++ b/src/lib/UserProfileContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { RenderUserProfileProps } from '../types';
 import { useSendbirdStateContext } from './Sendbird';
@@ -19,7 +19,7 @@ interface UserProfileContextInterface {
  * user profile goes deep inside the component tree
  * use this context as a short circuit to send in values
  */
-const UserProfileContext = React.createContext<UserProfileContextInterface>({
+export const UserProfileContext = React.createContext<UserProfileContextInterface>({
   disableUserProfile: true,
   isOpenChannel: false,
 });
@@ -34,7 +34,9 @@ export type UserProfileProviderProps = React.PropsWithChildren<
   }
 >;
 
-const UserProfileProvider = ({
+export const useUserProfileContext = () => useContext(UserProfileContext);
+
+export const UserProfileProvider = ({
   isOpenChannel = false,
   disableUserProfile: _disableUserProfile = false,
   renderUserProfile: _renderUserProfile,
@@ -60,5 +62,3 @@ const UserProfileProvider = ({
     </UserProfileContext.Provider>
   );
 };
-
-export { UserProfileContext, UserProfileProvider };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,7 +42,6 @@ import { SBUGlobalPubSub } from './pubSub/topics';
 import { EmojiManager } from './emojiManager';
 import { MessageTemplatesInfo, ProcessedMessageTemplate, WaitingTemplateKeyData } from './dux/appInfo/initialState';
 import { AppInfoActionTypes } from './dux/appInfo/actionTypes';
-import { UserProfileProviderProps } from './UserProfileContext';
 
 // note to SDK team:
 // using enum inside .d.ts won’t work for jest, but const enum will work.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,7 @@ import { SBUGlobalPubSub } from './pubSub/topics';
 import { EmojiManager } from './emojiManager';
 import { MessageTemplatesInfo, ProcessedMessageTemplate, WaitingTemplateKeyData } from './dux/appInfo/initialState';
 import { AppInfoActionTypes } from './dux/appInfo/actionTypes';
+import { UserProfileProviderProps } from './UserProfileContext';
 
 // note to SDK team:
 // using enum inside .d.ts won’t work for jest, but const enum will work.
@@ -65,7 +66,7 @@ export interface SBUEventHandlers {
 
 export interface SendBirdStateConfig {
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
-  onUserProfileMessage?: (props: GroupChannel) => void;
+  onStartDirectMessage?: (props: GroupChannel) => void;
   allowProfileEdit: boolean;
   isOnline: boolean;
   userId: string;
@@ -128,21 +129,29 @@ export interface SendBirdStateConfig {
     enableOgtag: SBUConfig['openChannel']['channel']['enableOgtag'];
     enableDocument: SBUConfig['openChannel']['channel']['input']['enableDocument'];
   },
-  /** @deprecated Please use `common.enableUsingDefaultUserProfile` instead * */
+  /**
+   * @deprecated Please use `onStartDirectMessage` instead. It's renamed.
+   */
+  onUserProfileMessage?: (props: GroupChannel) => void;
+  /**
+   * @deprecated Please use `!config.common.enableUsingDefaultUserProfile` instead.
+   * Note that you should use the negation of `config.common.enableUsingDefaultUserProfile`
+   * to replace `disableUserProfile`.
+   */
   disableUserProfile: boolean;
-  /** @deprecated Please use `groupChannel.enableReactions` instead * */
+  /** @deprecated Please use `config.groupChannel.enableReactions` instead * */
   isReactionEnabled: boolean;
-  /** @deprecated Please use `groupChannel.enableMention` instead * */
+  /** @deprecated Please use `config.groupChannel.enableMention` instead * */
   isMentionEnabled: boolean;
-  /** @deprecated Please use `groupChannel.enableVoiceMessage` instead * */
+  /** @deprecated Please use `config.groupChannel.enableVoiceMessage` instead * */
   isVoiceMessageEnabled?: boolean;
-  /** @deprecated Please use `groupChannel.replyType` instead * */
+  /** @deprecated Please use `config.groupChannel.replyType` instead * */
   replyType: ReplyType;
-  /** @deprecated Please use `groupChannelSettings.enableMessageSearch` instead * */
+  /** @deprecated Please use `config.groupChannelSettings.enableMessageSearch` instead * */
   showSearchIcon?: boolean;
-  /** @deprecated Please use `groupChannelList.enableTypingIndicator` instead * */
+  /** @deprecated Please use `config.groupChannelList.enableTypingIndicator` instead * */
   isTypingIndicatorEnabledOnChannelList?: boolean;
-  /** @deprecated Please use `groupChannelList.enableMessageReceiptStatus` instead * */
+  /** @deprecated Please use `config.groupChannelList.enableMessageReceiptStatus` instead * */
   isMessageReceiptStatusEnabledOnChannelList?: boolean;
   /** @deprecated Please use setCurrentTheme instead * */
   setCurrenttheme: (theme: 'light' | 'dark') => void;

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -139,7 +139,7 @@ export default function App(props: AppProps) {
       imageCompression={imageCompression}
       isMultipleFilesMessageEnabled={isMultipleFilesMessageEnabled}
       voiceRecord={voiceRecord}
-      onUserProfileMessage={(channel) => {
+      onStartDirectMessage={(channel) => {
         setCurrentChannel(channel);
       }}
       uikitOptions={uikitOptions}
@@ -147,12 +147,8 @@ export default function App(props: AppProps) {
       sdkInitParams={sdkInitParams}
       customExtensionParams={customExtensionParams}
       eventHandlers={eventHandlers}
-      isTypingIndicatorEnabledOnChannelList={
-        isTypingIndicatorEnabledOnChannelList
-      }
-      isMessageReceiptStatusEnabledOnChannelList={
-        isMessageReceiptStatusEnabledOnChannelList
-      }
+      isTypingIndicatorEnabledOnChannelList={isTypingIndicatorEnabledOnChannelList}
+      isMessageReceiptStatusEnabledOnChannelList={isMessageReceiptStatusEnabledOnChannelList}
       replyType={replyType}
       showSearchIcon={showSearchIcon}
       disableUserProfile={disableUserProfile}

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -19,7 +19,7 @@ import type {
 } from '@sendbird/chat/message';
 import type { EmojiContainer, SendbirdError, User } from '@sendbird/chat';
 
-import { ReplyType, RenderUserProfileProps, Nullable } from '../../../types';
+import { ReplyType, Nullable } from '../../../types';
 import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { CoreMessageType, SendableMessageType } from '../../../utils';
@@ -91,7 +91,7 @@ export interface ChannelContextProps extends
   onMessageHighlighted?: () => void;
   scrollBehavior?: 'smooth' | 'auto';
   reconnectOnIdle?: boolean;
-};
+}
 
 interface MessageStoreInterface {
   allMessages: CoreMessageType[];

--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -20,7 +20,7 @@ import type {
 import type { EmojiContainer, SendbirdError, User } from '@sendbird/chat';
 
 import { ReplyType, RenderUserProfileProps, Nullable } from '../../../types';
-import { UserProfileProvider } from '../../../lib/UserProfileContext';
+import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { CoreMessageType, SendableMessageType } from '../../../utils';
 import { ThreadReplySelectType } from './const';
@@ -61,7 +61,8 @@ export type ChannelQueries = {
   messageListParams?: MessageListParams;
 };
 
-export type ChannelContextProps = {
+export interface ChannelContextProps extends
+  Pick<UserProfileProviderProps, 'disableUserProfile' | 'renderUserProfile'> {
   children?: React.ReactElement;
   channelUrl: string;
   isReactionEnabled?: boolean;
@@ -82,9 +83,7 @@ export type ChannelContextProps = {
   replyType?: ReplyType;
   threadReplySelectType?: ThreadReplySelectType;
   queries?: ChannelQueries;
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   filterMessageList?(messages: BaseMessage): boolean;
-  disableUserProfile?: boolean;
   disableMarkAsRead?: boolean;
   onReplyInThread?: (props: { message: SendableMessageType }) => void;
   onQuoteMessageClick?: (props: { message: SendableMessageType }) => void;
@@ -209,7 +208,6 @@ const ChannelProvider = (props: ChannelContextProps) => {
     userId,
     isOnline,
     imageCompression,
-    onUserProfileMessage,
     markAsReadScheduler,
     groupChannel,
     htmlTextDirection,
@@ -523,11 +521,7 @@ const ChannelProvider = (props: ChannelContextProps) => {
       isScrolled,
       setIsScrolled,
     }}>
-      <UserProfileProvider
-        disableUserProfile={props?.disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
-        renderUserProfile={props?.renderUserProfile}
-        onUserProfileMessage={onUserProfileMessage}
-      >
+      <UserProfileProvider {...props}>
         {children}
       </UserProfileProvider>
     </ChannelContext.Provider>

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -26,7 +26,7 @@ import { DELIVERY_RECEIPT } from '../../../utils/consts';
 import * as channelListActions from '../dux/actionTypes';
 import { ChannelListActionTypes } from '../dux/actionTypes';
 
-import { UserProfileProvider } from '../../../lib/UserProfileContext';
+import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import channelListReducers from '../dux/reducers';
 import channelListInitialState from '../dux/initialState';
@@ -75,7 +75,8 @@ type OverrideInviteUserType = {
   channelType: CHANNEL_TYPE;
 };
 
-export interface ChannelListProviderProps {
+export interface ChannelListProviderProps extends
+  Pick<UserProfileProviderProps, 'disableUserProfile' | 'renderUserProfile'> {
   allowProfileEdit?: boolean;
   onBeforeCreateChannel?(users: Array<string>): GroupChannelCreateParams;
   overrideInviteUser?(params: OverrideInviteUserType): void;
@@ -86,8 +87,6 @@ export interface ChannelListProviderProps {
   queries?: ChannelListQueries;
   children?: React.ReactElement;
   className?: string | string[];
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
-  disableUserProfile?: boolean;
   disableAutoSelect?: boolean;
   activeChannelUrl?: string;
   typingChannels?: Array<GroupChannel>;
@@ -142,7 +141,7 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
   const globalStore = useSendbirdStateContext();
   const { config, stores } = globalStore;
   const { sdkStore } = stores;
-  const { pubSub, logger, onUserProfileMessage } = config;
+  const { pubSub, logger } = config;
   const {
     markAsDeliveredScheduler,
     disableMarkAsDelivered = false,
@@ -153,8 +152,6 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
 
   // derive some variables
   // enable if it is true at least once(both are false by default)
-  const userDefinedDisableUserProfile = disableUserProfile ?? !config.common.enableUsingDefaultUserProfile;
-  const userDefinedRenderProfile = config?.renderUserProfile;
   const enableEditProfile = allowProfileEdit || config.allowProfileEdit;
 
   const userFilledChannelListQuery = queries?.channelListQuery;
@@ -384,11 +381,7 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
         fetchChannelList,
       }}
     >
-      <UserProfileProvider
-        disableUserProfile={userDefinedDisableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
-        renderUserProfile={userDefinedRenderProfile}
-        onUserProfileMessage={onUserProfileMessage}
-      >
+      <UserProfileProvider {...props}>
         <div className={`sendbird-channel-list ${className}`}>{children}</div>
       </UserProfileProvider>
     </ChannelListContext.Provider>

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -16,8 +16,6 @@ import {
   UnreadChannelFilter,
 } from '@sendbird/chat/groupChannel';
 
-import { RenderUserProfileProps } from '../../../types';
-
 import setupChannelList, { pubSubHandler, pubSubHandleRemover } from '../utils';
 import { uuidv4 } from '../../../utils/uuid';
 import { noop } from '../../../utils/utils';

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { GroupChannel, GroupChannelHandler, GroupChannelUpdateParams } from '@sendbird/chat/groupChannel';
 
 import type { UserListItemProps } from '../../../ui/UserListItem';
-import type { RenderUserProfileProps } from '../../../types';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import uuidv4 from '../../../utils/uuid';

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -17,7 +17,7 @@ import type { SendableMessageType } from '../../../utils';
 import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { ThreadReplySelectType } from './const';
-import { RenderUserProfileProps, ReplyType } from '../../../types';
+import { ReplyType } from '../../../types';
 import useToggleReactionCallback from './hooks/useToggleReactionCallback';
 import { getCaseResolvedReplyType, getCaseResolvedThreadReplySelectType } from '../../../lib/utils/resolvedReplyType';
 import { getMessageTopOffset, isContextMenuClosed } from './utils';
@@ -34,7 +34,8 @@ type MessageActions = ReturnType<typeof useMessageActions>;
 type MessageListDataSourceWithoutActions = Omit<ReturnType<typeof useGroupChannelMessages>, keyof MessageActions | `_dangerous_${string}`>;
 export type OnBeforeDownloadFileMessageType = (params: { message: FileMessage | MultipleFilesMessage; index?: number }) => Promise<boolean>;
 
-interface ContextBaseType {
+interface ContextBaseType extends
+  Pick<UserProfileProviderProps, 'renderUserProfile' | 'disableUserProfile'> {
   // Required
   channelUrl: string;
 
@@ -45,7 +46,6 @@ interface ContextBaseType {
   showSearchIcon?: boolean;
   replyType?: ReplyType;
   threadReplySelectType?: ThreadReplySelectType;
-  disableUserProfile?: boolean;
   disableMarkAsRead?: boolean;
   scrollBehavior?: 'smooth' | 'auto';
   forceLeftToRightMessageLayout?: boolean;
@@ -75,7 +75,6 @@ interface ContextBaseType {
   onQuoteMessageClick?: (props: { message: SendableMessageType }) => void;
 
   // Render
-  renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   renderUserMentionItem?: (props: { user: User }) => JSX.Element;
 }
 
@@ -102,9 +101,9 @@ export interface GroupChannelContextType extends ContextBaseType, MessageListDat
   toggleReaction(message: SendableMessageType, emojiKey: string, isReacted: boolean): void;
 }
 
-export interface GroupChannelProviderProps
-  extends ContextBaseType,
-    Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'renderUserProfile' | 'disableUserProfile'> {
+export interface GroupChannelProviderProps extends
+  ContextBaseType,
+  Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'onStartDirectMessage'> {
   children?: React.ReactNode;
 }
 
@@ -382,11 +381,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
         ...messageActions,
       }}
     >
-      <UserProfileProvider
-        disableUserProfile={props?.disableUserProfile ?? config?.disableUserProfile}
-        renderUserProfile={props?.renderUserProfile ?? config?.renderUserProfile}
-        onUserProfileMessage={props?.onUserProfileMessage ?? config?.onUserProfileMessage}
-      >
+      <UserProfileProvider {...props}>
         {children}
       </UserProfileProvider>
     </GroupChannelContext.Provider>

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -46,9 +46,9 @@ interface ContextBaseType {
 export interface GroupChannelListContextType extends ContextBaseType, ChannelListDataSource {
   typingChannelUrls: string[];
 }
-export interface GroupChannelListProviderProps
-  extends PartialRequired<ContextBaseType, 'onChannelSelect' | 'onChannelCreated'>,
-  Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'renderUserProfile' | 'disableUserProfile'> {
+export interface GroupChannelListProviderProps extends
+  PartialRequired<ContextBaseType, 'onChannelSelect' | 'onChannelCreated'>,
+  Pick<UserProfileProviderProps, 'onUserProfileMessage' | 'onStartDirectMessage' | 'renderUserProfile' | 'disableUserProfile'> {
   children?: React.ReactNode;
 }
 
@@ -71,10 +71,6 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
     onCreateChannelClick,
     onBeforeCreateChannel,
     onUserProfileUpdated,
-
-    disableUserProfile,
-    renderUserProfile,
-    onUserProfileMessage,
   } = props;
   const globalStore = useSendbirdStateContext();
   const { config, stores } = globalStore;
@@ -147,11 +143,7 @@ export const GroupChannelListProvider = (props: GroupChannelListProviderProps) =
         loadMore,
       }}
     >
-      <UserProfileProvider
-        disableUserProfile={disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
-        renderUserProfile={renderUserProfile ?? config?.renderUserProfile}
-        onUserProfileMessage={onUserProfileMessage ?? config?.onUserProfileMessage}
-      >
+      <UserProfileProvider {...props}>
         <div className={`sendbird-channel-list ${className}`}>{children}</div>
       </UserProfileProvider>
     </GroupChannelListContext.Provider>

--- a/src/modules/OpenChannelSettings/components/ParticipantUI/ParticipantItem.tsx
+++ b/src/modules/OpenChannelSettings/components/ParticipantUI/ParticipantItem.tsx
@@ -8,7 +8,7 @@ import React, {
 import { Participant, type User } from '@sendbird/chat';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 
-import { UserProfileContext } from '../../../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../../../lib/UserProfileContext';
 import Button, { ButtonTypes, ButtonSizes } from '../../../../ui/Button';
 import Accordion from '../../../../ui/Accordion';
 import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
@@ -41,7 +41,7 @@ export const UserListItem: React.FC<UserListItemProps> = ({
 }: UserListItemProps) => {
   const avatarRef = useRef(null);
   const actionRef = useRef(null);
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const { stringSet } = useContext(LocalizationContext);
   return (
     <div className="sendbird-participants-accordion__member">

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import { FileMessage } from '@sendbird/chat/message';
 
@@ -11,7 +11,7 @@ import { getIsReactionEnabled } from '../../../../utils/getIsReactionEnabled';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useThreadContext } from '../../context/ThreadProvider';
-import { UserProfileContext } from '../../../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../../../lib/UserProfileContext';
 import SuggestedMentionList from '../SuggestedMentionList';
 
 import Avatar from '../../../../ui/Avatar';
@@ -143,7 +143,7 @@ export default function ParentMessageInfo({
 
   // User Profile
   const avatarRef = useRef(null);
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
 
   if (showEditInput && parentMessage?.isUserMessage?.()) {
     return (

--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import { EmojiContainer } from '@sendbird/chat';
 import { FileMessage, MultipleFilesMessage, UserMessage } from '@sendbird/chat/message';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
@@ -8,7 +8,7 @@ import './ThreadListItemContent.scss';
 import { ReplyType } from '../../../../types';
 import ContextMenu, { EMOJI_MENU_ROOT_ID, getObservingId, MENU_OBSERVING_CLASS_NAME, MENU_ROOT_ID, MenuItems } from '../../../../ui/ContextMenu';
 import Avatar from '../../../../ui/Avatar';
-import { UserProfileContext } from '../../../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../../../lib/UserProfileContext';
 import UserProfile from '../../../../ui/UserProfile';
 import { MessageEmojiMenu, MessageEmojiMenuProps } from '../../../../ui/MessageItemReactionMenu';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
@@ -106,7 +106,7 @@ export default function ThreadListItemContent({
       document.getElementById(EMOJI_MENU_ROOT_ID),
     ],
   );
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const { deleteMessage, onBeforeDownloadFileMessage } = useThreadContext();
   const avatarRef = useRef(null);
 

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@sendbird/chat/message';
 
 import { getNicknamesMapFromMembers, getParentMessageFrom } from './utils';
-import { UserProfileProvider } from '../../../lib/UserProfileContext';
+import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import { CustomUseReducerDispatcher } from '../../../lib/SendbirdState';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 
@@ -35,7 +35,8 @@ import { useThreadFetchers } from './hooks/useThreadFetchers';
 import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
 import { useMessageLayoutDirection } from '../../../hooks/useHTMLTextDirection';
 
-export type ThreadProviderProps = {
+export interface ThreadProviderProps extends
+  Pick<UserProfileProviderProps, 'disableUserProfile' | 'renderUserProfile'> {
   children?: React.ReactElement;
   channelUrl: string;
   message: SendableMessageType | null;
@@ -46,9 +47,6 @@ export type ThreadProviderProps = {
   onBeforeSendVoiceMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
   onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
-  // User Profile
-  disableUserProfile?: boolean;
-  renderUserProfile?: (props: { user: User, close: () => void }) => ReactElement;
   isMultipleFilesMessageEnabled?: boolean;
 };
 export interface ThreadProviderInterface extends ThreadProviderProps, ThreadContextInitialState {
@@ -79,9 +77,6 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
     onBeforeSendMultipleFilesMessage,
     onBeforeDownloadFileMessage,
     isMultipleFilesMessageEnabled,
-    // User Profile
-    disableUserProfile,
-    renderUserProfile,
   } = props;
   const propsMessage = props?.message;
   const propsParentMessage = getParentMessageFrom(propsMessage);
@@ -94,7 +89,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
   const { user } = userStore;
   const sdkInit = sdkStore?.initialized;
   // // config
-  const { logger, pubSub, onUserProfileMessage, htmlTextDirection, forceLeftToRightMessageLayout } = config;
+  const { logger, pubSub, htmlTextDirection, forceLeftToRightMessageLayout } = config;
 
   const isMentionEnabled = config.groupChannel.enableMention;
   const isReactionEnabled = config.groupChannel.enableReactions;
@@ -272,11 +267,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
       }}
     >
       {/* UserProfileProvider */}
-      <UserProfileProvider
-        disableUserProfile={disableUserProfile ?? !config.common.enableUsingDefaultUserProfile}
-        renderUserProfile={renderUserProfile}
-        onUserProfileMessage={onUserProfileMessage}
-      >
+      <UserProfileProvider {...props}>
         {children}
       </UserProfileProvider>
     </ThreadContext.Provider>

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -1,5 +1,4 @@
-import React, { useReducer, useMemo, useEffect, ReactElement } from 'react';
-import { User } from '@sendbird/chat';
+import React, { useReducer, useMemo, useEffect } from 'react';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type {
   BaseMessage, FileMessage,
@@ -48,7 +47,7 @@ export interface ThreadProviderProps extends
   onBeforeSendMultipleFilesMessage?: (files: Array<File>, quotedMessage?: SendableMessageType) => MultipleFilesMessageCreateParams;
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
   isMultipleFilesMessageEnabled?: boolean;
-};
+}
 export interface ThreadProviderInterface extends ThreadProviderProps, ThreadContextInitialState {
   // hooks for fetching threads
   fetchPrevThreads: (callback?: (messages?: Array<BaseMessage>) => void) => void;

--- a/src/ui/MessageContent/MessageProfile/index.tsx
+++ b/src/ui/MessageContent/MessageProfile/index.tsx
@@ -1,6 +1,5 @@
 import React, {
   ReactElement,
-  useContext,
   useRef,
 } from 'react';
 import '../index.scss';
@@ -9,7 +8,7 @@ import ContextMenu, { MenuItems } from '../../ContextMenu';
 import Avatar from '../../Avatar';
 import UserProfile from '../../UserProfile';
 import { MessageContentProps } from '../index';
-import { UserProfileContext } from '../../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../../lib/UserProfileContext';
 import { classnames } from '../../../utils/utils';
 
 export interface MessageProfileProps extends MessageContentProps {
@@ -32,7 +31,7 @@ export default function MessageProfile(
   } = props;
   const avatarRef = useRef(null);
 
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
 
   if (isByMe || chainBottom || !isSendableMessage(message)) {
     return null;

--- a/src/ui/OpenchannelFileMessage/index.tsx
+++ b/src/ui/OpenchannelFileMessage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { FileMessage } from '@sendbird/chat/message';
 import format from 'date-fns/format';
 import './index.scss';
@@ -11,7 +11,7 @@ import Icon, { IconTypes, IconColors } from '../Icon';
 import IconButton from '../IconButton';
 import TextButton from '../TextButton';
 import UserProfile from '../UserProfile';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 
 import { useLocalization } from '../../lib/LocalizationContext';
 import { checkFileType, truncate } from './utils';
@@ -57,7 +57,7 @@ export default function OpenChannelFileMessage({
   const contextMenuRef = useRef(null);
   const mobileMenuRef = useRef(null);
   const avatarRef = useRef(null);
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
 
   const { isMobile } = useMediaQueryContext();
   const openFileUrl = () => openURL(message.url);

--- a/src/ui/OpenchannelOGMessage/index.tsx
+++ b/src/ui/OpenchannelOGMessage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { UserMessage } from '@sendbird/chat/message';
 import format from 'date-fns/format';
 import './index.scss';
@@ -12,7 +12,7 @@ import LinkLabel from '../LinkLabel';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Loader from '../Loader';
 import UserProfile from '../UserProfile';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 
 import uuidv4 from '../../utils/uuid';
 import { copyToClipboard } from '../OpenchannelUserMessage/utils';
@@ -66,7 +66,7 @@ export default function OpenChannelOGMessage({
   const { stringSet, dateLocale } = useLocalization();
   const { isMobile } = useMediaQueryContext();
 
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const [contextStyle, setContextStyle] = useState({});
   const [showContextMenu, setShowContextMenu] = useState(false);
 

--- a/src/ui/OpenchannelThumbnailMessage/index.tsx
+++ b/src/ui/OpenchannelThumbnailMessage/index.tsx
@@ -3,7 +3,6 @@ import React, {
   useMemo,
   useState,
   useEffect,
-  useContext,
 } from 'react';
 import { FileMessage } from '@sendbird/chat/message';
 import format from 'date-fns/format';
@@ -19,7 +18,7 @@ import ImageRenderer from '../ImageRenderer';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Loader from '../Loader';
 import UserProfile from '../UserProfile';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 import {
   checkIsSent,
   checkIsPending,
@@ -71,7 +70,7 @@ export default function OpenchannelThumbnailMessage({
   const status = message?.sendingStatus;
   const thumbnailUrl = (thumbnails && thumbnails.length > 0 && thumbnails[0].url) || null;
   const { stringSet, dateLocale } = useLocalization();
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const [messageWidth, setMessageWidth] = useState(360);
   const [contextMenu, setContextMenu] = useState(false);
   const messageRef = useRef<HTMLDivElement>(null);

--- a/src/ui/OpenchannelUserMessage/index.tsx
+++ b/src/ui/OpenchannelUserMessage/index.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useContext,
   useRef,
   useState,
   ReactElement,
@@ -16,7 +15,7 @@ import IconButton from '../IconButton';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Loader from '../Loader';
 import UserProfile from '../UserProfile';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 
 import { useLocalization } from '../../lib/LocalizationContext';
 import { copyToClipboard } from './utils';
@@ -64,7 +63,7 @@ export default function OpenchannelUserMessage({
 }: OpenChannelUserMessageProps): ReactElement {
   // hooks
   const { stringSet, dateLocale } = useLocalization();
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const messageRef = useRef<HTMLDivElement>();
   const avatarRef = useRef<HTMLDivElement>();
   const contextMenuRef = useRef<HTMLDivElement>();

--- a/src/ui/UserListItem/index.tsx
+++ b/src/ui/UserListItem/index.tsx
@@ -1,10 +1,10 @@
-import React, { ChangeEvent, MutableRefObject, ReactElement, ReactNode, useContext, useRef } from 'react';
+import React, { ChangeEvent, MutableRefObject, ReactElement, ReactNode, useRef } from 'react';
 import type { User } from '@sendbird/chat';
 import type { GroupChannel, Member } from '@sendbird/chat/groupChannel';
 import './index.scss';
 
 import { useSendbirdStateContext } from '../../lib/Sendbird';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 import { useLocalization } from '../../lib/LocalizationContext';
 
 import Avatar from '../Avatar/index';
@@ -61,7 +61,7 @@ export function UserListItem({
   const actionRef = useRef(null);
   const parentRef = useRef(null);
   const avatarRef = useRef(null);
-  const { disableUserProfile, renderUserProfile } = useContext(UserProfileContext);
+  const { disableUserProfile, renderUserProfile } = useUserProfileContext();
   const { stringSet } = useLocalization();
   const { config } = useSendbirdStateContext();
   const currentUser = config.userId;

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -4,7 +4,7 @@ import type { GroupChannel, GroupChannelCreateParams } from '@sendbird/chat/grou
 import type { User } from '@sendbird/chat';
 
 import { LocalizationContext } from '../../lib/LocalizationContext';
-import { UserProfileContext } from '../../lib/UserProfileContext';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 import { getCreateGroupChannel } from '../../lib/selectors';
 import Avatar from '../Avatar/index';
 import Label, { LabelColors, LabelTypography } from '../Label';
@@ -35,7 +35,7 @@ function UserProfile({
   const logger = store?.config?.logger;
   const { stringSet } = useContext(LocalizationContext);
   const currentUserId_ = currentUserId || store?.config?.userId;
-  const { onStartDirectMessage } = useContext(UserProfileContext);
+  const { onStartDirectMessage } = useUserProfileContext();
   return (
     <div className="sendbird__user-profile">
       <section className="sendbird__user-profile-avatar">

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -35,7 +35,7 @@ function UserProfile({
   const logger = store?.config?.logger;
   const { stringSet } = useContext(LocalizationContext);
   const currentUserId_ = currentUserId || store?.config?.userId;
-  const { onUserProfileMessage } = useContext(UserProfileContext);
+  const { onStartDirectMessage } = useContext(UserProfileContext);
   return (
     <div className="sendbird__user-profile">
       <section className="sendbird__user-profile-avatar">
@@ -69,9 +69,7 @@ function UserProfile({
                 createChannel(params)
                   .then((groupChannel) => {
                     logger.info('UserProfile, channel create', groupChannel);
-                    if (typeof onUserProfileMessage === 'function') {
-                      onUserProfileMessage?.(groupChannel);
-                    }
+                    onStartDirectMessage?.(groupChannel);
                   });
               }}
             >


### PR DESCRIPTION
[CLNP-4601](https://sendbird.atlassian.net/browse/CLNP-4601)

### Fix
* Made `useUserProfileContext` hook and applied it

### Changelog
* Renamed the prop `onUserProfileMessage` to `onStartDirectMessage`
  * Deprecated `onUserProfileMessage` prop in `SendbirdProvider` and `UserProfileProvider`
  * Deprecated `onUserProfileMessage` interface in `SendbirdStateContext` and `UserProfileContext`
  * Use a `onStartDirectMessage` instead.

[CLNP-4601]: https://sendbird.atlassian.net/browse/CLNP-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ