### PR TITLE
[CLNP-5022] feat: add message input related eventHandlers

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,11 @@ export interface SBUEventHandlers {
   modal?: {
     onMounted?(params: { id: string; close(): void; }): void | (() => void);
   };
+  message?: {
+    onSendMessageFailed?: (message: CoreMessageType, error: unknown) => void;
+    onUpdateMessageFailed?: (message: CoreMessageType, error: unknown) => void;
+    onFileUploadFailed?: (error: unknown) => void;
+  }
 }
 
 export interface SendBirdStateConfig {

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -138,7 +138,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
 
   const textFieldId = messageFieldId || TEXT_FIELD_ID;
   const { stringSet } = useLocalization();
-  const { config } = useSendbirdStateContext();
+  const { config, eventHandlers } = useSendbirdStateContext();
 
   const isFileUploadEnabled = checkIfFileUploadEnabled({
     channel,
@@ -391,38 +391,45 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
   }, [isMentionEnabled]);
 
   const sendMessage = () => {
-    const textField = internalRef?.current;
-    if (!isEdit && textField?.textContent) {
-      const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
-      const params = { message: messageText, mentionTemplate };
-      onSendMessage(params);
-      resetInput(internalRef);
+    try {
+      const textField = internalRef?.current;
+      if (!isEdit && textField?.textContent) {
+        const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
+        const params = { message: messageText, mentionTemplate };
+        onSendMessage(params);
+        resetInput(internalRef);
+        /**
+         * Note: contentEditable does not work as expected in mobile WebKit (Safari).
+         * @see https://github.com/sendbird/sendbird-uikit-react/pull/1108
+         */
+        if (isMobileIOS(navigator.userAgent)) {
+          if (ghostInputRef.current) ghostInputRef.current.focus();
+          requestAnimationFrame(() => textField.focus());
+        } else {
+          // important: keeps the keyboard open -> must add test on refactor
+          textField.focus();
+        }
 
-      /**
-       * Note: contentEditable does not work as expected in mobile WebKit (Safari).
-       * @see https://github.com/sendbird/sendbird-uikit-react/pull/1108
-       */
-      if (isMobileIOS(navigator.userAgent)) {
-        if (ghostInputRef.current) ghostInputRef.current.focus();
-        requestAnimationFrame(() => textField.focus());
-      } else {
-        // important: keeps the keyboard open -> must add test on refactor
-        textField.focus();
+        setIsInput(false);
+        setHeight();
       }
-
-      setIsInput(false);
-      setHeight();
+    } catch (error) {
+      eventHandlers?.message?.onSendMessageFailed?.(message, error);
     }
   };
   const isEditDisabled = !internalRef?.current?.textContent?.trim();
   const editMessage = () => {
-    const textField = internalRef?.current;
-    const messageId = message?.messageId;
-    if (isEdit && messageId && textField) {
-      const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
-      const params = { messageId, message: messageText, mentionTemplate };
-      onUpdateMessage(params);
-      resetInput(internalRef);
+    try {
+      const textField = internalRef?.current;
+      const messageId = message?.messageId;
+      if (isEdit && messageId && textField) {
+        const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
+        const params = { messageId, message: messageText, mentionTemplate };
+        onUpdateMessage(params);
+        resetInput(internalRef);
+      }
+    } catch (error) {
+      eventHandlers?.message?.onUpdateMessageFailed?.(message, error);
     }
   };
   const onPaste = usePaste({
@@ -432,6 +439,19 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     setIsInput,
     setHeight,
   });
+
+  const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.currentTarget;
+    try {
+      if (files) {
+        onFileUpload(files && files.length === 1 ? [files[0]] : Array.from(files));
+      }
+    } catch (error) {
+      eventHandlers?.message?.onFileUploadFailed?.(error);
+    } finally {
+      event.target.value = '';
+    }
+  };
 
   return (
     <form className={classnames(
@@ -559,13 +579,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
                   type="file"
                   ref={fileInputRef}
                   // It will affect to <Channel /> and <Thread />
-                  onChange={(event) => {
-                    const { files } = event.currentTarget;
-                    if (files) {
-                      onFileUpload(files && files.length === 1 ? [files[0]] : Array.from(files));
-                    }
-                    event.target.value = '';
-                  }}
+                  onChange={(event) => uploadFile(event)}
                   accept={getMimeTypesUIKitAccepts(acceptableMimeTypes)}
                   multiple={isSelectingMultipleFilesEnabled && isChannelTypeSupportsMultipleFilesMessage(channel)}
                 />

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -444,7 +444,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     const { files } = event.currentTarget;
     try {
       if (files) {
-        onFileUpload(files && files.length === 1 ? [files[0]] : Array.from(files));
+        onFileUpload(Array.from(files));
       }
     } catch (error) {
       eventHandlers?.message?.onFileUploadFailed?.(error);


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-5022


### Main Changes 
```
eventHandlers?: {
 ...
  message?: {
    onSendMessageFailed?: (message: CoreMessageType, error: unknown) => void;
    onUpdateMessageFailed?: (message: CoreMessageType, error: unknown) => void;
    onFileUploadFailed?: (error: unknown) => void;
    // any message related event handlers can be added here
  }
}
```
The original request is only about sending message related event, but just added two more (onUpdateMessageFailed / onFileUploadFailed)

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


