### PR TITLE
[CLNP-6478] tel and mailto to markdown URL protocol

### DIFF
--- a/src/modules/Message/utils/tokens/__tests__/asSafeUrl.spec.ts
+++ b/src/modules/Message/utils/tokens/__tests__/asSafeUrl.spec.ts
@@ -4,10 +4,11 @@ describe('asSafeURL', () => {
   test('should return the same URL if it is already safe', () => {
     expect(asSafeURL('http://example.com')).toBe('http://example.com');
     expect(asSafeURL('https://example.com')).toBe('https://example.com');
+    expect(asSafeURL('mailto:email@gmail.com')).toBe('mailto:email@gmail.com');
+    expect(asSafeURL('tel:+14081234567')).toBe('tel:+14081234567');
   });
 
   test('should return a safe URL if it is not safe', () => {
-    expect(asSafeURL('mailto:email@gmail.com')).toBe('#');
     // eslint-disable-next-line no-script-url
     expect(asSafeURL('javascript:alert(1)')).toBe('#');
     expect(asSafeURL('javascript%3Aalert%281%29')).toBe('#');

--- a/src/modules/Message/utils/tokens/asSafeURL.ts
+++ b/src/modules/Message/utils/tokens/asSafeURL.ts
@@ -1,9 +1,11 @@
+
+const supportedProtocols = [ 'https:', 'http:', 'tel:', 'mailto:' ]
+
 export function asSafeURL(url: string) {
   let safeURL = decodeURIComponent(url);
-
   try {
     const { protocol } = new URL(safeURL);
-    if (['https:', 'http:'].some((it) => it === protocol.toLowerCase())) {
+    if (supportedProtocols.some((it) => it === protocol.toLowerCase())) {
       return safeURL;
     } else {
       return '#';
@@ -13,6 +15,5 @@ export function asSafeURL(url: string) {
       safeURL = 'https://' + safeURL;
     }
   }
-
   return safeURL;
 }

--- a/src/modules/Message/utils/tokens/asSafeURL.ts
+++ b/src/modules/Message/utils/tokens/asSafeURL.ts
@@ -1,5 +1,4 @@
-
-const supportedProtocols = [ 'https:', 'http:', 'tel:', 'mailto:' ]
+const supportedProtocols = ['https:', 'http:', 'tel:', 'mailto:'];
 
 export function asSafeURL(url: string) {
   let safeURL = decodeURIComponent(url);


### PR DESCRIPTION
Fixes [CLNP-6478](https://sendbird.atlassian.net/browse/CLNP-6478)

### Changelogs

- Added `tel` and `mailto` to supported markdown URL protocols

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

[CLNP-6478]: https://sendbird.atlassian.net/browse/CLNP-6478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ