### PR TITLE
fix: Doesn't scroll in the MessageInput when pasting

### DIFF
--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -17,7 +17,6 @@ import { createPasteNode, domToMessageTemplate, extractTextFromNodes, getLeafNod
 export function usePaste({
   ref,
   setIsInput,
-  setHeight,
   channel,
   setMentionedUsers,
 }: DynamicProps): (e: React.ClipboardEvent<HTMLDivElement>) => void {
@@ -29,7 +28,6 @@ export function usePaste({
       const text = e.clipboardData.getData('text') || getURIListText(e);
       document.execCommand('insertText', false, sanitizeString(text));
       setIsInput(true);
-      setHeight();
       return;
     }
 
@@ -46,7 +44,6 @@ export function usePaste({
         document.execCommand('insertText', false, sanitizeString(text));
         pasteNode.remove();
         setIsInput(true);
-        setHeight();
         return;
       }
 
@@ -62,8 +59,7 @@ export function usePaste({
     }
 
     setIsInput(true);
-    setHeight();
-  }, [ref, setIsInput, setHeight, channel, setMentionedUsers]);
+  }, [ref, setIsInput, channel, setMentionedUsers]);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#dragging_links

--- a/src/ui/MessageInput/hooks/usePaste/types.ts
+++ b/src/ui/MessageInput/hooks/usePaste/types.ts
@@ -12,5 +12,4 @@ export type DynamicProps = {
   channel: OpenChannel | GroupChannel;
   setMentionedUsers: React.Dispatch<React.SetStateAction<User[]>>;
   setIsInput: React.Dispatch<React.SetStateAction<boolean>>;
-  setHeight: () => void;
 };

--- a/src/ui/MessageInput/index.scss
+++ b/src/ui/MessageInput/index.scss
@@ -14,7 +14,7 @@
     font-stretch: normal;
     font-style: normal;
     line-height: 1.43;
-    height: 56px;
+    max-height: 92px;
     overflow-y: scroll;
     letter-spacing: normal;
     padding: 18px 64px 18px 16px;

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -28,8 +28,6 @@ import { OpenChannel } from '@sendbird/chat/openChannel';
 import { UserMessage } from '@sendbird/chat/message';
 
 const TEXT_FIELD_ID = 'sendbird-message-input-text-field';
-const LINE_HEIGHT = 76;
-const DEFAULT_CHAT_VIEW_HEIGHT = 92;
 const noop = () => {
   return null;
 };
@@ -160,28 +158,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
   const [isInput, setIsInput] = useState(false);
   const [mentionedUserIds, setMentionedUserIds] = useState<string[]>([]);
   const [targetStringInfo, setTargetStringInfo] = useState({ ...initialTargetStringInfo });
-  const setHeight = useCallback(
-    () => {
-      const elem = internalRef?.current;
-      if (!elem) return;
-
-      try {
-        const estimatedChatViewHeight = window.document.body.offsetHeight || DEFAULT_CHAT_VIEW_HEIGHT;
-        const MAX_HEIGHT = estimatedChatViewHeight * 0.6;
-        if (elem.scrollHeight >= LINE_HEIGHT) {
-          if (MAX_HEIGHT < elem.scrollHeight) {
-            elem.style.height = 'auto';
-            elem.style.height = `${MAX_HEIGHT}px`;
-          } else {
-            elem.style.height = '';
-          }
-        }
-      } catch (error) {
-        // error
-      }
-    },
-    [],
-  );
 
   // #Edit mode
   // for easily initialize input value from outside, but
@@ -191,7 +167,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     const textField = internalRef?.current;
     setMentionedUserIds([]);
     setIsInput(textField?.textContent ? textField.textContent.trim().length > 0 : false);
-    setHeight();
   }, [initialValue]);
 
   // #Mention | Clear input value when channel changes
@@ -246,7 +221,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         setMentionedUserIds([]);
       }
       setIsInput(textField?.textContent ? textField?.textContent?.trim().length > 0 : false);
-      setHeight();
     }
   }, [isEdit, message]);
 
@@ -317,7 +291,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           textField.focus();
         }
         setTargetStringInfo({ ...initialTargetStringInfo });
-        setHeight();
+        // setHeight();
         useMentionedLabelDetection();
       }
     }
@@ -414,7 +388,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         }
 
         setIsInput(false);
-        setHeight();
       }
     } catch (error) {
       eventHandlers?.message?.onSendMessageFailed?.(message, error);
@@ -440,7 +413,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     setMentionedUsers,
     channel,
     setIsInput,
-    setHeight,
   });
 
   const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -531,7 +503,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             useMentionInputDetection();
           })}
           onInput={handleCommonBehavior(() => {
-            setHeight();
             onStartTyping();
             setIsInput(internalRef?.current?.textContent ? internalRef.current.textContent.trim().length > 0 : false);
             useMentionedLabelDetection();

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -42,13 +42,11 @@ const scrollToCaret = () => {
     if (caretNode.nodeType === NodeTypes.TextNode) {
       const parentElement = caretNode.parentElement;
 
-      if (parentElement && parentElement.scrollIntoView) {
-        // Scroll the parent element of the caret into view
-        parentElement.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-        });
-      }
+      // Scroll the parent element of the caret into view
+      parentElement?.scrollIntoView?.({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
     }
   }
 };
@@ -291,7 +289,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           textField.focus();
         }
         setTargetStringInfo({ ...initialTargetStringInfo });
-        // setHeight();
         useMentionedLabelDetection();
       }
     }


### PR DESCRIPTION
[CLNP-5328](https://sendbird.atlassian.net/browse/CLNP-5328)
[SBISSUE-17384](https://sendbird.atlassian.net/browse/SBISSUE-17384)

#### ChangeLog
Fixes
* Modified the `MessageInput` to scroll to the caret position when pasting text.
* The maximum height of the `MessageInput` has been extended to `'92px'`

#### Fix
Functions
* Created a `scrollToCaret` and replaced the `displayCaret`
* Created a `handleCommonBehavior` for the common behavior of event handling logics
* Removed an unused logic `setHeight`
Variables
* Set a default value to the `internalRef`
CSS
* Extended the maximum input height from `56px` to `92px`
Chores
* Fixed typo 'easiily' to 'easily'

[CLNP-5328]: https://sendbird.atlassian.net/browse/CLNP-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SBISSUE-17384]: https://sendbird.atlassian.net/browse/SBISSUE-17384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ