### PR TITLE
fix: broken CSS in the ParentMessageInfo component

### DIFF
--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.scss
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.scss
@@ -80,7 +80,7 @@
   width: 56px;
 }
 
-.sendbird-parent-message-info-item__thumbnail-message__image-cover {;
+.sendbird-parent-message-info-item__thumbnail-message__image-cover {
   background-color: var(--sendbird-light-overlay-01);
   border-radius: 16px;
   display: none;

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -149,7 +149,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
         )
       }
       <div
-        className={classnames('sendbird-thread-ui--scroll, sendbird-conversation__messages')}
+        className={classnames('sendbird-thread-ui--scroll', 'sendbird-conversation__messages')}
         ref={scrollRef}
         onScroll={onScroll}
       >

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -16,6 +16,8 @@ import threadReducer from './dux/reducer';
 import { ThreadContextActionTypes } from './dux/actionTypes';
 import threadInitialState, { ThreadContextInitialState } from './dux/initialState';
 
+import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
+import type { ChannelStateTypes, ParentMessageStateTypes, ThreadListStateTypes } from '../types';
 import useGetChannel from './hooks/useGetChannel';
 import useGetAllEmoji from './hooks/useGetAllEmoji';
 import useGetParentMessage from './hooks/useGetParentMessage';
@@ -31,7 +33,6 @@ import useSendVoiceMessageCallback from './hooks/useSendVoiceMessageCallback';
 import { PublishingModuleType, useSendMultipleFilesMessage } from './hooks/useSendMultipleFilesMessage';
 import { SendableMessageType } from '../../../utils';
 import { useThreadFetchers } from './hooks/useThreadFetchers';
-import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
 import { useMessageLayoutDirection } from '../../../hooks/useHTMLTextDirection';
 
 export interface ThreadProviderProps extends
@@ -165,8 +166,9 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
   useMessageLayoutDirection(
     htmlTextDirection,
     forceLeftToRightMessageLayout,
-    // we're assuming that if the thread message list is empty, it's in the loading state
-    allThreadMessages.length === 0,
+    channelState === ChannelStateTypes.LOADING
+    || threadListState === ThreadListStateTypes.LOADING
+    || parentMessageState === ParentMessageStateTypes.LOADING,
   );
 
   const toggleReaction = useToggleReactionCallback({ currentChannel }, { logger });

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -17,7 +17,6 @@ import { ThreadContextActionTypes } from './dux/actionTypes';
 import threadInitialState, { ThreadContextInitialState } from './dux/initialState';
 
 import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
-import type { ChannelStateTypes, ParentMessageStateTypes, ThreadListStateTypes } from '../types';
 import useGetChannel from './hooks/useGetChannel';
 import useGetAllEmoji from './hooks/useGetAllEmoji';
 import useGetParentMessage from './hooks/useGetParentMessage';
@@ -34,6 +33,7 @@ import { PublishingModuleType, useSendMultipleFilesMessage } from './hooks/useSe
 import { SendableMessageType } from '../../../utils';
 import { useThreadFetchers } from './hooks/useThreadFetchers';
 import { useMessageLayoutDirection } from '../../../hooks/useHTMLTextDirection';
+import { ChannelStateTypes, ParentMessageStateTypes, ThreadListStateTypes } from '../types';
 
 export interface ThreadProviderProps extends
   Pick<UserProfileProviderProps, 'disableUserProfile' | 'renderUserProfile'> {


### PR DESCRIPTION
#### Changelog
* Fixed broken CSS in Thread:
  * Style was not applied to `ParentMessageInfo` until the first message was received on the thread list.
  * Scroll functionality was not working on the thread list.

#### Fix
* Use `channelState`, `parentMessageState` and `threadListState` to calculate the loading status in `useMessageLayoutDirection`
* Fix typo for className