### PR TITLE
fix: File viewer not scaling image to full size

### DIFF
--- a/src/modules/GroupChannel/components/FileViewer/index.scss
+++ b/src/modules/GroupChannel/components/FileViewer/index.scss
@@ -112,6 +112,9 @@
     .sendbird-fileviewer__content__img {
       max-width: 90%;
       max-height: 90%;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
     .sendbird-fileviewer__content__unsupported {
       max-width: 100%;

--- a/src/ui/FileViewer/index.scss
+++ b/src/ui/FileViewer/index.scss
@@ -99,6 +99,9 @@ $file-viewer-img-max-width: calc(100% - #{$file-viewer-slide-buttons-side-length
     .sendbird-fileviewer__content__img {
       max-width: 90%;
       max-height: 90%;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
     .sendbird-fileviewer__content__img__multi {
       max-width: $file-viewer-img-max-width;


### PR DESCRIPTION
Fixes [AC-3578](https://sendbird.atlassian.net/browse/AC-3578)

### Changelogs
- Fixed a bug where images are not scaling to full size in file viewer

[AC-3578]: https://sendbird.atlassian.net/browse/AC-3578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ