### PR TITLE
Add the missing import paths of deprecated interfaces

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -12,9 +12,8 @@ export default {
   // SendbirdProvider
   SendbirdProvider: 'src/lib/Sendbird/index.tsx',
   sendbirdSelectors: 'src/lib/selectors.ts',
-  // TODO: Support below legacy exports
-  // useSendbirdStateContext: 'src/hooks/useSendbirdStateContext.tsx',
-  // withSendbird: 'src/lib/SendbirdSdkContext.tsx',
+  useSendbirdStateContext: 'src/lib/Sendbird/context/hooks/useSendbirdStateContext.tsx',
+  withSendbird: 'src/lib/Sendbird/withSendbird.tsx',
 
   // Voice message
   'VoiceRecorder/context': 'src/hooks/VoiceRecorder/index.tsx',

--- a/src/lib/Sendbird/index.tsx
+++ b/src/lib/Sendbird/index.tsx
@@ -75,7 +75,7 @@ const withSendbirdContext = (OriginalComponent: any, mapStoreToProps: (props: an
   return ContextAwareComponent;
 };
 /**
- * @deprecated This function is deprecated. Use `useSendbirdStateContext` instead.
+ * @deprecated This function is deprecated. Use `useSendbird` instead.
  * */
 export const withSendBird = withSendbirdContext;
 

--- a/src/lib/Sendbird/withSendbird.tsx
+++ b/src/lib/Sendbird/withSendbird.tsx
@@ -1,0 +1,10 @@
+/**
+ * This file is for the backward compatibility.
+ */
+
+import { withSendBird } from './index';
+
+/**
+ * @deprecated This function is deprecated. Use `useSendbird` instead.
+ * */
+export default withSendBird;


### PR DESCRIPTION
### Changelog
* Added the missing import paths for the deprecated interfaces; `useSendbirdStateContext` and `withSendbird`.