### PR TITLE
[CLNP-5230] Support .bmp and .heic

### DIFF
--- a/src/utils/__tests__/isThumbnailMessage.spec.ts
+++ b/src/utils/__tests__/isThumbnailMessage.spec.ts
@@ -1,0 +1,38 @@
+import { FileMessage } from '@sendbird/chat/message';
+import { isThumbnailMessage } from '../index';
+
+const mockBmpFileMessage = {
+  message: null,
+  messageType: 'file',
+  createdAt: 1,
+  type: 'image/bmp',
+  name: 'test_image.bmp',
+  file: new File([], 'test_image.bmp'),
+  metaArrays: [
+    { key: 'KEY_INTERNAL_MESSAGE_TYPE', value: ['image/bmp'] },
+  ],
+} as unknown as FileMessage;
+
+const mockHeicFileMessage = {
+  message: null,
+  messageType: 'file',
+  createdAt: 1,
+  type: 'image/heic',
+  name: 'test_image.heic',
+  file: new File([], 'test_image.heic'),
+  metaArrays: [
+    { key: 'KEY_INTERNAL_MESSAGE_TYPE', value: ['image/heic'] },
+  ],
+} as unknown as FileMessage;
+
+describe('Global-utils/isThumbnailMessage', () => {
+
+  it('should return ture for .bmp extension', () => {
+    expect(isThumbnailMessage(mockBmpFileMessage)).toBe(true);
+  });
+
+  it('should return false for .heic extension', () => {
+    expect(isThumbnailMessage(mockHeicFileMessage)).toBe(false);
+  });
+
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,6 +30,7 @@ export const SUPPORTED_MIMES = {
     'image/gif',
     'image/svg+xml',
     'image/webp', // not supported in IE
+    'image/bmp',
   ],
   VIDEO: [
     'video/mpeg',
@@ -115,7 +116,7 @@ export const SUPPORTED_MIMES = {
 };
 
 export const SUPPORTED_FILE_EXTENSIONS = {
-  IMAGE: ['.apng', '.avif', '.gif', '.jpg', '.jpeg', '.jfif', '.pjpeg', '.pjp', '.png', '.svg', '.webp', '.bmp', '.ico', '.cur', '.tif', '.tiff'],
+  IMAGE: ['.apng', '.avif', '.gif', '.jpg', '.jpeg', '.jfif', '.pjpeg', '.pjp', '.png', '.svg', '.webp', '.bmp', '.ico', '.cur', '.tif', '.tiff', '.heic', '.heif'],
   VIDEO: ['.mp4', '.webm', '.ogv', '.3gp', '.3g2', '.avi', '.mov', '.wmv', '.mpg', '.mpeg', '.m4v', '.mkv'],
   AUDIO: ['.aac', '.midi', '.mp3', '.oga', '.opus', '.wav', '.weba', '.3gp', '.3g2'],
   DOCUMENT: ['.txt', '.log', '.csv', '.rtf', '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'],


### PR DESCRIPTION
### Changelog
* Support `.bmp` and `.heic` to be rendered properly in `MessageBody`.
    * `.bmp` file will rendered as `ThumbnailMessage`. `.heic` file will be rendered as regular `FileMessage`, for consistency between browsers.