### PR TITLE
fix: scroll not working for profile modal in horizontal mobile

### DIFF
--- a/src/ui/Modal/index.scss
+++ b/src/ui/Modal/index.scss
@@ -52,6 +52,7 @@
   }
   .sendbird-modal__body {
     height: calc(100% - 116px);
+    overflow: auto;
   }
   .sendbird-modal__footer {
     display: flex;


### PR DESCRIPTION
Fixes [AC-3324](https://sendbird.atlassian.net/browse/AC-3324)

### Changelogs
- Fixed a bug where y-scroll not working in `EditUserProfileUIView` when app is being displayed in horizontal view of mobile devices

### After
![IMG_4770](https://github.com/user-attachments/assets/166c3075-275d-4172-bd0a-afdb04138a42)


[AC-3324]: https://sendbird.atlassian.net/browse/AC-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ