### PR TITLE
[CLNP-5914] Fixed a GroupChannel UI error when the `Open in Channel` action is triggered in a different channel.

### DIFF
--- a/src/modules/App/DesktopLayout.tsx
+++ b/src/modules/App/DesktopLayout.tsx
@@ -167,9 +167,11 @@ export const DesktopLayout: React.FC<DesktopLayoutProps> = (props: DesktopLayout
             if (channel?.url !== currentChannel?.url) {
               setCurrentChannel(channel);
             }
-            if (message?.messageId !== highlightedMessage) {
-              setStartingPoint?.(message?.createdAt);
-            }
+            setTimeout(() => {
+              if (message?.messageId !== highlightedMessage) {
+                setStartingPoint?.(message?.createdAt);
+              }
+            }, 200);
             setTimeout(() => {
               setStartingPoint?.(null);
               setHighlightedMessage?.(message?.messageId);


### PR DESCRIPTION
### Changelog
* Fixed a GroupChannel UI error when the `Open in Channel` action is triggered in a different channel.
  * The `Open in Channel` implementation invokes both `setCurrentChannel` and `setStartingPoint`. The `setCurrentChannel` function triggers asynchronous side effects that update `channel`, `messagesDataSource`, and `startingPoint`. If `setStartingPoint` is invoked before these updates are completed, it can result in the channel not being updated correctly or the starting point being improperly set.