### PR TITLE
[CLNP-6276] Formatted text paste bug-fix

### DIFF
--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify';
 import { insertTemplateToDOM } from './insertTemplate';
 import { sanitizeString } from '../../utils';
 import { DynamicProps } from './types';
-import { domToMessageTemplate, extractTextFromNodes, getLeafNodes, getUsersFromWords, hasMention } from './utils';
+import { domToMessageTemplate, getLeafNodes, getUsersFromWords, hasMention } from './utils';
 
 function pasteContentAtCaret(content: string) {
   const selection = window.getSelection(); // Get the current selection

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -60,8 +60,7 @@ export function usePaste({
 
     if (!hasMention(pasteNode)) {
       // No mention, paste as plain text
-      const extractedText = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
-      pasteContentAtCaret(sanitizeString(extractedText));
+      pasteContentAtCaret(sanitizeString(text));
       pasteNode.remove();
       setIsInput(true);
       return;


### PR DESCRIPTION
[fix]: Formatted text paste broken

When a formatted text is copied and pasted into the `MessageInput`, the sanitized text is pasted instead of the text

Fixes [CLNP-6276](https://sendbird.atlassian.net/browse/CLNP-6276)

### Changelogs

- Fixed a bug that a formatted text is broken when pasted into the `MessageInput`

```

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.


[CLNP-6276]: https://sendbird.atlassian.net/browse/CLNP-6276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ