### PR TITLE
fix: scroll to bottom when bubble TypingIndicator appears

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -19,7 +19,7 @@ import { GroupChannelUIBasicProps } from '../GroupChannelUI/GroupChannelUIView';
 import { deleteNullish } from '../../../../utils/utils';
 import { getMessagePartsInfo } from './getMessagePartsInfo';
 import { MessageProvider } from '../../../Message/context/MessageProvider';
-import { getComponentKeyFromMessage } from '../../context/utils';
+import { getComponentKeyFromMessage, isContextMenuClosed } from '../../context/utils';
 import { InfiniteList } from './InfiniteList';
 
 export interface GroupChannelMessageListProps {
@@ -225,12 +225,19 @@ export const MessageList = (props: GroupChannelMessageListProps) => {
 
 const TypingIndicatorBubbleWrapper = (props: { handleScroll: () => void; channelUrl: string }) => {
   const { stores } = useSendbirdStateContext();
+  const { isScrollBottomReached, scrollPubSub } = useGroupChannelContext();
   const [typingMembers, setTypingMembers] = useState<Member[]>([]);
 
   useGroupChannelHandler(stores.sdkStore.sdk, {
     onTypingStatusUpdated(channel) {
       if (channel.url === props.channelUrl) {
         setTypingMembers(channel.getTypingUsers());
+      }
+
+      if (isScrollBottomReached && isContextMenuClosed()) {
+        setTimeout(() => {
+          scrollPubSub.publish('scrollToBottom', {});
+        }, 10);
       }
     },
   });


### PR DESCRIPTION
[CLNP-6036](https://sendbird.atlassian.net/browse/CLNP-6036)

### Issue
* Bubble type typing indicator appears but scroll doesn't move to the bottom. So users can't see the appeared typing indicator.

### ChangeLog
* Fixed an issue where the typing indicator for bubble type messages appeared but was not visible because the scroll did not move to the bottom.

[CLNP-6036]: https://sendbird.atlassian.net/browse/CLNP-6036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ