### PR TITLE
[CLNP-5476] Enhance getMimeTypesUIKitAccepts to support file extensions along with mime types

### DIFF
--- a/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
+++ b/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
@@ -100,7 +100,6 @@ describe('Global-utils/getMimeTypesUIKitAccepts', () => {
   it('should handle case-insensitive category names', () => {
     const result = getMimeTypesUIKitAccepts(['IMAGE', 'Video', 'AuDiO']);
 
-    // 각 카테고리의 MIME 타입과 확장자가 포함되어 있는지 확인
     SUPPORTED_MIMES.IMAGE.forEach(mime => expect(result).toContain(mime));
     SUPPORTED_FILE_EXTENSIONS.IMAGE.forEach(ext => expect(result).toContain(ext));
 
@@ -110,11 +109,11 @@ describe('Global-utils/getMimeTypesUIKitAccepts', () => {
     SUPPORTED_MIMES.AUDIO.forEach(mime => expect(result).toContain(mime));
     SUPPORTED_FILE_EXTENSIONS.AUDIO.forEach(ext => expect(result).toContain(ext));
 
-    // 결과에 중복이 없는지 확인
+    // assert if there are any duplicates
     const uniqueResult = new Set(result.split(','));
     expect(uniqueResult.size).toBe(result.split(',').length);
 
-    // 대소문자 구분 없이 처리되었는지 확인
+    // assert if there are no other types
     expect(result).not.toContain('IMAGE');
     expect(result).not.toContain('Video');
     expect(result).not.toContain('AuDiO');

--- a/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
+++ b/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
@@ -1,30 +1,111 @@
-import { getMimeTypesUIKitAccepts, SUPPORTED_MIMES } from '../index';
+import { getMimeTypesUIKitAccepts, SUPPORTED_MIMES, SUPPORTED_FILE_EXTENSIONS } from '../index';
 
 describe('Global-utils/getMimeTypesUIKitAccepts', () => {
-  it('when no input, should return all SUPPORTED_MIMES.', () => {
-    const allMimeTypes: string[] = Object.values(SUPPORTED_MIMES)
-      .reduce((accumulator: string[], mimes: string[]): string[] => {
-        return accumulator.concat(mimes);
-      });
-    expect(getMimeTypesUIKitAccepts()).toBe(allMimeTypes.join());
+  const allTypesAndExtensions = [
+    ...Object.values(SUPPORTED_MIMES).flat(),
+    ...Object.values(SUPPORTED_FILE_EXTENSIONS).flat(),
+  ].join();
+
+  it('should return all supported MIME types and file extensions when no input is provided', () => {
+    expect(getMimeTypesUIKitAccepts()).toBe(allTypesAndExtensions);
   });
-  it('when given [image], should return IMAGE mime types.', () => {
-    expect(getMimeTypesUIKitAccepts(['image'])).toBe(SUPPORTED_MIMES.IMAGE.join());
+
+  it('should return all supported MIME types and file extensions when an empty array is provided', () => {
+    expect(getMimeTypesUIKitAccepts([])).toBe(allTypesAndExtensions);
   });
-  it('when given [image, video], should return IMAGE and VIDEO mime types.', () => {
-    expect(getMimeTypesUIKitAccepts(['image', 'video']))
-      .toBe([SUPPORTED_MIMES.IMAGE.join(), SUPPORTED_MIMES.VIDEO.join()].join());
+
+  it('should return IMAGE mime types and extensions when [image] is provided', () => {
+    const expected = [...SUPPORTED_MIMES.IMAGE, ...SUPPORTED_FILE_EXTENSIONS.IMAGE].join();
+    expect(getMimeTypesUIKitAccepts(['image'])).toBe(expected);
   });
-  it('when given empty array, should return all SUPPORTED_MIMES.', () => {
-    const allMimeTypes: string[] = Object.values(SUPPORTED_MIMES)
-      .reduce((accumulator: string[], mimes: string[]): string[] => {
-        return accumulator.concat(mimes);
-      });
-    expect(getMimeTypesUIKitAccepts([])).toBe(allMimeTypes.join());
+
+  it('should return VIDEO mime types and extensions when [video] is provided', () => {
+    const expected = [...SUPPORTED_MIMES.VIDEO, ...SUPPORTED_FILE_EXTENSIONS.VIDEO].join();
+    expect(getMimeTypesUIKitAccepts(['video'])).toBe(expected);
   });
-  it('when given mime types, should return mime types string.', () => {
-    const accept = getMimeTypesUIKitAccepts(['image/png', 'image/heic']);
-    const expected = 'image/png,image/heic';
-    expect(accept).toBe(expected);
+
+  it('should return AUDIO mime types and extensions when [audio] is provided', () => {
+    const expected = [...SUPPORTED_MIMES.AUDIO, ...SUPPORTED_FILE_EXTENSIONS.AUDIO].join();
+    expect(getMimeTypesUIKitAccepts(['audio'])).toBe(expected);
+  });
+
+  it('should return combined IMAGE and VIDEO mime types and extensions when [image, video] is provided', () => {
+    const expected = [
+      ...SUPPORTED_MIMES.IMAGE,
+      ...SUPPORTED_FILE_EXTENSIONS.IMAGE,
+      ...SUPPORTED_MIMES.VIDEO,
+      ...SUPPORTED_FILE_EXTENSIONS.VIDEO,
+    ].join();
+    expect(getMimeTypesUIKitAccepts(['image', 'video'])).toBe(expected);
+  });
+
+  it('should return exact mime types or extensions when specific ones are provided', () => {
+    const input = ['image/png', '.pdf', 'audio/mp3'];
+    expect(getMimeTypesUIKitAccepts(input)).toBe(input.join(','));
+  });
+
+  it('should handle a mix of category names, specific mime types, and file extensions', () => {
+    const input = ['image', 'application/pdf', '.txt'];
+    const expected = [
+      ...SUPPORTED_MIMES.IMAGE,
+      ...SUPPORTED_FILE_EXTENSIONS.IMAGE,
+      'application/pdf',
+      '.txt',
+    ].join();
+    expect(getMimeTypesUIKitAccepts(input)).toBe(expected);
+  });
+
+  it('should ignore unsupported category names', () => {
+    const input = ['image', 'video', 'unsupported'];
+    const expected = [
+      ...SUPPORTED_MIMES.IMAGE,
+      ...SUPPORTED_FILE_EXTENSIONS.IMAGE,
+      ...SUPPORTED_MIMES.VIDEO,
+      ...SUPPORTED_FILE_EXTENSIONS.VIDEO,
+      'unsupported',
+    ].join();
+    expect(getMimeTypesUIKitAccepts(input)).toBe(expected);
+  });
+
+  it('should handle duplicate inputs', () => {
+    const input = ['image', 'image', 'video', 'image/png', '.jpg', '.jpg'];
+    const expected = [
+      ...SUPPORTED_MIMES.IMAGE,
+      ...SUPPORTED_FILE_EXTENSIONS.IMAGE,
+      ...SUPPORTED_MIMES.VIDEO,
+      ...SUPPORTED_FILE_EXTENSIONS.VIDEO,
+    ].join();
+    expect(getMimeTypesUIKitAccepts(input)).toBe(expected);
+  });
+
+  it('should return all supported types and extensions for null input', () => {
+    expect(getMimeTypesUIKitAccepts(null as any)).toBe(allTypesAndExtensions);
+  });
+
+  it('should return all supported types and extensions for undefined input', () => {
+    expect(getMimeTypesUIKitAccepts(undefined as any)).toBe(allTypesAndExtensions);
+  });
+
+  it('should handle case-insensitive category names', () => {
+    const result = getMimeTypesUIKitAccepts(['IMAGE', 'Video', 'AuDiO']);
+
+    // 각 카테고리의 MIME 타입과 확장자가 포함되어 있는지 확인
+    SUPPORTED_MIMES.IMAGE.forEach(mime => expect(result).toContain(mime));
+    SUPPORTED_FILE_EXTENSIONS.IMAGE.forEach(ext => expect(result).toContain(ext));
+
+    SUPPORTED_MIMES.VIDEO.forEach(mime => expect(result).toContain(mime));
+    SUPPORTED_FILE_EXTENSIONS.VIDEO.forEach(ext => expect(result).toContain(ext));
+
+    SUPPORTED_MIMES.AUDIO.forEach(mime => expect(result).toContain(mime));
+    SUPPORTED_FILE_EXTENSIONS.AUDIO.forEach(ext => expect(result).toContain(ext));
+
+    // 결과에 중복이 없는지 확인
+    const uniqueResult = new Set(result.split(','));
+    expect(uniqueResult.size).toBe(result.split(',').length);
+
+    // 대소문자 구분 없이 처리되었는지 확인
+    expect(result).not.toContain('IMAGE');
+    expect(result).not.toContain('Video');
+    expect(result).not.toContain('AuDiO');
   });
 });

--- a/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
+++ b/src/utils/__tests__/getMimeTypesUIKitAccepts.spec.ts
@@ -29,6 +29,17 @@ describe('Global-utils/getMimeTypesUIKitAccepts', () => {
     expect(getMimeTypesUIKitAccepts(['audio'])).toBe(expected);
   });
 
+  it('should return ARCHIVE mime types and extensions when [archive] is provided', () => {
+    const expected = [...SUPPORTED_MIMES.ARCHIVE, ...SUPPORTED_FILE_EXTENSIONS.ARCHIVE].join();
+    expect(getMimeTypesUIKitAccepts(['archive'])).toBe(expected);
+  });
+
+  it('should not include archive types when not specified', () => {
+    const result = getMimeTypesUIKitAccepts(['image', 'video']);
+    expect(result).not.toContain('application/zip');
+    expect(result).not.toContain('.7z');
+  });
+
   it('should return combined IMAGE and VIDEO mime types and extensions when [image, video] is provided', () => {
     const expected = [
       ...SUPPORTED_MIMES.IMAGE,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,6 +59,7 @@ export const SUPPORTED_MIMES = {
     'text/calendar',
     'text/javascript',
     'text/xml',
+    'text/x-log',
     'video/quicktime', // NOTE: Assume this video is a normal file, not video
   ],
   APPLICATION: [
@@ -102,21 +103,29 @@ export const SUPPORTED_MIMES = {
   ],
 };
 
-export const getMimeTypesUIKitAccepts = (acceptableMimeTypes?: string[]): string => {
-  if (Array.isArray(acceptableMimeTypes) && acceptableMimeTypes.length > 0) {
-    return acceptableMimeTypes
+export const SUPPORTED_FILE_EXTENSIONS = {
+  IMAGE: ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp'],
+  VIDEO: ['.mp4', '.mpeg', '.ogg', '.webm', '.quicktime'],
+  AUDIO: ['.aac', '.midi', '.mp3', '.mpeg', '.ogg', '.opus', '.wav', '.webm', '.3gpp', '.3gpp2'],
+  DOCUMENT: ['.txt', '.log', '.csv', '.rtf', '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'],
+};
+
+export const getMimeTypesUIKitAccepts = (acceptableTypes?: string[]): string => {
+  if (Array.isArray(acceptableTypes) && acceptableTypes.length > 0) {
+    const uniqueTypes = acceptableTypes
       .reduce((prev, curr) => {
-        switch (curr) {
+        const lowerCurr = curr.toLowerCase();
+        switch (lowerCurr) {
           case 'image': {
-            prev.push(...SUPPORTED_MIMES.IMAGE);
+            prev.push(...SUPPORTED_MIMES.IMAGE, ...SUPPORTED_FILE_EXTENSIONS.IMAGE);
             break;
           }
           case 'video': {
-            prev.push(...SUPPORTED_MIMES.VIDEO);
+            prev.push(...SUPPORTED_MIMES.VIDEO, ...SUPPORTED_FILE_EXTENSIONS.VIDEO);
             break;
           }
           case 'audio': {
-            prev.push(...SUPPORTED_MIMES.AUDIO);
+            prev.push(...SUPPORTED_MIMES.AUDIO, ...SUPPORTED_FILE_EXTENSIONS.AUDIO);
             break;
           }
           default: {
@@ -124,13 +133,17 @@ export const getMimeTypesUIKitAccepts = (acceptableMimeTypes?: string[]): string
             break;
           }
         }
-
         return prev;
-      }, [] as string[])
-      .join();
+      }, [] as string[]);
+
+    // To remove duplicates
+    return Array.from(new Set(uniqueTypes)).join(',');
   }
 
-  return Object.values(SUPPORTED_MIMES).reduce((prev, curr) => (prev.concat(curr)), []).join();
+  return [
+    ...Object.values(SUPPORTED_MIMES).flat(),
+    ...Object.values(SUPPORTED_FILE_EXTENSIONS).flat(),
+  ].join(',');
 };
 
 /* eslint-disable no-redeclare */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -101,13 +101,25 @@ export const SUPPORTED_MIMES = {
     'application/zip',
     'application/x-7z-compressed',
   ],
+  ARCHIVE: [
+    'application/zip',
+    'application/x-rar-compressed',
+    'application/x-7z-compressed',
+    'application/x-tar',
+    'application/gzip',
+    'application/x-bzip',
+    'application/x-bzip2',
+    'application/x-xz',
+    'application/x-iso9660-image',
+  ],
 };
 
 export const SUPPORTED_FILE_EXTENSIONS = {
-  IMAGE: ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp'],
-  VIDEO: ['.mp4', '.mpeg', '.ogg', '.webm', '.quicktime'],
-  AUDIO: ['.aac', '.midi', '.mp3', '.mpeg', '.ogg', '.opus', '.wav', '.webm', '.3gpp', '.3gpp2'],
+  IMAGE: ['.apng', '.avif', '.gif', '.jpg', '.jpeg', '.jfif', '.pjpeg', '.pjp', '.png', '.svg', '.webp', '.bmp', '.ico', '.cur', '.tif', '.tiff'],
+  VIDEO: ['.mp4', '.webm', '.ogv', '.3gp', '.3g2', '.avi', '.mov', '.wmv', '.mpg', '.mpeg', '.m4v', '.mkv'],
+  AUDIO: ['.aac', '.midi', '.mp3', '.oga', '.opus', '.wav', '.weba', '.3gp', '.3g2'],
   DOCUMENT: ['.txt', '.log', '.csv', '.rtf', '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'],
+  ARCHIVE: ['.zip', '.rar', '.7z', '.tar', '.gz', '.bz2', '.xz', '.iso'],
 };
 
 export const getMimeTypesUIKitAccepts = (acceptableTypes?: string[]): string => {
@@ -126,6 +138,10 @@ export const getMimeTypesUIKitAccepts = (acceptableTypes?: string[]): string => 
           }
           case 'audio': {
             prev.push(...SUPPORTED_MIMES.AUDIO, ...SUPPORTED_FILE_EXTENSIONS.AUDIO);
+            break;
+          }
+          case 'archive': {
+            prev.push(...SUPPORTED_MIMES.ARCHIVE, ...SUPPORTED_FILE_EXTENSIONS.ARCHIVE);
             break;
           }
           default: {


### PR DESCRIPTION
Resolves https://sendbird.atlassian.net/browse/SBISSUE-17456 

## Changes
- [x] Updated `getMimeTypesUIKitAccepts` to handle both MIME types and file extensions.
- [x] Improved case-insensitive handling of category names (image, video, audio).
- [x] Implemented duplicate removal in the returned string.
- [x] Updated related test cases to cover new functionality.


This change enhances the flexibility of file type handling in our application, allowing for both MIME types and file extensions to be processed. It also improves the robustness of the function by handling case-insensitivity and removing duplicates.


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

