### PR TITLE
[CLNP-5974] Add more GroupChannel module custom hook unit tests

### DIFF
--- a/src/modules/GroupChannel/context/__tests__/useMessageListScroll.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/useMessageListScroll.spec.tsx
@@ -46,6 +46,61 @@ describe('useMessageListScroll', () => {
       });
     });
 
+    it('should update scroll position refs when scrolling to bottom', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+      const mockScrollRef = {
+        current: {
+          scrollHeight: 1000,
+          clientHeight: 500,
+          scrollTop: 0,
+          scroll: jest.fn(),
+        },
+      };
+      // @ts-ignore
+      result.current.scrollRef = mockScrollRef;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scrollToBottom', {});
+        await waitFor(() => {
+          expect(result.current.scrollDistanceFromBottomRef.current).toBe(0);
+          expect(result.current.isScrollBottomReached).toBe(true);
+        });
+      });
+    });
+
+    it('should update scroll position refs when scrolling to specific position', async () => {
+      const mockElement = document.createElement('div');
+      Object.defineProperties(mockElement, {
+        scrollHeight: { value: 1000, configurable: true },
+        clientHeight: { value: 500, configurable: true },
+        scrollTop: {
+          value: 300,
+          writable: true,
+          configurable: true,
+        },
+        scroll: {
+          value: jest.fn(),
+          configurable: true,
+        },
+      });
+
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      await act(async () => {
+        // @ts-ignore
+        result.current.scrollRef.current = mockElement;
+        result.current.scrollPubSub.publish('scroll', {
+          top: 300,
+          lazy: false,
+        });
+
+        await waitFor(() => {
+          expect(result.current.scrollDistanceFromBottomRef.current).toBe(200);
+          expect(mockSetIsScrollBottomReached).toHaveBeenCalledWith(true);
+        });
+      });
+    });
+
     it('should use scrollTop if scroll method is not defined', async () => {
       const { result } = renderHook(() => useMessageListScroll('auto'));
 

--- a/src/modules/GroupChannel/context/__tests__/useMessageListScroll.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/useMessageListScroll.spec.tsx
@@ -1,0 +1,245 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useMessageListScroll } from '../hooks/useMessageListScroll';
+import { useGroupChannel } from '../hooks/useGroupChannel';
+
+jest.mock('../hooks/useGroupChannel', () => ({
+  useGroupChannel: jest.fn(),
+}));
+
+describe('useMessageListScroll', () => {
+  const mockSetIsScrollBottomReached = jest.fn();
+
+  beforeEach(() => {
+    (useGroupChannel as jest.Mock).mockImplementation(() => ({
+      state: { isScrollBottomReached: true },
+      actions: { setIsScrollBottomReached: mockSetIsScrollBottomReached },
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initialization and Basic Behavior', () => {
+    it('should set the initial state correctly', () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      expect(result.current.scrollRef.current).toBe(null);
+      expect(result.current.isScrollBottomReached).toBe(true);
+      expect(result.current.scrollDistanceFromBottomRef.current).toBe(0);
+      expect(result.current.scrollPositionRef.current).toBe(0);
+      expect(typeof result.current.scrollPubSub.publish).toBe('function');
+      expect(typeof result.current.scrollPubSub.subscribe).toBe('function');
+    });
+  });
+
+  describe('scrollToBottom', () => {
+    it('should call resolve only if scrollRef is null', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+      const resolveMock = jest.fn();
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scrollToBottom', { resolve: resolveMock });
+        await waitFor(() => {
+          expect(resolveMock).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it('should use scrollTop if scroll method is not defined', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      const mockScrollElement = {
+        scrollHeight: 1000,
+        scrollTop: 0,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        const promise = new Promise<void>((resolve) => {
+          result.current.scrollPubSub.publish('scrollToBottom', { resolve });
+        });
+        await promise;
+      });
+
+      expect(mockScrollElement.scrollTop).toBe(1000);
+    });
+
+    it('should use smooth behavior if behavior parameter is smooth', async () => {
+      const { result } = renderHook(() => useMessageListScroll('smooth'));
+
+      const mockScroll = jest.fn();
+      const mockScrollElement = {
+        scroll: mockScroll,
+        scrollHeight: 1000,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scrollToBottom', {});
+        await waitFor(() => {
+          expect(mockScroll).toHaveBeenCalledWith({
+            top: 1000,
+            behavior: 'smooth',
+          });
+        });
+      });
+    });
+  });
+
+  describe('scroll', () => {
+    it('should do nothing if scrollRef is null', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+      const resolveMock = jest.fn();
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', { resolve: resolveMock });
+      });
+
+      expect(resolveMock).not.toHaveBeenCalled();
+    });
+
+    it('should use scrollTop if scroll method is not defined', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      const mockScrollElement = {
+        scrollHeight: 1000,
+        scrollTop: 0,
+        clientHeight: 500,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', { top: 300 });
+        await waitFor(() => {
+          expect(mockScrollElement.scrollTop).toBe(300);
+        });
+      });
+    });
+
+    it('should not change the scroll position if top is not defined', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      const mockScroll = jest.fn();
+      const mockScrollElement = {
+        scroll: mockScroll,
+        scrollHeight: 1000,
+        scrollTop: 100,
+        clientHeight: 500,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', {});
+      });
+
+      expect(mockScroll).not.toHaveBeenCalled();
+    });
+
+    it('should execute immediately if lazy option is false', async () => {
+      jest.useFakeTimers();
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      const mockScroll = jest.fn();
+      const mockScrollElement = {
+        scroll: mockScroll,
+        scrollHeight: 1000,
+        scrollTop: 0,
+        clientHeight: 500,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', { top: 300, lazy: false });
+      });
+
+      expect(mockScroll).toHaveBeenCalledWith({
+        top: 300,
+        behavior: 'auto',
+      });
+      jest.useRealTimers();
+    });
+  });
+
+  describe('deps change', () => {
+    it('should reset all states if deps change', () => {
+      const mockScrollElement = {
+        scrollHeight: 1000,
+        scrollTop: 0,
+      };
+
+      const { rerender } = renderHook(
+        ({ deps }) => useMessageListScroll('auto', deps),
+        { initialProps: { deps: ['initial'] } },
+      );
+
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      rerender({ deps: ['updated'] });
+
+      expect(mockSetIsScrollBottomReached).toHaveBeenCalledWith(true);
+      expect(result.current.scrollDistanceFromBottomRef.current).toBe(0);
+      expect(result.current.scrollPositionRef.current).toBe(0);
+    });
+  });
+
+  describe('getScrollBehavior utility', () => {
+    it('should return smooth if animated is true', async () => {
+      const { result } = renderHook(() => useMessageListScroll('auto'));
+
+      const mockScroll = jest.fn();
+      const mockScrollElement = {
+        scroll: mockScroll,
+        scrollHeight: 1000,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', { top: 300, animated: true });
+        await waitFor(() => {
+          expect(mockScroll).toHaveBeenCalledWith({
+            top: 300,
+            behavior: 'smooth',
+          });
+        });
+      });
+    });
+
+    it('should return auto if animated is false', async () => {
+      const { result } = renderHook(() => useMessageListScroll('smooth'));
+
+      const mockScroll = jest.fn();
+      const mockScrollElement = {
+        scroll: mockScroll,
+        scrollHeight: 1000,
+      };
+
+      // @ts-ignore
+      result.current.scrollRef.current = mockScrollElement;
+
+      await act(async () => {
+        result.current.scrollPubSub.publish('scroll', { top: 300, animated: false });
+        await waitFor(() => {
+          expect(mockScroll).toHaveBeenCalledWith({
+            top: 300,
+            behavior: 'auto',
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/modules/GroupChannel/context/__tests__/utils.spec.ts
+++ b/src/modules/GroupChannel/context/__tests__/utils.spec.ts
@@ -1,0 +1,160 @@
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import { Role } from '@sendbird/chat';
+import {
+  getComponentKeyFromMessage,
+  isContextMenuClosed,
+  getMessageTopOffset,
+  isDisabledBecauseFrozen,
+  isDisabledBecauseMuted,
+  isDisabledBecauseSuggestedReplies,
+  isFormVersionCompatible,
+  isDisabledBecauseMessageForm,
+} from '../utils';
+import { UIKIT_COMPATIBLE_FORM_VERSION } from '../const';
+
+describe('GroupChannel utils', () => {
+  describe('getComponentKeyFromMessage', () => {
+    it('should return messageId if sendingStatus is succeeded', () => {
+      const message = {
+        messageId: 12345,
+        sendingStatus: 'succeeded',
+      };
+      expect(getComponentKeyFromMessage(message)).toBe('12345');
+    });
+
+    it('should return reqId if sendingStatus is pending', () => {
+      const message = {
+        messageId: 12345,
+        reqId: 'temp-id-123',
+        sendingStatus: 'pending',
+      };
+      expect(getComponentKeyFromMessage(message)).toBe('temp-id-123');
+    });
+  });
+
+  describe('isContextMenuClosed', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should return true if dropdown and emoji portal are empty', () => {
+      document.body.innerHTML = `
+        <div id="sendbird-dropdown-portal"></div>
+        <div id="sendbird-emoji-list-portal"></div>
+      `;
+      expect(isContextMenuClosed()).toBe(true);
+    });
+
+    it('should return false if dropdown or emoji portal has content', () => {
+      document.body.innerHTML = `
+        <div id="sendbird-dropdown-portal"><div>content</div></div>
+        <div id="sendbird-emoji-list-portal"></div>
+      `;
+      expect(isContextMenuClosed()).toBe(false);
+    });
+  });
+
+  describe('getMessageTopOffset', () => {
+    const mockCreatedAt = 1234567890;
+
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should return offsetTop if message element exists', () => {
+      document.body.innerHTML = `
+        <div data-sb-created-at="1234567890" style="position: absolute; top: 100px;"></div>
+      `;
+      const element = document.querySelector('[data-sb-created-at="1234567890"]');
+      Object.defineProperty(element, 'offsetTop', {
+        configurable: true,
+        value: 100,
+      });
+      expect(getMessageTopOffset(mockCreatedAt)).toBe(100);
+    });
+
+    it('should return null if message element does not exist', () => {
+      expect(getMessageTopOffset(mockCreatedAt)).toBe(null);
+    });
+  });
+
+  describe('isDisabledBecauseFrozen', () => {
+    it('should return true if channel is frozen and user is not operator', () => {
+      const channel = {
+        isFrozen: true,
+        myRole: Role.NONE,
+      } as GroupChannel;
+      expect(isDisabledBecauseFrozen(channel)).toBe(true);
+    });
+
+    it('should return false if channel is not frozen or user is operator', () => {
+      expect(isDisabledBecauseFrozen({ isFrozen: false, myRole: Role.NONE } as GroupChannel)).toBe(false);
+      expect(isDisabledBecauseFrozen({ isFrozen: true, myRole: Role.OPERATOR } as GroupChannel)).toBe(false);
+    });
+  });
+
+  describe('isDisabledBecauseMuted', () => {
+    it('should return true if user is muted', () => {
+      const channel = { myMutedState: 'muted' } as GroupChannel;
+      expect(isDisabledBecauseMuted(channel)).toBe(true);
+    });
+
+    it('should return false if user is not muted', () => {
+      const channel = { myMutedState: 'unmuted' } as GroupChannel;
+      expect(isDisabledBecauseMuted(channel)).toBe(false);
+    });
+  });
+
+  describe('isDisabledBecauseSuggestedReplies', () => {
+    it('should return true if suggested replies are enabled and chat input is disabled', () => {
+      const channel = {
+        lastMessage: {
+          extendedMessagePayload: {
+            suggested_replies: ['reply1', 'reply2'],
+            disable_chat_input: true,
+          },
+        },
+      };
+      expect(isDisabledBecauseSuggestedReplies(channel as any, true)).toBe(true);
+    });
+  });
+
+  describe('isFormVersionCompatible', () => {
+    it('should return true if version is compatible', () => {
+      expect(isFormVersionCompatible(UIKIT_COMPATIBLE_FORM_VERSION)).toBe(true);
+      expect(isFormVersionCompatible(UIKIT_COMPATIBLE_FORM_VERSION - 1)).toBe(true);
+    });
+
+    it('should return false if version is not compatible', () => {
+      expect(isFormVersionCompatible(UIKIT_COMPATIBLE_FORM_VERSION + 1)).toBe(false);
+    });
+  });
+
+  describe('isDisabledBecauseMessageForm', () => {
+    it('should return true if there is an unsent form and chat input is disabled', () => {
+      const messages = [{
+        messageForm: {
+          isSubmitted: false,
+          version: UIKIT_COMPATIBLE_FORM_VERSION,
+        },
+        extendedMessagePayload: {
+          disable_chat_input: true,
+        },
+      }];
+      expect(isDisabledBecauseMessageForm(messages as any, true)).toBe(true);
+    });
+
+    it('should return false if there is no form or it is already submitted', () => {
+      const messages = [{
+        messageForm: {
+          isSubmitted: true,
+          version: UIKIT_COMPATIBLE_FORM_VERSION,
+        },
+        extendedMessagePayload: {
+          disable_chat_input: true,
+        },
+      }];
+      expect(isDisabledBecauseMessageForm(messages as any, true)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- before
<img width="1099" alt="Screenshot 2024-12-03 at 11 14 47 PM" src="https://github.com/user-attachments/assets/75716138-2ac6-46d1-8fe7-d3793d53c3be">

- after
<img width="1107" alt="Screenshot 2024-12-03 at 11 13 43 PM" src="https://github.com/user-attachments/assets/182237d5-c322-4d59-8595-3abdaf15afa9">

GroupChannelProvider has some not covered lines but they're mostly from uikit-tools lib related logic. There could be a way to mock these lines too, but let me handle it separately. 
