### PR TITLE
fix: improve error handling in message handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@svgr/rollup": "^8.1.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/node": "^22.7.2",
     "@typescript-eslint/eslint-plugin": "^6.17.0",

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -29,7 +29,7 @@ import { getIsReactionEnabled } from '../../../utils/getIsReactionEnabled';
 
 export { ThreadReplySelectType } from './const'; // export for external usage
 
-type OnBeforeHandler<T> = (params: T) => T | Promise<T>;
+export type OnBeforeHandler<T> = (params: T) => T | Promise<T> | void | Promise<void>;
 type MessageListQueryParamsType = Omit<MessageCollectionParams, 'filter'> & MessageFilterParams;
 type MessageActions = ReturnType<typeof useMessageActions>;
 type MessageListDataSourceWithoutActions = Omit<ReturnType<typeof useGroupChannelMessages>, keyof MessageActions | `_dangerous_${string}`>;

--- a/src/modules/GroupChannel/context/__tests__/useMessageActions.spec.ts
+++ b/src/modules/GroupChannel/context/__tests__/useMessageActions.spec.ts
@@ -1,0 +1,154 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useMessageActions } from '../hooks/useMessageActions';
+import { UserMessageCreateParams, FileMessageCreateParams } from '@sendbird/chat/message';
+
+const mockEventHandlers = {
+  message: {
+    onSendMessageFailed: jest.fn(),
+    onUpdateMessageFailed: jest.fn(),
+    onFileUploadFailed: jest.fn(),
+  },
+};
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => ({
+    eventHandlers: mockEventHandlers,
+  }),
+}));
+
+describe('useMessageActions', () => {
+  const mockParams = {
+    sendUserMessage: jest.fn(),
+    sendFileMessage: jest.fn(),
+    sendMultipleFilesMessage: jest.fn(),
+    updateUserMessage: jest.fn(),
+    scrollToBottom: jest.fn(),
+    replyType: 'NONE',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processParams', () => {
+    it('should handle successful user message', async () => {
+      const { result } = renderHook(() => useMessageActions(mockParams));
+      const params: UserMessageCreateParams = { message: 'test' };
+
+      await result.current.sendUserMessage(params);
+
+      expect(mockParams.sendUserMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'test' }),
+        expect.any(Function),
+      );
+    });
+
+    it('should handle void return from onBeforeSendFileMessage', async () => {
+      const onBeforeSendFileMessage = jest.fn();
+      const { result } = renderHook(() => useMessageActions({
+        ...mockParams,
+        onBeforeSendFileMessage,
+      }),
+      );
+
+      const fileParams: FileMessageCreateParams = {
+        file: new File([], 'test.txt'),
+      };
+
+      await result.current.sendFileMessage(fileParams);
+
+      expect(onBeforeSendFileMessage).toHaveBeenCalled();
+      expect(mockParams.sendFileMessage).toHaveBeenCalledWith(
+        expect.objectContaining(fileParams),
+        expect.any(Function),
+      );
+    });
+
+    it('should handle file upload error', async () => {
+      // Arrange
+      const error = new Error('Upload failed');
+      const onBeforeSendFileMessage = jest.fn().mockRejectedValue(error);
+      const fileParams: FileMessageCreateParams = {
+        file: new File([], 'test.txt'),
+        fileName: 'test.txt',
+      };
+
+      const { result } = renderHook(() => useMessageActions({
+        ...mockParams,
+        onBeforeSendFileMessage,
+      }),
+      );
+
+      await expect(async () => {
+        await result.current.sendFileMessage(fileParams);
+      }).rejects.toThrow('Upload failed');
+
+      // Wait for next tick to ensure all promises are resolved
+      await new Promise(process.nextTick);
+
+      expect(onBeforeSendFileMessage).toHaveBeenCalled();
+      expect(mockEventHandlers.message.onFileUploadFailed).toHaveBeenCalledWith(error);
+      expect(mockEventHandlers.message.onSendMessageFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file: fileParams.file,
+          fileName: fileParams.fileName,
+        }),
+        error,
+      );
+    });
+
+    it('should handle message update error', async () => {
+      // Arrange
+      const error = new Error('Update failed');
+      const onBeforeUpdateUserMessage = jest.fn().mockRejectedValue(error);
+      const messageParams = {
+        messageId: 1,
+        message: 'update message',
+      };
+
+      const { result } = renderHook(() => useMessageActions({
+        ...mockParams,
+        onBeforeUpdateUserMessage,
+      }),
+      );
+
+      await expect(async () => {
+        await result.current.updateUserMessage(messageParams.messageId, {
+          message: messageParams.message,
+        });
+      }).rejects.toThrow('Update failed');
+
+      // Wait for next tick to ensure all promises are resolved
+      await new Promise(process.nextTick);
+
+      expect(onBeforeUpdateUserMessage).toHaveBeenCalled();
+      expect(mockEventHandlers.message.onUpdateMessageFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: messageParams.message,
+        }),
+        error,
+      );
+    });
+
+    it('should preserve modified params from onBefore handlers', async () => {
+      const onBeforeSendUserMessage = jest.fn().mockImplementation((params) => ({
+        ...params,
+        message: 'modified',
+      }));
+
+      const { result } = renderHook(() => useMessageActions({
+        ...mockParams,
+        onBeforeSendUserMessage,
+      }),
+      );
+
+      await result.current.sendUserMessage({ message: 'original' });
+
+      expect(mockParams.sendUserMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'modified' }),
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,6 +2778,7 @@ __metadata:
     "@svgr/rollup": ^8.1.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^13.4.0
+    "@testing-library/react-hooks": ^8.0.1
     "@testing-library/user-event": ^14.4.3
     "@types/node": ^22.7.2
     "@typescript-eslint/eslint-plugin": ^6.17.0
@@ -3465,6 +3466,28 @@ __metadata:
     lodash: ^4.17.15
     redent: ^3.0.0
   checksum: 9f28dbca8b50d7c306aae40c3aa8e06f0e115f740360004bd87d57f95acf7ab4b4f4122a7399a76dbf2bdaaafb15c99cc137fdcb0ae457a92e2de0f3fbf9b03b
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-hooks@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    react-error-boundary: ^3.1.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
   languageName: node
   linkType: hard
 
@@ -12529,6 +12552,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: c3907cc4c1d3e9ecc8ca7727058ebcba6ec89848d9e07bfd2c77ee8f28f1ad99bf55e38359dec8a1125de83d41ac09a2874f53c41415edc86ffa9840fa1b7856
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes some of comments in [SBISSUE-17017](https://sendbird.atlassian.net/browse/SBISSUE-17017?focusedCommentId=298138)

## Problem
Users currently need to return an empty object from `onBeforeSendFileMessage` due to type constraints. Additionally, error handling for message sending failures needs improvement to ensure `eventHandlers.message` callbacks (onSendMessageFailed, onUpdateMessageFailed, onFileUploadFailed) are properly triggered when errors occur within their corresponding `onBefore` handlers (`onBeforeSendUserMessage`, `onBeforeSendFileMessage`, etc).

## Solution
- Allow void return type in `onBeforeXXX` handler
- Add proper error handling via `eventHandlers.message` for:
  - onSendMessageFailed
  - onUpdateMessageFailed
  - onFileUploadFailed


### Checklist
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


[SBISSUE-17017]: https://sendbird.atlassian.net/browse/SBISSUE-17017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ