### PR TITLE
release: v3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - v3
 
+## [v3.15.1] (Aug 29, 2024)
+
+### Fixes
+- Fixed unread count badge position on the ChannelPreview item component.
+
 ## [v3.15.0] (Aug 29, 2024)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.15.1] (Aug 29, 2024)

### Fixes
- Fixed unread count badge position on the ChannelPreview item component.