### PR TITLE
release: v3.15.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - v3
 
+## [v3.15.11] (Dec 19 2024)
+
+- Fixed an issue where the bubble type typing indicator appeared but was not visible because the scroll did not move to the bottom.
+
 ## [v3.15.10] (Dec 12 2024)
 
 ### Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.15.10",
+  "version": "3.15.11",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.15.11] (Dec 19 2024)

- Fixed an issue where the bubble type typing indicator appeared but was not visible because the scroll did not move to the bottom.