### PR TITLE
fix: Handle the case when prop children is undefined in MenuItemAction component

### DIFF
--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuItem.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuItem.tsx
@@ -64,19 +64,22 @@ export const MenuItemAction = ({
   accordionOpened,
   children,
 }: MenuItemActionProps) => {
-
-  return useAccordion
-    ? <Icon
+  if (useAccordion) {
+    return (
+      <Icon
         type={IconTypes.CHEVRON_RIGHT}
         className={[
           'sendbird-accordion__panel-icon-right',
           'sendbird-accordion__panel-icon--chevron',
-          (accordionOpened ? 'sendbird-accordion__panel-icon--open' : ''),
+          accordionOpened ? 'sendbird-accordion__panel-icon--open' : '',
         ].join(' ')}
         height="24px"
         width="24px"
       />
-    : children;
+    );
+  }
+
+  return children || null;
 };
 
 export default MenuItem;


### PR DESCRIPTION
[CLNP-5329](https://sendbird.atlassian.net/browse/CLNP-5329)
[SBISSUE-17339](https://sendbird.atlassian.net/browse/SBISSUE-17339)

### ChangeLog
- Fixed an error message on MenuItemAction when the children prop is undefined

### fix
- Handle the case when prop children is undefined in MenuItemAction comp

[CLNP-5329]: https://sendbird.atlassian.net/browse/CLNP-5329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SBISSUE-17339]: https://sendbird.atlassian.net/browse/SBISSUE-17339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ