### PR TITLE
release: v3.15.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog - v3
 
+
 ## [v3.15.15] (Feb 14 2025)
 ### Fixes:
 - Added the missing import paths for the following deprecated interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - v3
 
+## [v3.15.15] (Feb 14 2025)
+### Fixes:
+- Added the missing import paths for the following deprecated interfaces.
+  - `useSendbirdStateContext`
+  - `withSendbird`
+- Fixed an issue where `VoiceMessageInput` failed to record the audio at first.
+
+### Chore
+- Updated `@sendbird/chat` version to 4.16.4
 
 ## [v3.15.14] (Feb 7 2025)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react",
-  "version": "3.15.14",
+  "version": "3.15.15",
   "description": "Sendbird UIKit for React: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",


### PR DESCRIPTION
## [v3.15.15] (Feb 14 2025)
### Fixes:
- Added the missing import paths for the following deprecated interfaces.
  - `useSendbirdStateContext`
  - `withSendbird`
- Fixed an issue where `VoiceMessageInput` failed to record the audio at first.

### Chore:
- Updated `@sendbird/chat` version to 4.16.4