### PR TITLE
refactor: ChannelSettingsProvider migration

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -56,7 +56,7 @@ export default {
 
   // ChannelSettings
   ChannelSettings: 'src/modules/ChannelSettings/index.tsx',
-  'ChannelSettings/context': 'src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx',
+  'ChannelSettings/context': 'src/modules/ChannelSettings/context/index.tsx',
   'ChannelSettings/hooks/useMenuList': 'src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx',
   'ChannelSettings/components/ChannelProfile': 'src/modules/ChannelSettings/components/ChannelProfile/index.tsx',
   'ChannelSettings/components/ChannelSettingsUI': 'src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx',

--- a/src/modules/ChannelSettings/components/ChannelProfile/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelProfile/index.tsx
@@ -1,9 +1,9 @@
 import './channel-profile.scss';
 import React, { useState, useContext, useMemo } from 'react';
 
-import { LocalizationContext } from '../../../../lib/LocalizationContext';
+import useChannelSettings from '../../context/useChannelSettings';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
+import { LocalizationContext } from '../../../../lib/LocalizationContext';
 
 import ChannelAvatar from '../../../../ui/ChannelAvatar';
 import TextButton from '../../../../ui/TextButton';
@@ -11,12 +11,11 @@ import Label, {
   LabelTypography,
   LabelColors,
 } from '../../../../ui/Label';
-
 import EditDetailsModal from '../EditDetailsModal';
 
 const ChannelProfile: React.FC = () => {
   const state = useSendbirdStateContext();
-  const channelSettingStore = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const { stringSet } = useContext(LocalizationContext);
   const [showModal, setShowModal] = useState(false);
 
@@ -24,8 +23,6 @@ const ChannelProfile: React.FC = () => {
   const theme = state?.config?.theme || 'light';
   const isOnline = state?.config?.isOnline;
   const disabled = !isOnline;
-
-  const channel = channelSettingStore?.channel;
 
   const channelName = useMemo(() => {
     if (channel?.name && channel.name !== 'Group Channel') {

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/MenuListByRole.tsx
@@ -8,8 +8,8 @@ import Icon from '../../../../ui/Icon';
 import { isOperator } from '../../../Channel/context/utils';
 
 import MenuItem from './MenuItem';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import useMenuItems from './hooks/useMenuItems';
+import useChannelSettings from '../../context/useChannelSettings';
 
 interface MenuListByRoleProps {
   menuItems: ReturnType<typeof useMenuItems>;
@@ -17,7 +17,7 @@ interface MenuListByRoleProps {
 export const MenuListByRole = ({
   menuItems,
 }: MenuListByRoleProps) => {
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const menuItemsByRole = isOperator(channel) ? menuItems.operator : menuItems.nonOperator;
   // State to track the open accordion key
   const [openAccordionKey, setOpenAccordionKey] = useState<string | null>(null);

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/hooks/useMenuItems.tsx
@@ -11,9 +11,9 @@ import { IconColors, IconTypes, IconProps } from '../../../../../ui/Icon';
 import Badge from '../../../../../ui/Badge';
 import { Toggle } from '../../../../../ui/Toggle';
 import { LabelColors, LabelTypography, type LabelProps } from '../../../../../ui/Label';
-import { useChannelSettingsContext } from '../../../context/ChannelSettingsProvider';
 
 import { MenuItemAction, type MenuItemActionProps } from '../MenuItem';
+import useChannelSettings from '../../../context/useChannelSettings';
 
 const kFormatter = (num: number): string | number => {
   return Math.abs(num) > 999
@@ -55,7 +55,7 @@ const commonLabelProps = {
 export const useMenuItems = (): MenuItems => {
   const [frozen, setFrozen] = useState(false);
   const { stringSet } = useContext(LocalizationContext);
-  const { channel, renderUserListItem } = useChannelSettingsContext();
+  const { state: { channel, renderUserListItem } } = useChannelSettings();
 
   // work around for
   // https://sendbird.slack.com/archives/G01290GCDCN/p1595922832000900

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -1,23 +1,24 @@
 import './channel-settings-ui.scss';
 
-import React, { ReactNode, useContext, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
+import useChannelSettings from '../../context/useChannelSettings';
+import { useLocalization } from '../../../../lib/LocalizationContext';
+import useMenuItems from './hooks/useMenuItems';
 
+import { deleteNullish, classnames } from '../../../../utils/utils';
 import { ChannelSettingsHeader, ChannelSettingsHeaderProps } from './ChannelSettingsHeader';
 
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
-import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
+import { UserListItemProps } from '../../../../ui/UserListItem';
+
 import ChannelProfile from '../ChannelProfile';
 import LeaveChannelModal from '../LeaveChannel';
-import { deleteNullish, classnames } from '../../../../utils/utils';
 import MenuItem from './MenuItem';
 import MenuListByRole from './MenuListByRole';
-import useMenuItems from './hooks/useMenuItems';
-import { UserListItemProps } from '../../../../ui/UserListItem';
 
 interface ModerationPanelProps {
   menuItems: ReturnType<typeof useMenuItems>;
@@ -37,7 +38,6 @@ export interface ChannelSettingsUIProps {
 }
 
 const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
-  const { channel, invalidChannel, onCloseClick, loading } = useChannelSettingsContext();
   const {
     renderHeader = (props: ChannelSettingsHeaderProps) => <ChannelSettingsHeader {...props} />,
     renderLeaveChannel,
@@ -46,13 +46,21 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
     renderPlaceholderError,
     renderPlaceholderLoading,
   } = deleteNullish(props);
+  const {
+    config: { isOnline },
+  } = useSendbirdStateContext();
+  const {
+    state: {
+      channel,
+      invalidChannel,
+      onCloseClick,
+      loading,
+    },
+  } = useChannelSettings();
+  const { stringSet } = useLocalization();
   const menuItems = useMenuItems();
 
-  const state = useSendbirdStateContext();
   const [showLeaveChannelModal, setShowLeaveChannelModal] = useState(false);
-
-  const isOnline = state?.config?.isOnline;
-  const { stringSet } = useContext(LocalizationContext);
 
   if (loading) {
     if (renderPlaceholderLoading) return renderPlaceholderLoading();
@@ -120,6 +128,7 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
 };
 
 export default ChannelSettingsUI;
+/** NOTE: For exportation */
 export { OperatorList } from '../ModerationPanel/OperatorList';
 export { MemberList } from '../ModerationPanel/MemberList';
 export { MutedMemberList } from '../ModerationPanel/MutedMemberList';

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -79,7 +79,7 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
   }
 
   return (
-    <>
+    <div className="sendbird-channel-settings">
       {renderHeader(headerProps)}
       <div className="sendbird-channel-settings__scroll-area">
         {renderChannelProfile?.() || <ChannelProfile />}
@@ -123,7 +123,7 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
           />
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
+++ b/src/modules/ChannelSettings/components/ChannelSettingsUI/index.tsx
@@ -79,7 +79,7 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
   }
 
   return (
-    <div className="sendbird-channel-settings">
+    <>
       {renderHeader(headerProps)}
       <div className="sendbird-channel-settings__scroll-area">
         {renderChannelProfile?.() || <ChannelProfile />}
@@ -123,7 +123,7 @@ const ChannelSettingsUI = (props: ChannelSettingsUIProps) => {
           />
         )}
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/modules/ChannelSettings/components/EditDetailsModal/index.tsx
+++ b/src/modules/ChannelSettings/components/EditDetailsModal/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useContext } from 'react';
 
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
+import useChannelSettings from '../../context/useChannelSettings';
 
 import Modal from '../../../../ui/Modal';
 import Input, { InputLabel } from '../../../../ui/Input';
@@ -26,11 +26,13 @@ const EditDetails: React.FC<EditDetailsProps> = (props: EditDetailsProps) => {
   } = props;
 
   const {
-    channel,
-    onChannelModified,
-    onBeforeUpdateChannel,
-    setChannelUpdateId,
-  } = useChannelSettingsContext();
+    state: {
+      channel,
+      onChannelModified,
+      onBeforeUpdateChannel,
+      setChannelUpdateId,
+    },
+  } = useChannelSettings();
   const title = channel?.name;
 
   const state = useSendbirdStateContext();

--- a/src/modules/ChannelSettings/components/LeaveChannel/index.tsx
+++ b/src/modules/ChannelSettings/components/LeaveChannel/index.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { noop } from '../../../../utils/utils';
 
 import Modal from '../../../../ui/Modal';
@@ -15,6 +14,7 @@ import Label, {
   LabelTypography,
   LabelColors,
 } from '../../../../ui/Label';
+import useChannelSettings from '../../context/useChannelSettings';
 
 export type LeaveChannelProps = {
   onSubmit: () => void;
@@ -27,7 +27,7 @@ const LeaveChannel: React.FC<LeaveChannelProps> = (props: LeaveChannelProps) => 
     onCancel = noop,
   } = props;
 
-  const { channel, onLeaveChannel } = useChannelSettingsContext();
+  const { state: { channel, onLeaveChannel } } = useChannelSettings();
   const { stringSet } = useLocalization();
   const state = useSendbirdStateContext();
   const logger = state?.config?.logger;

--- a/src/modules/ChannelSettings/components/ModerationPanel/AddOperatorsModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/AddOperatorsModal.tsx
@@ -14,9 +14,9 @@ import Label, {
 } from '../../../../ui/Label';
 import { ButtonTypes } from '../../../../ui/Button';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { Member, MemberListQuery, OperatorFilter } from '@sendbird/chat/groupChannel';
 import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
+import useChannelSettings from '../../context/useChannelSettings';
 
 export interface AddOperatorsModalProps {
   onCancel(): void;
@@ -34,7 +34,7 @@ export default function AddOperatorsModal({
   const [memberQuery, setMemberQuery] = useState<MemberListQuery | null>(null);
   const { stringSet } = useContext(LocalizationContext);
 
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
 
   useEffect(() => {
     const memberListQuery = channel?.createMemberListQuery({

--- a/src/modules/ChannelSettings/components/ModerationPanel/BannedUserList.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/BannedUserList.tsx
@@ -17,9 +17,9 @@ Label, {
 
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
 import BannedUsersModal from './BannedUsersModal';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
+import useChannelSettings from '../../context/useChannelSettings';
 
 interface BannedUserListProps {
   renderUserListItem?: (props: UserListItemProps) => ReactNode;
@@ -35,7 +35,7 @@ export const BannedUserList = ({
   const [showModal, setShowModal] = useState(false);
 
   const { stringSet } = useContext(LocalizationContext);
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
 
   const refreshList = useCallback(() => {
     if (!channel) {

--- a/src/modules/ChannelSettings/components/ModerationPanel/BannedUsersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/BannedUsersModal.tsx
@@ -4,15 +4,15 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { BannedUserListQuery, BannedUserListQueryParams, RestrictedUser } from '@sendbird/chat';
+
+import useChannelSettings from '../../context/useChannelSettings';
+import { useLocalization } from '../../../../lib/LocalizationContext';
+import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
+import { noop } from '../../../../utils/utils';
 
 import Modal from '../../../../ui/Modal';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
-
-import { noop } from '../../../../utils/utils';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
-import { useLocalization } from '../../../../lib/LocalizationContext';
-import { BannedUserListQuery, BannedUserListQueryParams, RestrictedUser } from '@sendbird/chat';
-import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
 
 export interface BannedUsersModalProps {
@@ -28,7 +28,7 @@ export function BannedUsersModal({
 }: BannedUsersModalProps): ReactElement {
   const [members, setMembers] = useState<RestrictedUser[]>([]);
   const [memberQuery, setMemberQuery] = useState<BannedUserListQuery | null>(null);
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const { stringSet } = useLocalization();
 
   useEffect(() => {

--- a/src/modules/ChannelSettings/components/ModerationPanel/InviteUsersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/InviteUsersModal.tsx
@@ -4,11 +4,11 @@ import { User } from '@sendbird/chat';
 import Modal from '../../../../ui/Modal';
 import { ButtonTypes } from '../../../../ui/Button';
 import UserListItem, { type UserListItemProps } from '../../../../ui/UserListItem';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import useSendbirdStateContext from '../../../../hooks/useSendbirdStateContext';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 import { UserListQuery } from '../../../../types';
+import useChannelSettings from '../../context/useChannelSettings';
 
 type UserId = string;
 export interface InviteUsersModalProps {
@@ -30,7 +30,7 @@ export function InviteUsersModal({
   const sdk = state?.stores?.sdkStore?.sdk;
   const globalUserListQuery = state?.config?.userListQuery;
 
-  const { channel, overrideInviteUser, queries } = useChannelSettingsContext();
+  const { state: { channel, overrideInviteUser, queries } } = useChannelSettings();
   const { stringSet } = useLocalization();
 
   const onScroll = useOnScrollPositionChangeDetector({

--- a/src/modules/ChannelSettings/components/ModerationPanel/MemberList.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/MemberList.tsx
@@ -10,7 +10,6 @@ import type { Member, MemberListQueryParams } from '@sendbird/chat/groupChannel'
 import { Role } from '@sendbird/chat';
 
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 
 import Button, { ButtonTypes, ButtonSizes } from '../../../../ui/Button';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
@@ -18,6 +17,7 @@ import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
 import MembersModal from './MembersModal';
 import { InviteUsersModal } from './InviteUsersModal';
+import useChannelSettings from '../../context/useChannelSettings';
 
 interface MemberListProps {
   renderUserListItem?: (props: UserListItemProps & { index: number }) => ReactNode;
@@ -31,10 +31,7 @@ export const MemberList = ({
   const [hasNext, setHasNext] = useState(false);
   const [showAllMembers, setShowAllMembers] = useState(false);
   const [showInviteUsers, setShowInviteUsers] = useState(false);
-  const {
-    channel,
-    forceUpdateUI,
-  } = useChannelSettingsContext();
+  const { state: { channel, forceUpdateUI } } = useChannelSettings();
   const { stringSet } = useContext(LocalizationContext);
 
   const refreshList = useCallback(() => {

--- a/src/modules/ChannelSettings/components/ModerationPanel/MembersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/MembersModal.tsx
@@ -12,10 +12,10 @@ import Modal from '../../../../ui/Modal';
 import UserListItem, { type UserListItemProps } from '../../../../ui/UserListItem';
 import { noop } from '../../../../utils/utils';
 
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
+import useChannelSettings from '../../context/useChannelSettings';
 
 export interface MembersModalProps {
   onCancel(): void;
@@ -31,7 +31,7 @@ export function MembersModal({
   const [members, setMembers] = useState<Member[]>([]);
   const [memberQuery, setMemberQuery] = useState<MemberListQuery | null>(null);
 
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const { stringSet } = useContext(LocalizationContext);
 
   useEffect(() => {

--- a/src/modules/ChannelSettings/components/ModerationPanel/MutedMemberList.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/MutedMemberList.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import type { Member, MemberListQueryParams } from '@sendbird/chat/groupChannel';
 
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 
 import Button, { ButtonTypes, ButtonSizes } from '../../../../ui/Button';
@@ -15,6 +14,7 @@ import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
 import MutedMembersModal from './MutedMembersModal';
+import useChannelSettings from '../../context/useChannelSettings';
 
 interface MutedMemberListProps {
   renderUserListItem?: (props: UserListItemProps) => ReactNode;
@@ -29,7 +29,7 @@ export const MutedMemberList = ({
   const [showModal, setShowModal] = useState(false);
   const { stringSet } = useLocalization();
 
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
 
   const refreshList = useCallback(() => {
     if (!channel) {

--- a/src/modules/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/MutedMembersModal.tsx
@@ -4,14 +4,15 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { Member, MemberListQuery, MemberListQueryParams } from '@sendbird/chat/groupChannel';
+
+import useChannelSettings from '../../context/useChannelSettings';
+import { useLocalization } from '../../../../lib/LocalizationContext';
+import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 import Modal from '../../../../ui/Modal';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
 import { noop } from '../../../../utils/utils';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
-import { useLocalization } from '../../../../lib/LocalizationContext';
-import { Member, MemberListQuery, MemberListQueryParams } from '@sendbird/chat/groupChannel';
-import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
 
 export interface MutedMembersModalProps {
@@ -28,7 +29,7 @@ export function MutedMembersModal({
   const [members, setMembers] = useState<Member[]>([]);
   const [memberQuery, setMemberQuery] = useState<MemberListQuery | null>(null);
 
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const { stringSet } = useLocalization();
 
   useEffect(() => {

--- a/src/modules/ChannelSettings/components/ModerationPanel/OperatorList.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/OperatorList.tsx
@@ -3,18 +3,17 @@ import React, {
   useEffect,
   useState,
   useCallback,
-  useContext,
   ReactNode,
 } from 'react';
 import type { OperatorListQueryParams, User } from '@sendbird/chat';
 
-import { LocalizationContext } from '../../../../lib/LocalizationContext';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
+import useChannelSettings from '../../context/useChannelSettings';
+import { useLocalization } from '../../../../lib/LocalizationContext';
 
-import Button, { ButtonTypes, ButtonSizes } from '../../../../ui/Button';
 import UserListItemMenu from '../../../../ui/UserListItemMenu/UserListItemMenu';
-
+import Button, { ButtonTypes, ButtonSizes } from '../../../../ui/Button';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
+
 import OperatorsModal from './OperatorsModal';
 import AddOperatorsModal from './AddOperatorsModal';
 
@@ -30,8 +29,8 @@ export const OperatorList = ({
   const [showMore, setShowMore] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
   const [hasNext, setHasNext] = useState(false);
-  const { stringSet } = useContext(LocalizationContext);
-  const { channel } = useChannelSettingsContext();
+  const { stringSet } = useLocalization();
+  const { state: { channel } } = useChannelSettings();
 
   const refreshList = useCallback(() => {
     if (!channel) {

--- a/src/modules/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/OperatorsModal.tsx
@@ -9,11 +9,11 @@ import React, {
 import Modal from '../../../../ui/Modal';
 import UserListItem, { UserListItemProps } from '../../../../ui/UserListItem';
 
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 import { LocalizationContext } from '../../../../lib/LocalizationContext';
 import { OperatorListQuery, OperatorListQueryParams, User } from '@sendbird/chat';
 import { useOnScrollPositionChangeDetector } from '../../../../hooks/useOnScrollReachedEndDetector';
 import { UserListItemMenu } from '../../../../ui/UserListItemMenu';
+import useChannelSettings from '../../context/useChannelSettings';
 
 export interface OperatorsModalProps {
   onCancel?(): void;
@@ -29,7 +29,7 @@ export function OperatorsModal({
   const [operators, setOperators] = useState<User[]>([]);
   const [operatorQuery, setOperatorQuery] = useState<OperatorListQuery | null>(null);
 
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   const { stringSet } = useContext(LocalizationContext);
 
   useEffect(() => {

--- a/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
+++ b/src/modules/ChannelSettings/components/ModerationPanel/index.tsx
@@ -22,7 +22,7 @@ import MemberList from './MemberList';
 import BannedUserList from './BannedUserList';
 import MutedMemberList from './MutedMemberList';
 
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
+import useChannelSettings from '../../context/useChannelSettings';
 
 const kFormatter = (num: number): string | number => {
   return Math.abs(num) > 999
@@ -39,7 +39,7 @@ export default function ModerationPanel(): ReactElement {
   const [frozen, setFrozen] = useState(false);
 
   const { stringSet } = useContext(LocalizationContext);
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
 
   // work around for
   // https://sendbird.slack.com/archives/G01290GCDCN/p1595922832000900

--- a/src/modules/ChannelSettings/components/UserPanel/index.tsx
+++ b/src/modules/ChannelSettings/components/UserPanel/index.tsx
@@ -1,18 +1,15 @@
 import './user-panel.scss';
 
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 
-import { LocalizationContext } from '../../../../lib/LocalizationContext';
-import
-Label, {
-  LabelTypography,
-  LabelColors,
-} from '../../../../ui/Label';
-import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
+import useChannelSettings from '../../context/useChannelSettings';
+import { useLocalization } from '../../../../lib/LocalizationContext';
+
 import Badge from '../../../../ui/Badge';
+import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
+import Icon, { IconTypes, IconColors } from '../../../../ui/Icon';
 
 import MemberList from '../ModerationPanel/MemberList';
-import { useChannelSettingsContext } from '../../context/ChannelSettingsProvider';
 
 const kFormatter = (num: number): string|number => {
   return Math.abs(num) > 999
@@ -21,9 +18,9 @@ const kFormatter = (num: number): string|number => {
 };
 
 const UserPanel: React.FC = () => {
-  const { stringSet } = useContext(LocalizationContext);
+  const { stringSet } = useLocalization();
   const [showAccordion, setShowAccordion] = useState(false);
-  const { channel } = useChannelSettingsContext();
+  const { state: { channel } } = useChannelSettings();
   return (
     <div className='sendbird-channel-settings__user-panel'>
       <div

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -2,13 +2,15 @@ import React, { createContext, useCallback, useEffect, useRef, useState } from '
 
 import type { ChannelSettingsContextProps, ChannelSettingsState } from './types';
 
+import useSetChannel from './hooks/useSetChannel';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { useStore } from '../../../hooks/useStore';
+import { useChannelHandler } from './hooks/useChannelHandler';
 
 import uuidv4 from '../../../utils/uuid';
+import { classnames } from '../../../utils/utils';
 import { createStore } from '../../../utils/storeManager';
-import useSetChannel from './hooks/useSetChannel';
-import { useChannelHandler } from './hooks/useChannelHandler';
+import { UserProfileProvider } from '../../../lib/UserProfileContext';
 
 export const ChannelSettingsContext = createContext<ReturnType<typeof createStore<ChannelSettingsState>> | null>(null);
 
@@ -110,11 +112,15 @@ const InternalChannelSettingsProvider = ({ children }) => {
 };
 
 const ChannelSettingsProvider = (props: ChannelSettingsContextProps) => {
-  const { children } = props;
+  const { children, className } = props;
   return (
     <InternalChannelSettingsProvider>
       <ChannelSettingsManager {...props} />
-      {children}
+      <UserProfileProvider {...props}>
+        <div className={classnames('sendbird-channel-settings', className)}>
+          {children}
+        </div>
+      </UserProfileProvider>
     </InternalChannelSettingsProvider>
   );
 };

--- a/src/modules/ChannelSettings/context/hooks/useChannelHandler.ts
+++ b/src/modules/ChannelSettings/context/hooks/useChannelHandler.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { GroupChannelHandler } from "@sendbird/chat/groupChannel";
+
+import uuidv4 from "../../../../utils/uuid";
+import compareIds from "../../../../utils/compareIds";
+import type { SdkStore } from "../../../../lib/types";
+import type { Logger } from "../../../../lib/SendbirdState";
+
+interface UseChannelHandlerProps {
+  sdk: SdkStore['sdk'];
+  channelUrl: string;
+  logger: Logger;
+  forceUpdateUI: () => void;
+  dependencies?: any[];
+}
+
+export const useChannelHandler = ({
+  sdk,
+  channelUrl,
+  logger,
+  forceUpdateUI,
+  dependencies = [],
+}: UseChannelHandlerProps) => {
+  const [channelHandlerId, setChannelHandlerId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sdk || !sdk.groupChannel) {
+      logger.warning("ChannelSettings: SDK or GroupChannelModule is not available");
+      return;
+    }
+
+    const channelHandler = new GroupChannelHandler({
+      onUserLeft: (channel, user) => {
+        if (compareIds(channel?.url, channelUrl)) {
+          logger.info("ChannelSettings: onUserLeft", { channel, user });
+          forceUpdateUI();
+        }
+      },
+      onUserBanned: (channel, user) => {
+        if (compareIds(channel?.url, channelUrl) && channel.isGroupChannel()) {
+          logger.info("ChannelSettings: onUserBanned", { channel, user });
+          forceUpdateUI();
+        }
+      },
+    });
+
+    const newChannelHandlerId = uuidv4();
+    sdk.groupChannel.addGroupChannelHandler(newChannelHandlerId, channelHandler);
+    setChannelHandlerId(newChannelHandlerId);
+
+    return () => {
+      if (sdk.groupChannel && channelHandlerId) {
+        logger.info("ChannelSettings: Removing message receiver handler", channelHandlerId);
+        sdk.groupChannel.removeGroupChannelHandler(channelHandlerId);
+      }
+    };
+  }, [sdk, channelUrl, logger, ...dependencies]);
+
+  return null;
+};

--- a/src/modules/ChannelSettings/context/hooks/useChannelHandler.ts
+++ b/src/modules/ChannelSettings/context/hooks/useChannelHandler.ts
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-import { GroupChannelHandler } from "@sendbird/chat/groupChannel";
+import { useEffect, useState } from 'react';
+import { GroupChannelHandler } from '@sendbird/chat/groupChannel';
 
-import uuidv4 from "../../../../utils/uuid";
-import compareIds from "../../../../utils/compareIds";
-import type { SdkStore } from "../../../../lib/types";
-import type { Logger } from "../../../../lib/SendbirdState";
+import uuidv4 from '../../../../utils/uuid';
+import compareIds from '../../../../utils/compareIds';
+import type { SdkStore } from '../../../../lib/types';
+import type { Logger } from '../../../../lib/SendbirdState';
 
 interface UseChannelHandlerProps {
   sdk: SdkStore['sdk'];
@@ -25,20 +25,20 @@ export const useChannelHandler = ({
 
   useEffect(() => {
     if (!sdk || !sdk.groupChannel) {
-      logger.warning("ChannelSettings: SDK or GroupChannelModule is not available");
+      logger.warning('ChannelSettings: SDK or GroupChannelModule is not available');
       return;
     }
 
     const channelHandler = new GroupChannelHandler({
       onUserLeft: (channel, user) => {
         if (compareIds(channel?.url, channelUrl)) {
-          logger.info("ChannelSettings: onUserLeft", { channel, user });
+          logger.info('ChannelSettings: onUserLeft', { channel, user });
           forceUpdateUI();
         }
       },
       onUserBanned: (channel, user) => {
         if (compareIds(channel?.url, channelUrl) && channel.isGroupChannel()) {
-          logger.info("ChannelSettings: onUserBanned", { channel, user });
+          logger.info('ChannelSettings: onUserBanned', { channel, user });
           forceUpdateUI();
         }
       },
@@ -50,7 +50,7 @@ export const useChannelHandler = ({
 
     return () => {
       if (sdk.groupChannel && channelHandlerId) {
-        logger.info("ChannelSettings: Removing message receiver handler", channelHandlerId);
+        logger.info('ChannelSettings: Removing message receiver handler', channelHandlerId);
         sdk.groupChannel.removeGroupChannelHandler(channelHandlerId);
       }
     };

--- a/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
+++ b/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
@@ -1,7 +1,7 @@
-  import { useEffect } from 'react';
-  import type { Logger } from '../../../../lib/SendbirdState';
-  import { SdkStore } from '../../../../lib/types';
-  import useChannelSettings from '../useChannelSettings';
+import { useEffect } from 'react';
+import type { Logger } from '../../../../lib/SendbirdState';
+import { SdkStore } from '../../../../lib/types';
+import useChannelSettings from '../useChannelSettings';
 
   interface Props {
     channelUrl: string;
@@ -11,53 +11,53 @@
     dependencies?: any[];
   }
 
-  function useSetChannel({
-    channelUrl,
-    sdk,
-    logger,
-    initialized,
-    dependencies = [],
-  }: Props) {
-    const {
-      actions: {
-        setChannel,
-        setInvalid,
-        setLoading,
-      },
-    } = useChannelSettings();
-    const logAndStopLoading = (message): void => {
-      logger.warning(message);
-      setLoading(false);
-      return null;
-    };
+function useSetChannel({
+  channelUrl,
+  sdk,
+  logger,
+  initialized,
+  dependencies = [],
+}: Props) {
+  const {
+    actions: {
+      setChannel,
+      setInvalid,
+      setLoading,
+    },
+  } = useChannelSettings();
+  const logAndStopLoading = (message): void => {
+    logger.warning(message);
+    setLoading(false);
+    return null;
+  };
 
-    useEffect(() => {
-      if (!channelUrl) {
-        return logAndStopLoading('ChannelSettings: channel url is required');
-      }
-      if (!initialized || !sdk) {
-        return logAndStopLoading('ChannelSettings: SDK is not initialized');
-      }
-      if (!sdk.groupChannel) {
-        return logAndStopLoading('ChannelSettings: GroupChannelModule is not specified in the SDK');
-      }
+  useEffect(() => {
+    if (!channelUrl) {
+      return logAndStopLoading('ChannelSettings: channel url is required');
+    }
+    if (!initialized || !sdk) {
+      return logAndStopLoading('ChannelSettings: SDK is not initialized');
+    }
+    if (!sdk.groupChannel) {
+      return logAndStopLoading('ChannelSettings: GroupChannelModule is not specified in the SDK');
+    }
 
-      if (channelUrl && sdk?.groupChannel) {
-        setLoading(true);
-        sdk.groupChannel.getChannel(channelUrl)
-          .then((groupChannel) => {
-            logger.info('ChannelSettings | useSetChannel: fetched group channel', groupChannel);
-            setChannel(groupChannel);
-          })
-          .catch((err) => {
-            logger.error('ChannelSettings | useSetChannel: failed fetching channel', err);
-            setInvalid(true);
-          })
-          .finally(() => {
-            setLoading(false);
-          });
-      }
-    }, [channelUrl, initialized, ...dependencies]);
-  }
+    if (channelUrl && sdk?.groupChannel) {
+      setLoading(true);
+      sdk.groupChannel.getChannel(channelUrl)
+        .then((groupChannel) => {
+          logger.info('ChannelSettings | useSetChannel: fetched group channel', groupChannel);
+          setChannel(groupChannel);
+        })
+        .catch((err) => {
+          logger.error('ChannelSettings | useSetChannel: failed fetching channel', err);
+          setInvalid(true);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+  }, [channelUrl, initialized, ...dependencies]);
+}
 
-  export default useSetChannel;
+export default useSetChannel;

--- a/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
+++ b/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
@@ -3,13 +3,13 @@ import type { Logger } from '../../../../lib/SendbirdState';
 import { SdkStore } from '../../../../lib/types';
 import useChannelSettings from '../useChannelSettings';
 
-  interface Props {
-    channelUrl: string;
-    sdk: SdkStore['sdk'];
-    logger: Logger;
-    initialized: boolean;
-    dependencies?: any[];
-  }
+interface Props {
+  channelUrl: string;
+  sdk: SdkStore['sdk'];
+  logger: Logger;
+  initialized: boolean;
+  dependencies?: any[];
+}
 
 function useSetChannel({
   channelUrl,

--- a/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
+++ b/src/modules/ChannelSettings/context/hooks/useSetChannel.ts
@@ -1,0 +1,63 @@
+  import { useEffect } from 'react';
+  import type { Logger } from '../../../../lib/SendbirdState';
+  import { SdkStore } from '../../../../lib/types';
+  import useChannelSettings from '../useChannelSettings';
+
+  interface Props {
+    channelUrl: string;
+    sdk: SdkStore['sdk'];
+    logger: Logger;
+    initialized: boolean;
+    dependencies?: any[];
+  }
+
+  function useSetChannel({
+    channelUrl,
+    sdk,
+    logger,
+    initialized,
+    dependencies = [],
+  }: Props) {
+    const {
+      actions: {
+        setChannel,
+        setInvalid,
+        setLoading,
+      },
+    } = useChannelSettings();
+    const logAndStopLoading = (message): void => {
+      logger.warning(message);
+      setLoading(false);
+      return null;
+    };
+
+    useEffect(() => {
+      if (!channelUrl) {
+        return logAndStopLoading('ChannelSettings: channel url is required');
+      }
+      if (!initialized || !sdk) {
+        return logAndStopLoading('ChannelSettings: SDK is not initialized');
+      }
+      if (!sdk.groupChannel) {
+        return logAndStopLoading('ChannelSettings: GroupChannelModule is not specified in the SDK');
+      }
+
+      if (channelUrl && sdk?.groupChannel) {
+        setLoading(true);
+        sdk.groupChannel.getChannel(channelUrl)
+          .then((groupChannel) => {
+            logger.info('ChannelSettings | useSetChannel: fetched group channel', groupChannel);
+            setChannel(groupChannel);
+          })
+          .catch((err) => {
+            logger.error('ChannelSettings | useSetChannel: failed fetching channel', err);
+            setInvalid(true);
+          })
+          .finally(() => {
+            setLoading(false);
+          });
+      }
+    }, [channelUrl, initialized, ...dependencies]);
+  }
+
+  export default useSetChannel;

--- a/src/modules/ChannelSettings/context/index.tsx
+++ b/src/modules/ChannelSettings/context/index.tsx
@@ -1,0 +1,2 @@
+export { ChannelSettingsProvider, useChannelSettingsContext } from './ChannelSettingsProvider';
+export type { ChannelSettingsContextProps } from './types';

--- a/src/modules/ChannelSettings/context/types.ts
+++ b/src/modules/ChannelSettings/context/types.ts
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import type { GroupChannel, GroupChannelUpdateParams } from '@sendbird/chat/groupChannel';
+import type { UserListItemProps } from '../../../ui/UserListItem';
+import type { UserProfileProviderProps } from '../../../lib/UserProfileContext';
+
+interface ApplicationUserListQuery {
+  limit?: number;
+  userIdsFilter?: Array<string>;
+  metaDataKeyFilter?: string;
+  metaDataValuesFilter?: Array<string>;
+}
+
+interface ChannelSettingsQueries {
+  applicationUserListQuery?: ApplicationUserListQuery;
+}
+
+type OverrideInviteUserType = {
+  users: Array<string>;
+  onClose: () => void;
+  channel: GroupChannel;
+};
+
+interface CommonChannelSettingsProps {
+  channelUrl: string;
+  onCloseClick?(): void;
+  onLeaveChannel?(): void;
+  overrideInviteUser?(params: OverrideInviteUserType): void;
+  onChannelModified?(channel: GroupChannel): void;
+  onBeforeUpdateChannel?(currentTitle: string, currentImg: File | null, data: string | undefined): GroupChannelUpdateParams;
+  queries?: ChannelSettingsQueries;
+  renderUserListItem?: (props: UserListItemProps) => ReactNode;
+}
+
+export interface ChannelSettingsState extends CommonChannelSettingsProps {
+  channel: GroupChannel | null;
+  loading: boolean;
+  invalidChannel: boolean;
+  forceUpdateUI(): void;
+  setChannelUpdateId(uniqId: string): void;
+}
+
+export interface ChannelSettingsContextProps extends
+  CommonChannelSettingsProps,
+  Pick<UserProfileProviderProps, 'renderUserProfile' | 'disableUserProfile'> {
+  children?: React.ReactElement;
+  className?: string;
+}

--- a/src/modules/ChannelSettings/context/useChannelSettings.ts
+++ b/src/modules/ChannelSettings/context/useChannelSettings.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import type { GroupChannel } from "@sendbird/chat/groupChannel";
+
+import { useChannelSettingsContext } from "./ChannelSettingsProvider";
+import { ChannelSettingsState } from "./types";
+
+export const useChannelSettings = () => {
+  const store = useChannelSettingsContext();
+  if (!store) throw new Error('useChannelSettings must be used within a ChannelSettingsProvider');
+
+  const state: ChannelSettingsState = useSyncExternalStore(store.subscribe, store.getState);
+  const actions = useMemo(() => ({
+    setChannel: (channel: GroupChannel) => store.setState(state => ({
+      ...state,
+      channel,
+    })),
+
+    setLoading: (loading: boolean) => store.setState((state): ChannelSettingsState => ({
+      ...state, 
+      loading,
+    })),
+
+    setInvalid: (invalid: boolean) => store.setState((state): ChannelSettingsState => ({
+      ...state,
+      invalidChannel: invalid,
+    })),
+  }), [store]);
+
+  return { state, actions };
+};
+
+export default useChannelSettings;

--- a/src/modules/ChannelSettings/context/useChannelSettings.ts
+++ b/src/modules/ChannelSettings/context/useChannelSettings.ts
@@ -1,9 +1,9 @@
-import { useMemo } from "react";
+import { useMemo } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
-import type { GroupChannel } from "@sendbird/chat/groupChannel";
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
 
-import { useChannelSettingsContext } from "./ChannelSettingsProvider";
-import { ChannelSettingsState } from "./types";
+import { useChannelSettingsContext } from './ChannelSettingsProvider';
+import { ChannelSettingsState } from './types';
 
 export const useChannelSettings = () => {
   const store = useChannelSettingsContext();
@@ -17,7 +17,7 @@ export const useChannelSettings = () => {
     })),
 
     setLoading: (loading: boolean) => store.setState((state): ChannelSettingsState => ({
-      ...state, 
+      ...state,
       loading,
     })),
 

--- a/src/modules/ChannelSettings/index.tsx
+++ b/src/modules/ChannelSettings/index.tsx
@@ -3,10 +3,7 @@ import ChannelSettingsUI, {
   ChannelSettingsUIProps,
 } from './components/ChannelSettingsUI';
 
-import {
-  ChannelSettingsProvider,
-  ChannelSettingsContextProps,
-} from './context/ChannelSettingsProvider';
+import { ChannelSettingsProvider, ChannelSettingsContextProps } from './context/index';
 
 interface ChannelSettingsProps extends ChannelSettingsContextProps, Omit<ChannelSettingsUIProps, 'renderUserListItem'> { }
 

--- a/src/utils/storeManager.ts
+++ b/src/utils/storeManager.ts
@@ -9,12 +9,12 @@ export type Store<T> = {
  * A custom store creation utility
  */
 export function createStore<T extends object>(initialState: T): Store<T> {
-  const state = { ...initialState };
+  let state = { ...initialState };
   const listeners = new Set<() => void>();
 
   const setState = (partial: Partial<T> | ((state: T) => Partial<T>)) => {
     const nextState = typeof partial === 'function' ? partial(state) : partial;
-    Object.assign(state, nextState);
+    state = { ...state, ...nextState };
     listeners.forEach((listener) => listener());
   };
 


### PR DESCRIPTION
[CLNP-5044](https://sendbird.atlassian.net/browse/CLNP-5044)

### Fix
ChannelSettingsProvider migration
- Created a hook `useChannelSettings` for replacing `useChannelSettingsContext`
- Created hooks `useSetChannel` and `useChannelHandler` to separate the logics from the ChannelSettingsProvider

[CLNP-5044]: https://sendbird.atlassian.net/browse/CLNP-5044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ