### PR TITLE
[CLNP-5111] feat: replace sdk.disconnect -> sdk.disconnectWebsocket

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -252,7 +252,7 @@ const SendbirdSDK = ({
         sdk,
       });
     }
-  }, [sdk.disconnect]);
+  }, [sdk.disconnectWebSocket]);
 
   // to create a pubsub to communicate between parent and child
   useEffect(() => {

--- a/src/lib/hooks/useConnect/__test__/data.mocks.ts
+++ b/src/lib/hooks/useConnect/__test__/data.mocks.ts
@@ -28,6 +28,7 @@ export const mockSdk = {
     return Promise.reject();
   }),
   disconnect: jest.fn().mockImplementation(() => Promise.resolve(true)),
+  disconnectWebSocket: jest.fn().mockImplementation(() => Promise.resolve(true)),
   updateCurrentUserInfo: jest.fn().mockImplementation((user) => Promise.resolve(user)),
   setSessionHandler: jest.fn(),
   addExtension: jest.fn(),

--- a/src/lib/hooks/useConnect/__test__/disconnectSdk.spec.ts
+++ b/src/lib/hooks/useConnect/__test__/disconnectSdk.spec.ts
@@ -7,7 +7,7 @@ describe('useConnect/disconnectSdk', () => {
   it('should call disconnectSdk when there is proper SDK', async () => {
     // setup
     const disconnectProps = generateDisconnectSdkParams();
-    const mockDisconnect = disconnectProps.sdk.disconnect as jest.Mock;
+    const mockDisconnect = disconnectProps.sdk.disconnectWebSocket as jest.Mock;
 
     // execute
     await disconnectSdk(disconnectProps);
@@ -15,7 +15,7 @@ describe('useConnect/disconnectSdk', () => {
     // verify
     expect(disconnectProps.sdkDispatcher).toHaveBeenCalledBefore(mockDisconnect);
     expect(disconnectProps.sdkDispatcher).toBeCalledWith({ type: SDK_ACTIONS.SET_SDK_LOADING, payload: true });
-    expect(disconnectProps.sdk.disconnect).toHaveBeenCalled();
+    expect(disconnectProps.sdk.disconnectWebSocket).toHaveBeenCalled();
     expect(disconnectProps.sdkDispatcher).toBeCalledWith({ type: SDK_ACTIONS.RESET_SDK });
     expect(disconnectProps.userDispatcher).toBeCalledWith({ type: USER_ACTIONS.RESET_USER });
   });

--- a/src/lib/hooks/useConnect/disconnectSdk.ts
+++ b/src/lib/hooks/useConnect/disconnectSdk.ts
@@ -9,8 +9,8 @@ export async function disconnectSdk({
 }: DisconnectSdkTypes): Promise<boolean> {
   return new Promise((resolve) => {
     sdkDispatcher({ type: SDK_ACTIONS.SET_SDK_LOADING, payload: true });
-    if (sdk?.disconnect) {
-      sdk.disconnect()
+    if (sdk?.disconnectWebSocket) {
+      sdk.disconnectWebSocket()
         .then(() => {
           sdkDispatcher({ type: SDK_ACTIONS.RESET_SDK });
           userDispatcher({ type: USER_ACTIONS.RESET_USER });


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/CLNP-5111

Changed the method we call when SendbirdProvider is unmounted from `disconnect()` to `disconnectWebsocket()` since `disconnect()` is equal to "logout" not just "disconnect". 

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.
