### PR TITLE
[CLNP-6022] fix scroll position issue when switching GroupChannel

### DIFF
--- a/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
+++ b/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
@@ -19,6 +19,7 @@ import useSendbird from '../../../../lib/Sendbird/context/hooks/useSendbird';
 import { GroupChannelContext } from '../GroupChannelProvider';
 import type { GroupChannelState, MessageActions } from '../types';
 import { useMessageActions } from './useMessageActions';
+import { delay } from '../../../../utils/utils';
 
 export interface GroupChannelActions extends MessageActions {
   // Channel actions
@@ -69,16 +70,16 @@ export const useGroupChannel = () => {
 
   const scrollToBottom = async (animated?: boolean) => {
     if (!state.scrollRef.current) return;
+    // wait a bit for scroll ref to be updated
+    await delay();
 
     flagActions.setAnimatedMessageId(null);
     flagActions.setIsScrollBottomReached(true);
 
     if (config.isOnline && state.hasNext()) {
       await state.resetWithStartingPoint(Number.MAX_SAFE_INTEGER);
-      state.scrollPubSub.publish('scrollToBottom', { animated });
-    } else {
-      state.scrollPubSub.publish('scrollToBottom', { animated });
     }
+    state.scrollPubSub.publish('scrollToBottom', { animated });
 
     if (state.currentChannel && !state.hasNext()) {
       state.resetNewMessages();

--- a/src/modules/Thread/context/__test__/useThread.spec.tsx
+++ b/src/modules/Thread/context/__test__/useThread.spec.tsx
@@ -753,7 +753,6 @@ describe('useThread', () => {
     });
 
     await waitFor(() => {
-      console.log(result.current.state.localThreadMessages[0]);
       expect(result.current.state.localThreadMessages[0].messageParams.fileInfoList).toContain(newFileInfo);
     });
   });

--- a/src/utils/__tests__/utils.spec.ts
+++ b/src/utils/__tests__/utils.spec.ts
@@ -6,7 +6,7 @@ import {
   isMultipleFilesMessage,
 } from '../index';
 import { AdminMessage, FileMessage, MultipleFilesMessage, UserMessage } from '@sendbird/chat/message';
-import { deleteNullish } from '../utils';
+import { delay, deleteNullish } from '../utils';
 import { isMobileIOS } from '../browser';
 
 describe('Global-utils: verify message type util functions', () => {
@@ -232,5 +232,42 @@ describe('deleteNullish', () => {
     expect(component({ a: null, b: undefined })).toEqual({ a: 1, b: '2', c: 3 });
     expect(component({ a: null, c: 4 })).toEqual({ a: 1, b: '2', c: 4 });
     expect(component({ a: null, b: '3', c: 4 })).toEqual({ a: 1, b: '3', c: 4 });
+  });
+});
+
+describe('delay', () => {
+  it('should resolve after the specified time', async () => {
+    const start = Date.now();
+    const delayTime = 100;
+
+    await delay(delayTime);
+
+    const end = Date.now();
+    const elapsed = end - start;
+
+    // Check if the elapsed time is at least the delay time
+    expect(elapsed).toBeGreaterThanOrEqual(delayTime);
+  });
+
+  it('should resolve immediately for 0 milliseconds', async () => {
+    const start = Date.now();
+
+    await delay(0);
+
+    const end = Date.now();
+    const elapsed = end - start;
+
+    // Check if the elapsed time is very small
+    expect(elapsed).toBeLessThan(10);
+  });
+  it('should resolve immediately when no parameter is provided', async () => {
+    const start = Date.now();
+
+    await delay();
+
+    const end = Date.now();
+    const elapsed = end - start;
+
+    expect(elapsed).toBeLessThan(10);
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,10 @@
 import { SendableMessageType } from './index';
 
+/**
+ * @param ms - milliseconds to delay
+ * @returns Promise that resolves after the specified time
+ */
+export const delay = (ms?: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
 export const noop = () => {
   /** noop * */
 };


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/CLNP-6022

This PR addresses an issue where the scroll position was not correctly set to the bottom when switching from a channel with few messages to one with many messages. 

The problem was resolved by adding a delay to ensure the scroll reference is updated before attempting to scroll to the bottom. This change ensures that users always see the latest messages when switching channels.

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)