### PR TITLE
hotfix: fix unread count position on channel preview

### DIFF
--- a/src/modules/GroupChannelList/components/GroupChannelListItem/index.scss
+++ b/src/modules/GroupChannelList/components/GroupChannelListItem/index.scss
@@ -184,10 +184,3 @@
     }
   }
 }
-
-.sendbird-channel-preview__content__lower__unread-message-count {
-  @include mobile() {
-    position: absolute;
-    right: 0;
-  }
-}


### PR DESCRIPTION
hotfix
* fix unread count position on the ChannelPreview item

<img width="409" alt="image" src="https://github.com/user-attachments/assets/6211e9de-4179-4815-9822-0957d15a3a34">
