### PR TITLE
fix: Ensure correct caret placement and rect calculation after paste

### DIFF
--- a/src/ui/MessageInput/index.scss
+++ b/src/ui/MessageInput/index.scss
@@ -15,7 +15,7 @@
     font-style: normal;
     line-height: 1.43;
     max-height: 92px;
-    overflow-y: scroll;
+    overflow-y: auto;
     letter-spacing: normal;
     padding: 18px 64px 18px 16px;
     box-sizing: border-box;

--- a/src/ui/MessageInput/index.scss
+++ b/src/ui/MessageInput/index.scss
@@ -15,7 +15,7 @@
     font-style: normal;
     line-height: 1.43;
     max-height: 92px;
-    overflow-y: auto;
+    overflow-y: scroll;
     letter-spacing: normal;
     padding: 18px 64px 18px 16px;
     box-sizing: border-box;

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -32,25 +32,6 @@ const noop = () => {
   return null;
 };
 
-const scrollToCaret = () => {
-  const selection = window.getSelection();
-  if (selection && selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-    const caretNode = range.endContainer;
-
-    // Ensure the caret is in a text node
-    if (caretNode.nodeType === NodeTypes.TextNode) {
-      const parentElement = caretNode.parentElement;
-
-      // Scroll the parent element of the caret into view
-      parentElement?.scrollIntoView?.({
-        behavior: 'smooth',
-        block: 'nearest',
-      });
-    }
-  }
-};
-
 const resetInput = (ref: MutableRefObject<HTMLInputElement | null> | null) => {
   if (ref && ref.current) {
     ref.current.innerHTML = '';
@@ -425,12 +406,6 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     }
   };
 
-  const handleCommonBehavior = (handleEvent) => {
-    scrollToCaret();
-    type CommonEvent<T> = React.KeyboardEvent<T> | React.MouseEvent<T> | React.ClipboardEvent<T>;
-    return (e: CommonEvent<HTMLDivElement>) => handleEvent(e);
-  };
-
   return (
     <form className={classnames(
       ...(Array.isArray(className) ? className : [className]),
@@ -456,7 +431,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           // @ts-ignore
           disabled={disabled}
           maxLength={maxLength}
-          onKeyDown={handleCommonBehavior((e) => {
+          onKeyDown={(e) => {
             const preventEvent = onKeyDown(e);
             if (preventEvent) {
               e.preventDefault();
@@ -487,24 +462,26 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
                 internalRef.current.removeChild(internalRef.current.childNodes[1]);
               }
             }
-          })}
-          onKeyUp={handleCommonBehavior((e) => {
+          }}
+          onKeyUp={(e) => {
             const preventEvent = onKeyUp(e);
             if (preventEvent) {
               e.preventDefault();
             } else {
               useMentionInputDetection();
             }
-          })}
-          onClick={handleCommonBehavior(() => {
+          }}
+          onClick={() => {
             useMentionInputDetection();
-          })}
-          onInput={handleCommonBehavior(() => {
+          }}
+          onInput={() => {
             onStartTyping();
             setIsInput(internalRef?.current?.textContent ? internalRef.current.textContent.trim().length > 0 : false);
             useMentionedLabelDetection();
-          })}
-          onPaste={handleCommonBehavior(onPaste)}
+          }}
+          onPaste={(e) => {
+            onPaste(e);
+          }}
         />
         {/* placeholder */}
         {(internalRef?.current?.textContent?.length ?? 0) === 0 && (


### PR DESCRIPTION
[CLNP-5528](https://sendbird.atlassian.net/browse/CLNP-5528)
[SBISSUE-17384](https://sendbird.atlassian.net/browse/SBISSUE-17384)

This PR resolves an issue where `getBoundingClientRect()` would return `(0, 0, 0, 0)` after a paste operation due to improper caret placement. The following changes ensure accurate caret positioning and consistent rect values:

1. **Zero-width space (`\u200B`)**: Appended to the pasted content to ensure the caret has a valid text node to reside in.
2. **Selection and Range Synchronization**: The range is collapsed and selection is reset to align with the updated DOM.
3. **Caret Adjustment**: The caret is moved to the end of the newly inserted content to maintain user expectation.

[CLNP-5528]: https://sendbird.atlassian.net/browse/CLNP-5528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SBISSUE-17384]: https://sendbird.atlassian.net/browse/SBISSUE-17384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ