### PR TITLE
feat: Support rendering subcomponents of ThreadListItem

### DIFF
--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -243,7 +243,6 @@ export default function ThreadListItem({
         chainTop={chainTop}
         chainBottom={chainBottom}
         isReactionEnabled={isReactionEnabled}
-        isMentionEnabled={isMentionEnabled}
         disableQuoteMessage
         replyType={replyType}
         nicknamesMap={nicknamesMap}

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useEffect, useLayoutEffect, ReactNode } from 'react';
+import React, { useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
 import format from 'date-fns/format';
 import type { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
 
@@ -21,10 +21,9 @@ import { SendableMessageType } from '../../../../utils';
 import { User } from '@sendbird/chat';
 import { getCaseResolvedReplyType } from '../../../../lib/utils/resolvedReplyType';
 import { classnames } from '../../../../utils/utils';
-import type { MessageMenuProps } from '../../../../ui/MessageMenu';
-import type { MessageEmojiMenuProps } from '../../../../ui/MessageItemReactionMenu';
+import { MessageComponentRenderers } from '../../../../ui/MessageContent';
 
-export interface ThreadListItemProps {
+export interface ThreadListItemProps extends MessageComponentRenderers {
   className?: string;
   message: SendableMessageType;
   chainTop?: boolean;
@@ -32,21 +31,18 @@ export interface ThreadListItemProps {
   hasSeparator?: boolean;
   renderCustomSeparator?: (props: { message: SendableMessageType }) => React.ReactElement;
   handleScroll?: () => void;
-  renderEmojiMenu?: (props: MessageEmojiMenuProps) => ReactNode;
-  renderMessageMenu?: (props: MessageMenuProps) => ReactNode;
 }
 
-export default function ThreadListItem({
-  className,
-  message,
-  chainTop,
-  chainBottom,
-  hasSeparator,
-  renderCustomSeparator,
-  handleScroll,
-  renderEmojiMenu,
-  renderMessageMenu,
-}: ThreadListItemProps): React.ReactElement {
+export default function ThreadListItem(props: ThreadListItemProps): React.ReactElement {
+  const {
+    className,
+    message,
+    chainTop,
+    chainBottom,
+    hasSeparator,
+    renderCustomSeparator,
+    handleScroll,
+  } = props;
   const { stores, config } = useSendbirdStateContext();
   const { isOnline, userMention, logger, groupChannel } = config;
   const userId = stores?.userStore?.user?.userId;
@@ -237,6 +233,7 @@ export default function ThreadListItem({
         ))
       }
       <ThreadListItemContent
+        {...props}
         userId={userId}
         channel={currentChannel}
         message={message}
@@ -252,8 +249,6 @@ export default function ThreadListItem({
         showFileViewer={setShowFileViewer}
         toggleReaction={toggleReaction}
         showEdit={setShowEdit}
-        renderEmojiMenu={renderEmojiMenu}
-        renderMessageMenu={renderMessageMenu}
       />
       {/* modal */}
       {showRemove && (

--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -31,13 +31,13 @@ import { useThreadContext } from '../../context/ThreadProvider';
 import { classnames, deleteNullish } from '../../../../utils/utils';
 import { MessageMenu, MessageMenuProps } from '../../../../ui/MessageMenu';
 import useElementObserver from '../../../../hooks/useElementObserver';
-import type { MessageContentRenderSubComponentProps } from '../../../../ui/MessageContent';
+import type { MessageComponentRenderers } from '../../../../ui/MessageContent';
 import MessageProfile, { MessageProfileProps } from '../../../../ui/MessageContent/MessageProfile';
 import MessageBody, { CustomSubcomponentsProps, MessageBodyProps } from '../../../../ui/MessageContent/MessageBody';
 import { MessageHeaderProps, MessageHeader } from '../../../../ui/MessageContent/MessageHeader';
 import { MobileBottomSheetProps } from '../../../../ui/MobileMenu/types';
 
-export interface ThreadListItemContentProps extends MessageContentRenderSubComponentProps {
+export interface ThreadListItemContentProps extends MessageComponentRenderers {
   className?: string;
   userId: string;
   channel: GroupChannel;

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -23,10 +23,16 @@ import { match } from 'ts-pattern';
 import TemplateMessageItemBody from '../../TemplateMessageItemBody';
 import type { OnBeforeDownloadFileMessageType } from '../../../modules/GroupChannel/context/GroupChannelProvider';
 
+export type CustomSubcomponentsProps = Record<
+  'ThumbnailMessageItemBody' | 'MultipleFilesMessageItemBody',
+  Record<string, any>
+>;
+
 const MESSAGE_ITEM_BODY_CLASSNAME = 'sendbird-message-content__middle__message-item-body';
 export type RenderedTemplateBodyType = 'failed' | 'composite' | 'simple';
 
 export interface MessageBodyProps {
+  className?: string;
   channel: Nullable<GroupChannel>;
   message: CoreMessageType;
   showFileViewer?: (bool: boolean) => void;
@@ -43,6 +49,7 @@ export interface MessageBodyProps {
 
 export const MessageBody = (props: MessageBodyProps) => {
   const {
+    className = MESSAGE_ITEM_BODY_CLASSNAME,
     message,
     channel,
     showFileViewer,
@@ -56,6 +63,8 @@ export const MessageBody = (props: MessageBodyProps) => {
     isReactionEnabledInChannel,
     isByMe,
   } = props;
+  // Private props for internal customization.
+  const customSubcomponentsProps: CustomSubcomponentsProps = props['customSubcomponentsProps'] ?? {};
 
   const threadMessageKindKey = useThreadMessageKindKeySelector({
     isMobile,
@@ -68,7 +77,7 @@ export const MessageBody = (props: MessageBodyProps) => {
   return match(message)
     .when(isTemplateMessage, () => (
       <TemplateMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as BaseMessage}
         isByMe={isByMe}
         theme={config?.theme as SendbirdTheme}
@@ -78,20 +87,20 @@ export const MessageBody = (props: MessageBodyProps) => {
     .when((message) => isOgMessageEnabledInGroupChannel
       && isSendableMessage(message)
       && isOGMessage(message), () => (
-      <OGMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
-        message={message as UserMessage}
-        isByMe={isByMe}
-        mouseHover={mouseHover}
-        isMentionEnabled={config.groupChannel.enableMention ?? false}
-        isReactionEnabled={isReactionEnabledInChannel}
-        onMessageHeightChange={onMessageHeightChange}
-        isMarkdownEnabled={config.groupChannel.enableMarkdownForUserMessage}
-      />
+        <OGMessageItemBody
+          className={className}
+          message={message as UserMessage}
+          isByMe={isByMe}
+          mouseHover={mouseHover}
+          isMentionEnabled={config.groupChannel.enableMention ?? false}
+          isReactionEnabled={isReactionEnabledInChannel}
+          onMessageHeightChange={onMessageHeightChange}
+          isMarkdownEnabled={config.groupChannel.enableMarkdownForUserMessage}
+        />
     ))
     .when(isTextMessage, () => (
       <TextMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as UserMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
@@ -102,7 +111,7 @@ export const MessageBody = (props: MessageBodyProps) => {
     ))
     .when((message) => getUIKitMessageType(message) === messageTypes.FILE, () => (
       <FileMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as FileMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
@@ -112,7 +121,7 @@ export const MessageBody = (props: MessageBodyProps) => {
     ))
     .when(isMultipleFilesMessage, () => (
       <MultipleFilesMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as MultipleFilesMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
@@ -120,11 +129,12 @@ export const MessageBody = (props: MessageBodyProps) => {
         threadMessageKindKey={threadMessageKindKey}
         statefulFileInfoList={statefulFileInfoList}
         onBeforeDownloadFileMessage={onBeforeDownloadFileMessage}
+        {...customSubcomponentsProps['MultipleFilesMessageItemBody'] ?? {}}
       />
     ))
     .when(isVoiceMessage, () => (
       <VoiceMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as FileMessage}
         channelUrl={channel?.url ?? ''}
         isByMe={isByMe}
@@ -133,18 +143,19 @@ export const MessageBody = (props: MessageBodyProps) => {
     ))
     .when(isThumbnailMessage, () => (
       <ThumbnailMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message as FileMessage}
         isByMe={isByMe}
         mouseHover={mouseHover}
         isReactionEnabled={isReactionEnabledInChannel}
         showFileViewer={showFileViewer}
         style={isMobile ? { width: '100%' } : {}}
+        {...customSubcomponentsProps['ThumbnailMessageItemBody'] ?? {}}
       />
     ))
     .otherwise((message) => (
       <UnknownMessageItemBody
-        className={MESSAGE_ITEM_BODY_CLASSNAME}
+        className={className}
         message={message}
         isByMe={isByMe}
         mouseHover={mouseHover}

--- a/src/ui/MessageContent/MessageProfile/index.tsx
+++ b/src/ui/MessageContent/MessageProfile/index.tsx
@@ -1,7 +1,4 @@
-import React, {
-  ReactElement,
-  useRef,
-} from 'react';
+import React, { ReactElement, useRef } from 'react';
 import '../index.scss';
 import { isSendableMessage } from '../../../utils';
 import ContextMenu, { MenuItems } from '../../ContextMenu';
@@ -12,21 +9,24 @@ import { useUserProfileContext } from '../../../lib/UserProfileContext';
 import { classnames } from '../../../utils/utils';
 
 export interface MessageProfileProps extends MessageContentProps {
+  className?: string;
   isByMe?: boolean;
   displayThreadReplies?: boolean;
   bottom?: string
 }
 
-export const MessageProfile = (props: MessageProfileProps) => {
-  const {
-    message,
-    channel,
-    userId,
-    chainBottom = false,
-    isByMe,
-    displayThreadReplies,
-    bottom,
-  } = props;
+export function MessageProfile({
+  // Internal props
+  className = '',
+  isByMe,
+  displayThreadReplies,
+  bottom,
+  // MessageContentProps
+  message,
+  channel,
+  userId,
+  chainBottom = false,
+}: MessageProfileProps) {
   const avatarRef = useRef(null);
 
   const { disableUserProfile, renderUserProfile } = useUserProfileContext();
@@ -39,11 +39,9 @@ export const MessageProfile = (props: MessageProfileProps) => {
     <ContextMenu
       menuTrigger={(toggleDropdown: () => void): ReactElement => (
         <Avatar
-          className={classnames('sendbird-message-content__left__avatar', displayThreadReplies && 'use-thread-replies')}
+          className={classnames(className, displayThreadReplies && 'use-thread-replies')}
           src={
-            channel?.members?.find(
-              (member) => member?.userId === message.sender.userId,
-            )?.profileUrl
+            channel?.members?.find((member) => member?.userId === message.sender.userId)?.profileUrl
             || message.sender.profileUrl
             || ''
           }
@@ -82,6 +80,6 @@ export const MessageProfile = (props: MessageProfileProps) => {
       )}
     />
   );
-};
+}
 
 export default MessageProfile;

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -53,7 +53,7 @@ export { MessageBody } from './MessageBody';
 export { MessageHeader } from './MessageHeader';
 export { MessageProfile } from './MessageProfile';
 
-export interface MessageContentProps {
+export interface MessageContentProps extends MessageContentRenderSubComponentProps {
   className?: string | Array<string>;
   userId: string;
   channel: Nullable<GroupChannel>;
@@ -81,8 +81,9 @@ export interface MessageContentProps {
   onQuoteMessageClick?: (props: { message: SendableMessageType }) => void;
   onMessageHeightChange?: () => void;
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
+}
 
-  // For injecting customizable subcomponents
+export interface MessageContentRenderSubComponentProps {
   renderSenderProfile?: (props: MessageProfileProps) => ReactNode;
   renderMessageBody?: (props: MessageBodyProps) => ReactNode;
   renderMessageHeader?: (props: MessageHeaderProps) => ReactNode;
@@ -285,6 +286,7 @@ export function MessageContent(props: MessageContentProps): ReactElement {
         {
           renderSenderProfile({
             ...props,
+            className: 'sendbird-message-content__left__avatar',
             isByMe,
             displayThreadReplies,
             bottom: totalBottom > 0 ? totalBottom + 'px' : '',

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -53,7 +53,7 @@ export { MessageBody } from './MessageBody';
 export { MessageHeader } from './MessageHeader';
 export { MessageProfile } from './MessageProfile';
 
-export interface MessageContentProps extends MessageContentRenderSubComponentProps {
+export interface MessageContentProps extends MessageComponentRenderers {
   className?: string | Array<string>;
   userId: string;
   channel: Nullable<GroupChannel>;
@@ -83,7 +83,7 @@ export interface MessageContentProps extends MessageContentRenderSubComponentPro
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
 }
 
-export interface MessageContentRenderSubComponentProps {
+export interface MessageComponentRenderers {
   renderSenderProfile?: (props: MessageProfileProps) => ReactNode;
   renderMessageBody?: (props: MessageBodyProps) => ReactNode;
   renderMessageHeader?: (props: MessageHeaderProps) => ReactNode;
@@ -337,7 +337,7 @@ export function MessageContent(props: MessageContentProps): ReactElement {
         ref={contentRef}
       >
         {
-          !isByMe && !chainTop && !useReplying && renderMessageHeader(props)
+          (!isByMe && !chainTop && !useReplying) && renderMessageHeader(props)
         }
         {/* quote message */}
         {(useReplying) ? (


### PR DESCRIPTION
### ChangeLog
* Added sub-rendering props to the `ThreadListItem` and `ThreadListItemContent` components.
  * Added props list: `renderSenderProfile`, `renderMessageBody`, `renderMessageHeader`, `renderEmojiReactions`, and `renderMobileMenuOnLongPress`.
  * How to use:
  ```tsx
  const CustomThread = () => (
    <ThreadProvider>
      <ThreadUI
        renderMessage={(props) => (
          <ThreadListItem
            {...props}
            renderSenderProfile={() => <></>}
          />
        )}
      />
    </ThreadProvider>
  )
  ```