### PR TITLE
[CLNP-4962] fix: prevent HTML entity conversion by using insertText in document.execCommand

### DIFF
--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -27,7 +27,7 @@ export function usePaste({
     // simple text, continue as normal
     if (!html) {
       const text = e.clipboardData.getData('text') || getURIListText(e);
-      document.execCommand('insertHTML', false, sanitizeString(text));
+      document.execCommand('insertText', false, sanitizeString(text));
       setIsInput(true);
       setHeight();
       return;
@@ -43,7 +43,7 @@ export function usePaste({
       if (!hasMention(pasteNode)) {
         // to preserve space between words
         const text = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
-        document.execCommand('insertHTML', false, sanitizeString(text));
+        document.execCommand('insertText', false, sanitizeString(text));
         pasteNode.remove();
         setIsInput(true);
         setHeight();


### PR DESCRIPTION
Fixes the issue https://sendbird.atlassian.net/browse/CLNP-4962 
where HTML entities like `&sect` or `&lt` were being automatically converted to their corresponding symbols (§ or >) when pasting content into a contentEditable element.

### Changes 
The `document.execCommand('insertHTML', false, sanitizeString(text))` command was replaced with `document.execCommand('insertText', false, sanitizeString(text))`.
This change ensures that HTML entities are inserted as plain text rather than being interpreted and converted by the browser. Now it prevents unintended conversion of HTML entities, maintaining the original text as expected when pasting content.

### How to test? 
Try this on the preview.
Type `&sect` and copy & paste the text to the input box. The exact same text(=`&sect`) should be on the input not `§`.