### PR TITLE
release: v3.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog - v3
 
+## [v3.15.6] (Oct 11th, 2024)
+
+### Features:
+- Exported `useLocalization` Hook:
+  - Provided access to stringSet and dateLocale.
+  - Note: Required SendbirdProvider to wrap your component for proper usage.
+  - Import Path: `"@sendbird/uikit-react/hooks/useLocalization"`
+- Exported `ThreadReplySelectType`:
+  - Import Paths:
+    - `"@sendbird/uikit-react/Channel/context"`
+    - `"@sendbird/uikit-react/GroupChannel/context"`
+
+### Fixes
+- Modified the `MessageInput` to scroll to the caret position when pasting text.
+- The maximum height of the `MessageInput` has been extended to `'92px'`
+- Fixed an `error message` on `MenuItemAction` when the children prop is `undefined`
+
 ## [v3.15.5] (Oct 4th, 2024)
 
 ### Updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.15.5",
+  "version": "3.15.6",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
[SDKRLSD-1433](https://sendbird.atlassian.net/browse/SDKRLSD-1433)

## [v3.15.6] (Oct 11th, 2024)

### Features:
- Exported `useLocalization` Hook:
  - Provided access to stringSet and dateLocale.
  - Note: Required SendbirdProvider to wrap your component for proper usage.
  - Import Path: `"@sendbird/uikit-react/hooks/useLocalization"`
- Exported `ThreadReplySelectType`:
  - Import Paths:
    - `"@sendbird/uikit-react/Channel/context"`
    - `"@sendbird/uikit-react/GroupChannel/context"`

### Fixes
- Modified the `MessageInput` to scroll to the caret position when pasting text.
- The maximum height of the `MessageInput` has been extended to `'92px'`
- Fixed an `error message` on `MenuItemAction` when the children prop is `undefined`

[SDKRLSD-1433]: https://sendbird.atlassian.net/browse/SDKRLSD-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ