### PR TITLE
fix: Applied scroll after rendering DOM using setTimeout

### DIFF
--- a/src/modules/OpenChannel/context/utils.ts
+++ b/src/modules/OpenChannel/context/utils.ts
@@ -21,22 +21,30 @@ export const shouldFetchMore = (messageLength: number, maxMessages?: number): bo
 };
 
 /* eslint-disable default-param-last */
-export const scrollIntoLast = (initialTry = 0, scrollRef: React.RefObject<HTMLElement>): void => {
+export const scrollIntoLast = (
+  initialTry = 0,
+  scrollRef: React.RefObject<HTMLElement>
+): void => {
   const MAX_TRIES = 10;
-  const currentTry = initialTry;
-  if (currentTry > MAX_TRIES) {
+
+  if (initialTry > MAX_TRIES) {
     return;
   }
-  try {
-    const scrollDOM = scrollRef?.current || document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
-    // eslint-disable-next-line no-multi-assign
-    if (scrollDOM) {
+
+  const scrollDOM = scrollRef?.current ||
+    document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
+
+  if (scrollDOM) {
+    const applyScroll = () => {
+      scrollDOM.style.overflow = 'auto';
       scrollDOM.scrollTop = scrollDOM.scrollHeight;
-    }
-  } catch (error) {
+    };
+
+    window.requestAnimationFrame(applyScroll);
+  } else {
     setTimeout(() => {
-      scrollIntoLast(currentTry + 1, scrollRef);
-    }, 500 * currentTry);
+      scrollIntoLast(initialTry + 1, scrollRef);
+    }, 500 * initialTry);
   }
 };
 

--- a/src/modules/OpenChannel/context/utils.ts
+++ b/src/modules/OpenChannel/context/utils.ts
@@ -39,8 +39,7 @@ export const scrollIntoLast = (
       scrollDOM.style.overflow = 'auto';
       scrollDOM.scrollTop = scrollDOM.scrollHeight;
     };
-
-    window.requestAnimationFrame(applyScroll);
+    setTimeout(applyScroll);
   } else {
     setTimeout(() => {
       scrollIntoLast(initialTry + 1, scrollRef);

--- a/src/modules/OpenChannel/context/utils.ts
+++ b/src/modules/OpenChannel/context/utils.ts
@@ -23,7 +23,7 @@ export const shouldFetchMore = (messageLength: number, maxMessages?: number): bo
 /* eslint-disable default-param-last */
 export const scrollIntoLast = (
   initialTry = 0,
-  scrollRef: React.RefObject<HTMLElement>
+  scrollRef: React.RefObject<HTMLElement>,
 ): void => {
   const MAX_TRIES = 10;
 
@@ -31,8 +31,8 @@ export const scrollIntoLast = (
     return;
   }
 
-  const scrollDOM = scrollRef?.current ||
-    document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
+  const scrollDOM = scrollRef?.current
+    || document.querySelector('.sendbird-openchannel-conversation-scroll__container__item-container');
 
   if (scrollDOM) {
     const applyScroll = () => {


### PR DESCRIPTION
[CLNP-5487](https://sendbird.atlassian.net/browse/CLNP-5487)
[SBISSUE-17529](https://sendbird.atlassian.net/browse/SBISSUE-17529)

#### Issue
- OpenChannel scroll doesn't move when fetching the initial messages on mobile(iPhone)

#### Fix
- Applied scroll after rendering DOM using `setTimeout`

[CLNP-5487]: https://sendbird.atlassian.net/browse/CLNP-5487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SBISSUE-17529]: https://sendbird.atlassian.net/browse/SBISSUE-17529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ