### PR TITLE
fix: search messages with messageSearchQuery

### DIFF
--- a/src/modules/MessageSearch/context/MessageSearchProvider.tsx
+++ b/src/modules/MessageSearch/context/MessageSearchProvider.tsx
@@ -104,7 +104,7 @@ const MessageSearchProvider: React.FC<MessageSearchProviderProps> = (props: Mess
     { sdk, logger, messageSearchDispatcher },
   );
 
-  const requestString = useSearchStringEffect({ searchString: searchString ?? '' }, { messageSearchDispatcher });
+  const requestString = useSearchStringEffect({ searchString: searchString ?? messageSearchQuery.keyword }, { messageSearchDispatcher });
 
   useGetSearchMessages(
     { currentChannel, channelUrl, requestString, messageSearchQuery, onResultLoaded, retryCount },

--- a/src/modules/MessageSearch/context/__tests__/MessageSearchNew.migration.spec.tsx
+++ b/src/modules/MessageSearch/context/__tests__/MessageSearchNew.migration.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MessageSearchProvider, useMessageSearchContext } from '../MessageSearchProvider';
+import { match } from 'ts-pattern';
+
+jest.mock('../../../../hooks/useSendbirdStateContext', () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+const mockProps = {
+  channelUrl: 'channel-1',
+  searchString: '',
+  messageSearchQuery: {
+    keyword: 'test',
+  },
+  onResultLoaded: jest.fn(),
+  onResultClick: jest.fn(),
+  children: <div>Child Component</div>,
+};
+
+describe('MessageSearch Migration Compatibility Tests', () => {
+  // 1. Provider Props Interface test
+  describe('MessageSearchProvider Props Compatibility', () => {
+    it('should accept all legacy props without type errors', () => {
+      const { rerender } = render(<MessageSearchProvider {...mockProps}>{mockProps.children}</MessageSearchProvider>);
+
+      // Props change scenario test
+      rerender(
+        <MessageSearchProvider {...mockProps} searchString="updated" onResultLoaded={() => {}}>
+          {mockProps.children}
+        </MessageSearchProvider>
+      );
+    });
+  });
+
+  // 2. Context Hook return value test
+  describe('useMessageSearchContext Hook Return Values', () => {
+    type ContextType = ReturnType<typeof useMessageSearchContext>;
+    const expectedProps: Array<keyof ContextType> = [
+      'channelUrl',
+      'searchString',
+      'messageSearchQuery',
+      'onResultLoaded',
+      'onResultClick',
+      'children',
+      'requestString',
+      'retryCount',
+      'setRetryCount',
+      'selectedMessageId',
+      'setSelectedMessageId',
+      'messageSearchDispatcher',
+      'scrollRef',
+      'allMessages',
+      'loading',
+      'isInvalid',
+      'currentChannel',
+      'currentMessageSearchQuery',
+      'hasMoreResult',
+      'onScroll',
+      'handleRetryToConnect',
+      'handleOnScroll',
+    ];
+
+    const TestComponent = () => {
+      const context = useMessageSearchContext();
+      return (
+        <div>
+          {expectedProps.map((prop) => (
+            <div key={prop} data-testid={`prop-${prop}`}>
+              {/* text can be function, object, string, or unknown */}
+              {match(context[prop])
+                .with('function', () => 'function')
+                .with('object', () => JSON.stringify(context[prop]))
+                .with('string', () => String(context[prop]))
+                .otherwise(() => 'unknown')}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    it('should provide all legacy context values', () => {
+      render(
+        <MessageSearchProvider {...mockProps}>
+          <TestComponent />
+        </MessageSearchProvider>
+      );
+
+      expectedProps.forEach((prop) => {
+        const element = screen.getByTestId(`prop-${prop}`);
+        expect(element).toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The details of the pull request I am proposing involve using messageSearchParams to provide to the messageSearchProvider. Currently, there is no way to input a messageSearchQuery without a searchString.

+ I couldn't send the email. The email address(<developer-advocates@sendbird.com>) could not be found.


### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)
