### PR TITLE
[CLNP-6019][CLNP-6023][CLNP-6024] Add state management migration tests

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -25,4 +25,43 @@ global.requestAnimationFrame = function (callback) {
 global.cancelAnimationFrame = function (id) {
   clearTimeout(id);
 };
+class MockMediaRecorder {
+  static isTypeSupported(type) {
+    const supportedMimeTypes = ['audio/webm', 'audio/wav'];
+    return supportedMimeTypes.includes(type);
+  }
+
+  constructor() {
+    this.state = 'inactive';
+    this.ondataavailable = null;
+    this.onerror = null;
+    this.onpause = null;
+    this.onresume = null;
+    this.onstart = null;
+    this.onstop = null;
+  }
+
+  start() {
+    this.state = 'recording';
+    if (this.onstart) this.onstart(new Event('start'));
+  }
+
+  stop() {
+    this.state = 'inactive';
+    if (this.onstop) this.onstop(new Event('stop'));
+  }
+
+  pause() {
+    this.state = 'paused';
+    if (this.onpause) this.onpause(new Event('pause'));
+  }
+
+  resume() {
+    this.state = 'recording';
+    if (this.onresume) this.onresume(new Event('resume'));
+  }
+}
+
+global.MediaRecorder = MockMediaRecorder;
+
 copyProps(window, global);

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -25,6 +25,8 @@ global.requestAnimationFrame = function (callback) {
 global.cancelAnimationFrame = function (id) {
   clearTimeout(id);
 };
+
+// MediaRecorder and MediaRecorder.isTypeSupported are used within SendbirdProvider's internal logic.
 class MockMediaRecorder {
   static isTypeSupported(type) {
     const supportedMimeTypes = ['audio/webm', 'audio/wav'];
@@ -61,7 +63,6 @@ class MockMediaRecorder {
     if (this.onresume) this.onresume(new Event('resume'));
   }
 }
-
 global.MediaRecorder = MockMediaRecorder;
 
 copyProps(window, global);

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,4 +1,5 @@
 import './__mocks__/intersectionObserverMock';
+import '@testing-library/jest-dom';
 
 const { JSDOM } = require('jsdom');
 

--- a/src/lib/SendbirdProvider.migration.spec.tsx
+++ b/src/lib/SendbirdProvider.migration.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render, renderHook, screen } from '@testing-library/react';
+import SendbirdProvider, { SendbirdProviderProps } from './Sendbird';
+import useSendbirdStateContext from '../hooks/useSendbirdStateContext';
+import { match } from 'ts-pattern';
+import { DEFAULT_MULTIPLE_FILES_MESSAGE_LIMIT, DEFAULT_UPLOAD_SIZE_LIMIT } from '../utils/consts';
+
+const mockProps: SendbirdProviderProps = {
+  appId: 'test-app-id',
+  userId: 'test-user-id',
+  accessToken: 'test-access-token',
+  customApiHost: 'api.sendbird.com',
+  customWebSocketHost: 'socket.sendbird.com',
+  theme: 'light',
+  config: { logLevel: 'info', isREMUnitEnabled: true },
+  nickname: 'test-nickname',
+  colorSet: { primary: '#000' },
+  stringSet: { CHANNEL_PREVIEW_MOBILE_LEAVE: 'Leave Channel' },
+  dateLocale: {} as Locale,
+  profileUrl: 'test-profile-url',
+  voiceRecord: { maxRecordingTime: 3000, minRecordingTime: 1000 },
+  userListQuery: () => ({ limit: 10 } as any),
+  imageCompression: { compressionRate: 0.8, outputFormat: 'png' },
+  allowProfileEdit: true,
+  disableMarkAsDelivered: false,
+  breakpoint: '768px',
+  htmlTextDirection: 'ltr',
+  forceLeftToRightMessageLayout: true,
+  uikitOptions: { groupChannel: { enableReactions: true } },
+  isUserIdUsedForNickname: true,
+  sdkInitParams: { localCacheEnabled: true },
+  customExtensionParams: { feature: 'custom' },
+  isMultipleFilesMessageEnabled: true,
+  renderUserProfile: jest.fn(),
+  onStartDirectMessage: jest.fn(),
+  onUserProfileMessage: jest.fn(),
+  eventHandlers: {},
+  children: <div>Test Child</div>,
+};
+class MockMediaRecorder {
+  static isTypeSupported(type: string): boolean {
+    const supportedTypes = ['audio/webm', 'audio/webm;codecs=opus'];
+    return supportedTypes.includes(type);
+  }
+}
+Object.defineProperty(global, 'MediaRecorder', {
+  value: MockMediaRecorder,
+  writable: true,
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+describe('SendbirdProvider Props & Context Interface Validation', () => {
+  it('should accept all props without errors', () => {
+    render(<SendbirdProvider {...mockProps} />);
+  });
+
+  it('should provide all expected keys in context', () => {
+    const expectedKeys = [
+      'config',
+      'stores',
+      'dispatchers',
+      'eventHandlers',
+      'emojiManager',
+      'utils',
+    ];
+
+    const TestComponent = () => {
+      const context = useSendbirdStateContext();
+      return (
+        <div>
+          {Object.keys(context).map((key) => (
+            <div key={key} data-testid={`context-${key}`}>
+              {match(context[key])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[key]))
+                .with('string', () => String(context[key]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    render(
+      <SendbirdProvider appId="test-app-id" userId="test-user-id">
+        <TestComponent />
+      </SendbirdProvider>,
+    );
+
+    expectedKeys.forEach((key) => {
+      const element = screen.getByTestId(`context-${key}`);
+      expect(element).toBeInTheDocument();
+    });
+  });
+
+  it('should pass all expected values to the config object', () => {
+    const mockProps: SendbirdProviderProps = {
+      appId: 'test-app-id',
+      userId: 'test-user-id',
+      theme: 'light',
+      allowProfileEdit: true,
+      disableMarkAsDelivered: false,
+      voiceRecord: { maxRecordingTime: 3000, minRecordingTime: 1000 },
+      config: {
+        userMention: { maxMentionCount: 5, maxSuggestionCount: 10 },
+      },
+      imageCompression: { compressionRate: 0.7, resizingWidth: 800 },
+      htmlTextDirection: 'ltr',
+      forceLeftToRightMessageLayout: false,
+      isMultipleFilesMessageEnabled: true,
+    };
+
+    const wrapper = ({ children }) => (
+      <SendbirdProvider {...mockProps}>{children}</SendbirdProvider>
+    );
+
+    const { result } = renderHook(() => useSendbirdStateContext(), { wrapper });
+
+    const config = result.current.config;
+
+    expect(config.appId).toBe(mockProps.appId);
+    expect(config.userId).toBe(mockProps.userId);
+    expect(config.theme).toBe(mockProps.theme);
+    expect(config.allowProfileEdit).toBe(mockProps.allowProfileEdit);
+    expect(config.disableMarkAsDelivered).toBe(mockProps.disableMarkAsDelivered);
+    expect(config.voiceRecord.maxRecordingTime).toBe(mockProps.voiceRecord?.maxRecordingTime);
+    expect(config.voiceRecord.minRecordingTime).toBe(mockProps.voiceRecord?.minRecordingTime);
+    expect(config.userMention.maxMentionCount).toBe(mockProps.config?.userMention?.maxMentionCount);
+    expect(config.userMention.maxSuggestionCount).toBe(mockProps.config?.userMention?.maxSuggestionCount);
+    expect(config.imageCompression.compressionRate).toBe(mockProps.imageCompression?.compressionRate);
+    expect(config.imageCompression.resizingWidth).toBe(mockProps.imageCompression?.resizingWidth);
+    expect(config.htmlTextDirection).toBe(mockProps.htmlTextDirection);
+    expect(config.forceLeftToRightMessageLayout).toBe(mockProps.forceLeftToRightMessageLayout);
+    expect(config.isMultipleFilesMessageEnabled).toBe(mockProps.isMultipleFilesMessageEnabled);
+
+    // Default values validation
+    expect(config.uikitUploadSizeLimit).toBe(DEFAULT_UPLOAD_SIZE_LIMIT);
+    expect(config.uikitMultipleFilesMessageLimit).toBe(DEFAULT_MULTIPLE_FILES_MESSAGE_LIMIT);
+    expect(config.logger).toBeDefined();
+    expect(config.pubSub).toBeDefined();
+    expect(config.markAsReadScheduler).toBeDefined();
+    expect(config.markAsDeliveredScheduler).toBeDefined();
+  });
+
+  it('should handle optional and default values correctly', () => {
+    const wrapper = ({ children }) => (
+      <SendbirdProvider {...mockProps} appId="test-app-id" userId="test-user-id">
+        {children}
+      </SendbirdProvider>
+    );
+
+    const { result } = renderHook(() => useSendbirdStateContext(), { wrapper });
+
+    expect(result.current.config.pubSub).toBeDefined();
+    expect(result.current.config.logger).toBeDefined();
+    expect(result.current.config.imageCompression.compressionRate).toBe(0.8);
+  });
+});

--- a/src/lib/SendbirdProvider.migration.spec.tsx
+++ b/src/lib/SendbirdProvider.migration.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { render, renderHook, screen } from '@testing-library/react';
 import SendbirdProvider, { SendbirdProviderProps } from './Sendbird';
@@ -42,6 +43,11 @@ const mockDisconnect = jest.fn();
 const mockConnect = jest.fn();
 const mockUpdateCurrentUserInfo = jest.fn();
 
+/**
+ * Mocking Sendbird SDK
+ * sdk.connect causes DOMException issue in jest.
+ * Because it retries many times to connect indexDB.
+ */
 jest.mock('@sendbird/chat', () => {
   return {
     __esModule: true,
@@ -100,7 +106,6 @@ describe('SendbirdProvider Props & Context Interface Validation', () => {
       }),
     } as any;
 
-    // Window matchMedia 모킹
     window.matchMedia = jest.fn().mockImplementation((query) => ({
       matches: false,
       media: query,
@@ -120,7 +125,6 @@ describe('SendbirdProvider Props & Context Interface Validation', () => {
       </SendbirdProvider>,
     );
 
-    // Props change scenario test
     rerender(
       <SendbirdProvider {...mockProps}>
         {mockProps.children}

--- a/src/modules/ChannelSettings/__test__/ChannelSettings.migration.spec.tsx
+++ b/src/modules/ChannelSettings/__test__/ChannelSettings.migration.spec.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, renderHook, screen } from '@testing-library/react';
+
+import { ChannelSettingsContextProps, ChannelSettingsProvider, useChannelSettingsContext } from '../context/ChannelSettingsProvider';
+import { match } from 'ts-pattern';
+
+const mockState = {
+  stores: {
+    sdkStore: {
+      sdk: {},
+    },
+  },
+  config: {
+    logger: {
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    },
+  },
+};
+
+jest.mock('../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockState),
+}));
+jest.mock('../../../lib/Sendbird', () => ({
+  __esModule: true,
+  useSendbirdStateContext: jest.fn(() => mockState),
+}));
+
+const mockProps: ChannelSettingsContextProps = {
+  channelUrl: 'test-channel-url',
+  onCloseClick: jest.fn(),
+  onLeaveChannel: jest.fn(),
+  onChannelModified: jest.fn(),
+  onBeforeUpdateChannel: jest.fn(),
+  overrideInviteUser: jest.fn(),
+  queries: {
+    applicationUserListQuery: { limit: 10 },
+  },
+  className: 'test-class',
+  renderUserListItem: jest.fn(),
+  renderUserProfile: jest.fn(),
+  disableUserProfile: true,
+  children: <div>Child Component</div>,
+};
+
+describe('ChannelSettingsProvider Interface Validation', () => {
+  it('should pass all props to the context correctly', () => {
+    const wrapper = ({ children }) => (
+      <ChannelSettingsProvider {...mockProps}>{children}</ChannelSettingsProvider>
+    );
+
+    const { result } = renderHook(() => useChannelSettingsContext(), { wrapper });
+
+    expect(result.current.channelUrl).toBe(mockProps.channelUrl);
+    expect(result.current.onCloseClick).toBe(mockProps.onCloseClick);
+    expect(result.current.onLeaveChannel).toBe(mockProps.onLeaveChannel);
+    expect(result.current.onChannelModified).toBe(mockProps.onChannelModified);
+    expect(result.current.onBeforeUpdateChannel).toBe(mockProps.onBeforeUpdateChannel);
+    expect(result.current.overrideInviteUser).toBe(mockProps.overrideInviteUser);
+    expect(result.current.queries).toBe(mockProps.queries);
+    expect(result.current.renderUserListItem).toBe(mockProps.renderUserListItem);
+    // Only props
+    expect(result.current['className']).toBeUndefined();
+    expect(result.current['renderUserProfile']).toBeUndefined();
+    expect(result.current['disableUserProfile']).toBeUndefined();
+  });
+
+  it('should provide default values for optional props', () => {
+    const minimalProps = { channelUrl: 'minimal-channel-url' };
+
+    const wrapper = ({ children }) => (
+      <ChannelSettingsProvider {...minimalProps}>{children}</ChannelSettingsProvider>
+    );
+
+    const { result } = renderHook(() => useChannelSettingsContext(), { wrapper });
+
+    expect(result.current.channelUrl).toBe('minimal-channel-url');
+    expect(result.current.onCloseClick).toBeUndefined();
+    expect(result.current.onLeaveChannel).toBeUndefined();
+    expect(result.current.overrideInviteUser).toBeUndefined();
+    expect(result.current.queries).toBeUndefined();
+    expect(result.current.renderUserListItem).toBeUndefined();
+  });
+
+  it('should provide all expected context values', () => {
+    const expectedKeys = [
+      'channelUrl',
+      'onCloseClick',
+      'onLeaveChannel',
+      'onChannelModified',
+      'onBeforeUpdateChannel',
+      'overrideInviteUser',
+      'setChannelUpdateId',
+      'forceUpdateUI',
+      'channel',
+      'loading',
+      'invalidChannel',
+      'queries',
+      'renderUserListItem',
+    ];
+
+    const TestComponent = () => {
+      const context = useChannelSettingsContext();
+      return (
+        <div>
+          {Object.keys(context).map((key) => (
+            <div key={key} data-testid={`context-${key}`}>
+              {match(context[key])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[key]))
+                .with('string', () => String(context[key]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    render(
+      <ChannelSettingsProvider {...mockProps}>
+        <TestComponent />
+      </ChannelSettingsProvider>,
+    );
+
+    expectedKeys.forEach((key) => {
+      const element = screen.getByTestId(`context-${key}`);
+      expect(element).toBeInTheDocument();
+    });
+  });
+});

--- a/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
+++ b/src/modules/ChannelSettings/context/ChannelSettingsProvider.tsx
@@ -29,9 +29,9 @@ interface CommonChannelSettingsProps {
   channelUrl: string;
   onCloseClick?(): void;
   onLeaveChannel?(): void;
-  overrideInviteUser?(params: OverrideInviteUserType): void;
   onChannelModified?(channel: GroupChannel): void;
   onBeforeUpdateChannel?(currentTitle: string, currentImg: File | null, data: string | undefined): GroupChannelUpdateParams;
+  overrideInviteUser?(params: OverrideInviteUserType): void;
   queries?: ChannelSettingsQueries;
   renderUserListItem?: (props: UserListItemProps) => ReactNode;
 }

--- a/src/modules/CreateChannel/context/__tests__/CreateChannel.migration.spec.tsx
+++ b/src/modules/CreateChannel/context/__tests__/CreateChannel.migration.spec.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { match } from 'ts-pattern';
+import React from 'react';
+import {
+  CreateChannelProvider,
+  CreateChannelProviderProps,
+  useCreateChannelContext,
+} from '../CreateChannelProvider';
+
+const mockSendbirdStateContext = {
+  stores: {
+    userStore: {
+      user: {
+        userId: ' test-user-id',
+      },
+    },
+    sdkStore: {
+      sdk: {
+        currentUser: {
+          userId: 'test-user-id',
+        },
+      },
+      initialized: true,
+    },
+  },
+  config: {
+    logger: console,
+    userId: 'test-user-id',
+    groupChannel: {
+      enableMention: true,
+    },
+    groupChannelList: {
+      enableTypingIndicator: true,
+    },
+    isOnline: true,
+  },
+};
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => mockSendbirdStateContext,
+}));
+
+jest.mock('../../../../lib/Sendbird', () => ({
+  __esModule: true,
+  useSendbirdStateContext: () => mockSendbirdStateContext,
+}));
+
+const mockProps: CreateChannelProviderProps = {
+  children: <div>test children</div>,
+  userListQuery: () => ({ hasNext: true, next: jest.fn(), isLoading: false }),
+  onCreateChannelClick: jest.fn(),
+  onChannelCreated: jest.fn(),
+  onBeforeCreateChannel: jest.fn(),
+  onCreateChannel: jest.fn(),
+  overrideInviteUser: jest.fn(),
+};
+
+describe('CreateChannel Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('CreateChannelProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(
+        <CreateChannelProvider {...mockProps}>
+          {mockProps.children}
+        </CreateChannelProvider>,
+      );
+
+      // Props change scenario test
+      rerender(
+        <CreateChannelProvider
+          {...mockProps}
+        >
+          {mockProps.children}
+        </CreateChannelProvider>,
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useCreateChannelContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useCreateChannelContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      'sdk',
+      'createChannel',
+      'userListQuery',
+      'onCreateChannelClick',
+      'onChannelCreated',
+      'onBeforeCreateChannel',
+      'step',
+      'setStep',
+      'type',
+      'setType',
+      'onCreateChannel',
+      'overrideInviteUser',
+    ];
+
+    const TestComponent = () => {
+      const context = useCreateChannelContext();
+      return (
+        <div>
+          {expectedProps.map(prop => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {/* text can be function, object, string, or unknown */}
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <CreateChannelProvider {...mockProps}>
+          <TestComponent />
+        </CreateChannelProvider>,
+      );
+
+      expectedProps.forEach(prop => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/modules/GroupChannel/context/__tests__/GroupChannel.migration.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/GroupChannel.migration.spec.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GroupChannelProvider, GroupChannelProviderProps, useGroupChannelContext } from '../GroupChannelProvider';
+import { ThreadReplySelectType } from '../const';
+import { match } from 'ts-pattern';
+
+const mockSendbirdStateContext = {
+  config: {
+    pubSub: { subscribe: () => ({ remove: () => {} }) },
+    isOnline: true,
+    logger: {},
+    groupChannel: {
+      replyType: 'NONE',
+      threadReplySelectType: 'NONE',
+    },
+    groupChannelSettings: {
+      enableMessageSearch: false,
+    },
+    onStartDirectMessage: jest.fn(),
+  },
+  stores: {
+    sdkStore: {
+      initialized: true,
+      sdk: {
+        groupChannel: {
+          getChannel: jest.fn().mockResolvedValue({}),
+          addGroupChannelHandler: jest.fn(),
+          removeGroupChannelHandler: jest.fn(),
+        },
+      },
+    },
+  },
+};
+
+jest.mock('../../../../lib/Sendbird', () => ({
+  __esModule: true,
+  useSendbirdStateContext: () => mockSendbirdStateContext,
+}));
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => mockSendbirdStateContext,
+}));
+
+const mockProps: GroupChannelProviderProps = {
+  // from ContextBaseType
+  channelUrl: 'channel-1',
+  children: <div>Child Component</div>,
+
+  renderUserProfile: jest.fn(),
+  disableUserProfile: false,
+  // Flags
+  isReactionEnabled: true,
+  isMessageGroupingEnabled: true,
+  isMultipleFilesMessageEnabled: true,
+  showSearchIcon: true,
+  replyType: 'NONE',
+  threadReplySelectType: ThreadReplySelectType.THREAD,
+  disableMarkAsRead: false,
+  scrollBehavior: 'smooth',
+  forceLeftToRightMessageLayout: false,
+
+  startingPoint: 0,
+
+  // Message Focusing
+  animatedMessageId: null,
+  onMessageAnimated: jest.fn(),
+
+  // Custom
+  messageListQueryParams: {},
+  filterEmojiCategoryIds: jest.fn(),
+
+  // Handlers
+  onBeforeSendUserMessage: jest.fn(),
+  onBeforeSendFileMessage: jest.fn(),
+  onBeforeSendVoiceMessage: jest.fn(),
+  onBeforeSendMultipleFilesMessage: jest.fn(),
+  onBeforeUpdateUserMessage: jest.fn(),
+  onBeforeDownloadFileMessage: jest.fn(),
+
+  // Click
+  onBackClick: jest.fn(),
+  onChatHeaderActionClick: jest.fn(),
+  onReplyInThreadClick: jest.fn(),
+  onSearchClick: jest.fn(),
+  onQuoteMessageClick: jest.fn(),
+
+  // Render
+  renderUserMentionItem: jest.fn(),
+
+  // from UserProfileProviderProps
+  onUserProfileMessage: jest.fn(),
+  onStartDirectMessage: jest.fn(),
+};
+
+describe('GroupChannel Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('GroupChannelProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(
+        <GroupChannelProvider {...mockProps}>
+          {mockProps.children}
+        </GroupChannelProvider>,
+      );
+
+      // Props change scenario test
+      rerender(
+        <GroupChannelProvider
+          {...mockProps}
+          isReactionEnabled={false}
+          onBackClick={() => {}}
+        >
+          {mockProps.children}
+        </GroupChannelProvider>,
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useGroupChannelContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useGroupChannelContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      // from ContextBaseType
+      'channelUrl',
+      'renderUserProfile',
+      'disableUserProfile',
+      'isReactionEnabled',
+      'isMessageGroupingEnabled',
+      'isMultipleFilesMessageEnabled',
+      'showSearchIcon',
+      'replyType',
+      'threadReplySelectType',
+      'disableMarkAsRead',
+      'scrollBehavior',
+      'forceLeftToRightMessageLayout',
+      'startingPoint',
+      'animatedMessageId',
+      'onMessageAnimated',
+      'messageListQueryParams',
+      'filterEmojiCategoryIds',
+      'onBeforeSendUserMessage',
+      'onBeforeSendFileMessage',
+      'onBeforeSendVoiceMessage',
+      'onBeforeSendMultipleFilesMessage',
+      'onBeforeUpdateUserMessage',
+      'onBeforeDownloadFileMessage',
+      'onBackClick',
+      'onChatHeaderActionClick',
+      'onReplyInThreadClick',
+      'onSearchClick',
+      'onQuoteMessageClick',
+      'renderUserMentionItem',
+      // from MessageListDataSourceWithoutActions
+      'initialized',
+      'loading',
+      'refreshing',
+      'messages',
+      'newMessages',
+      'resetNewMessages',
+      'refresh',
+      'loadPrevious',
+      'hasPrevious',
+      'loadNext',
+      'hasNext',
+      'updateFileMessage',
+      'resendMessage',
+      'deleteMessage',
+      'resetWithStartingPoint',
+      // from useMessageActions
+      'sendUserMessage',
+      'sendFileMessage',
+      'sendVoiceMessage',
+      'sendMultipleFilesMessage',
+      'updateUserMessage',
+      // from GroupChannelContextType
+      'currentChannel',
+      'fetchChannelError',
+      'nicknamesMap',
+      'scrollRef',
+      'scrollDistanceFromBottomRef',
+      'scrollPositionRef',
+      'scrollPubSub',
+      'messageInputRef',
+      'quoteMessage',
+      'setQuoteMessage',
+      'setAnimatedMessageId',
+      'isScrollBottomReached',
+      'setIsScrollBottomReached',
+      'scrollToBottom',
+      'scrollToMessage',
+      'toggleReaction',
+    ];
+
+    const TestComponent = () => {
+      const context = useGroupChannelContext();
+      return (
+        <div>
+          {expectedProps.map(prop => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <GroupChannelProvider {...mockProps}>
+          <TestComponent />
+        </GroupChannelProvider>,
+      );
+
+      expectedProps.forEach(prop => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/modules/GroupChannelList/context/__tests__/GroupChannelList.migration.spec.tsx
+++ b/src/modules/GroupChannelList/context/__tests__/GroupChannelList.migration.spec.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { match } from 'ts-pattern';
+import {
+  GroupChannelListProvider,
+  GroupChannelListProviderProps,
+  useGroupChannelListContext,
+} from '../GroupChannelListProvider';
+
+const mockSendbirdStateContext = {
+  stores: {
+    userStore: {
+      user: {
+        userId: ' test-user-id',
+      },
+    },
+    sdkStore: {
+      sdk: {
+        currentUser: {
+          userId: 'test-user-id',
+        },
+      },
+      initialized: true,
+    },
+  },
+  config: {
+    logger: console,
+    userId: 'test-user-id',
+    groupChannel: {
+      enableMention: true,
+    },
+    groupChannelList: {
+      enableTypingIndicator: true,
+    },
+    isOnline: true,
+  },
+};
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => mockSendbirdStateContext,
+}));
+
+jest.mock('../../../../lib/Sendbird', () => ({
+  __esModule: true,
+  useSendbirdStateContext: () => mockSendbirdStateContext,
+}));
+
+jest.mock('@sendbird/uikit-tools', () => ({
+  ...jest.requireActual('@sendbird/uikit-tools'),
+  useGroupChannelList: () => ({
+    refreshing: false,
+    initialized: true,
+    groupChannels: [],
+    refresh: jest.fn(),
+    loadMore: jest.fn(),
+  }),
+}));
+
+const mockProps: GroupChannelListProviderProps = {
+  onChannelSelect: jest.fn(),
+  onChannelCreated: jest.fn(),
+
+  className: 'test-classname',
+  selectedChannelUrl: 'test-selected-channel-url',
+
+  allowProfileEdit: true,
+  disableAutoSelect: true,
+  isTypingIndicatorEnabled: true,
+  isMessageReceiptStatusEnabled: true,
+
+  channelListQueryParams: { limit: 30 },
+  onThemeChange: jest.fn(),
+  onCreateChannelClick: jest.fn(),
+  onBeforeCreateChannel: jest.fn(),
+  onUserProfileUpdated: jest.fn(),
+
+  onUserProfileMessage: jest.fn(),
+  onStartDirectMessage: jest.fn(),
+  renderUserProfile: jest.fn(),
+  disableUserProfile: true,
+  children: <div>test children</div>,
+};
+
+describe('GroupChannelList Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('GroupChannelListProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(
+        <GroupChannelListProvider {...mockProps}>
+          {mockProps.children}
+        </GroupChannelListProvider>,
+      );
+
+      // Props change scenario test
+      rerender(
+        <GroupChannelListProvider
+          {...mockProps}
+        >
+          {mockProps.children}
+        </GroupChannelListProvider>,
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useGroupChannelListContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useGroupChannelListContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      'onChannelSelect',
+      'onChannelCreated',
+      'className',
+      'selectedChannelUrl',
+      'allowProfileEdit',
+      'disableAutoSelect',
+      'isTypingIndicatorEnabled',
+      'isMessageReceiptStatusEnabled',
+      'channelListQueryParams',
+      'onThemeChange',
+      'onCreateChannelClick',
+      'onBeforeCreateChannel',
+      'onUserProfileUpdated',
+      'typingChannelUrls',
+      'refreshing',
+      'initialized',
+      'groupChannels',
+      'refresh',
+      'loadMore',
+    ];
+
+    const TestComponent = () => {
+      const context = useGroupChannelListContext();
+      return (
+        <div>
+          {expectedProps.map(prop => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {/* text can be function, object, string, or unknown */}
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <GroupChannelListProvider {...mockProps}>
+          <TestComponent />
+        </GroupChannelListProvider>,
+      );
+
+      expectedProps.forEach(prop => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/modules/MessageSearch/context/__tests__/MessageSearch.migration.spec.tsx
+++ b/src/modules/MessageSearch/context/__tests__/MessageSearch.migration.spec.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MessageSearchProvider, useMessageSearchContext } from '../MessageSearchProvider';
+import { match } from 'ts-pattern';
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+const mockProps = {
+  channelUrl: 'channel-1',
+  searchString: 'test',
+  messageSearchQuery: {},
+  onResultLoaded: jest.fn(),
+  onResultClick: jest.fn(),
+  children: <div>Child Component</div>,
+};
+
+describe('MessageSearch Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('MessageSearchProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(
+        <MessageSearchProvider {...mockProps}>
+          {mockProps.children}
+        </MessageSearchProvider>,
+      );
+
+      // Props change scenario test
+      rerender(
+        <MessageSearchProvider
+          {...mockProps}
+          searchString="updated"
+          onResultLoaded={() => {}}
+        >
+          {mockProps.children}
+        </MessageSearchProvider>,
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useMessageSearchContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useMessageSearchContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      'channelUrl',
+      'searchString',
+      'messageSearchQuery',
+      'onResultLoaded',
+      'onResultClick',
+      'children',
+      'requestString',
+      'retryCount',
+      'setRetryCount',
+      'selectedMessageId',
+      'setSelectedMessageId',
+      'messageSearchDispatcher',
+      'scrollRef',
+      'allMessages',
+      'loading',
+      'isInvalid',
+      'currentChannel',
+      'currentMessageSearchQuery',
+      'hasMoreResult',
+      'onScroll',
+      'handleRetryToConnect',
+      'handleOnScroll',
+    ];
+
+    const TestComponent = () => {
+      const context = useMessageSearchContext();
+      return (
+        <div>
+          {expectedProps.map(prop => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {/* text can be function, object, string, or unknown */}
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <MessageSearchProvider {...mockProps}>
+          <TestComponent />
+        </MessageSearchProvider>,
+      );
+
+      expectedProps.forEach(prop => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/modules/Thread/context/__test__/Thread.migration.spec.tsx
+++ b/src/modules/Thread/context/__test__/Thread.migration.spec.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from '@testing-library/react';
+import { match } from 'ts-pattern';
+import React from 'react';
+
+import { ThreadProvider, ThreadProviderProps, useThreadContext } from '../ThreadProvider';
+import { SendableMessageType } from '../../../../utils';
+
+const mockSendbirdStateContext = {
+  stores: {
+    userStore: {
+    },
+    sdkStore: {
+      sdk: {
+        currentUser: {
+          userId: 'test-user-id',
+        },
+      },
+      initialized: true,
+    },
+  },
+  config: {
+    logger: console,
+    userId: 'test-user-id',
+    groupChannel: {
+      enableMention: true,
+    },
+    groupChannelList: {
+      enableTypingIndicator: true,
+    },
+    isOnline: true,
+  },
+};
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => mockSendbirdStateContext,
+}));
+
+jest.mock('../../../../lib/Sendbird', () => ({
+  __esModule: true,
+  useSendbirdStateContext: () => mockSendbirdStateContext,
+}));
+
+jest.mock('../hooks/useThreadFetchers', () => ({
+  useThreadFetchers: jest.fn().mockReturnValue({
+    initialize: jest.fn(),
+    loadPrevious: jest.fn(),
+    loadNext: jest.fn(),
+  }),
+}));
+
+const mockProps: ThreadProviderProps = {
+  disableUserProfile: true,
+  renderUserProfile: jest.fn(),
+  children: <div>test children</div>,
+  channelUrl: 'test-channel-url',
+  message: { messageId: 42, message: 'test message' } as SendableMessageType,
+  onHeaderActionClick: jest.fn(),
+  onMoveToParentMessage: jest.fn(),
+  onBeforeSendUserMessage: jest.fn(),
+  onBeforeSendFileMessage: jest.fn(),
+  onBeforeSendVoiceMessage: jest.fn(),
+  onBeforeSendMultipleFilesMessage: jest.fn(),
+  onBeforeDownloadFileMessage: jest.fn(),
+  isMultipleFilesMessageEnabled: true,
+  filterEmojiCategoryIds: jest.fn(),
+};
+
+describe('CreateChannel Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('CreateChannelProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(
+        <ThreadProvider {...mockProps}>
+          {mockProps.children}
+        </ThreadProvider>,
+      );
+
+      // Props change scenario test
+      rerender(
+        <ThreadProvider
+          {...mockProps}
+        >
+          {mockProps.children}
+        </ThreadProvider>,
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useCreateChannelContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useThreadContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      'disableUserProfile',
+      'renderUserProfile',
+      'children',
+      'channelUrl',
+      'message',
+      'onHeaderActionClick',
+      'onMoveToParentMessage',
+      'onBeforeSendUserMessage',
+      'onBeforeSendFileMessage',
+      'onBeforeSendVoiceMessage',
+      'onBeforeSendMultipleFilesMessage',
+      'onBeforeDownloadFileMessage',
+      'isMultipleFilesMessageEnabled',
+      'filterEmojiCategoryIds',
+      'currentChannel',
+      'allThreadMessages',
+      'localThreadMessages',
+      'parentMessage',
+      'channelState',
+      'parentMessageState',
+      'threadListState',
+      'hasMorePrev',
+      'hasMoreNext',
+      'emojiContainer',
+      'isMuted',
+      'isChannelFrozen',
+      'currentUserId',
+      'typingMembers',
+      'fetchPrevThreads',
+      'fetchNextThreads',
+      'toggleReaction',
+      'sendMessage',
+      'sendFileMessage',
+      'sendVoiceMessage',
+      'sendMultipleFilesMessage',
+      'resendMessage',
+      'updateMessage',
+      'deleteMessage',
+      'nicknamesMap',
+    ];
+
+    const TestComponent = () => {
+      const context = useThreadContext();
+      return (
+        <div>
+          {expectedProps.map(prop => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {/* text can be function, object, string, or unknown */}
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <ThreadProvider {...mockProps}>
+          <TestComponent />
+        </ThreadProvider>,
+      );
+
+      expectedProps.forEach(prop => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Addresses 
- https://sendbird.atlassian.net/browse/CLNP-6019
- https://sendbird.atlassian.net/browse/CLNP-6023
- https://sendbird.atlassian.net/browse/CLNP-6024

to verify legacy Provider props compatibility  and test context hook return values.

This will help validate that the state management migration doesn't break existing implementations and maintains backward compatibility.