### PR TITLE
[CLNP-6496] Support multiline ellipsis of quoted message

### DIFF
--- a/src/ui/QuoteMessage/index.scss
+++ b/src/ui/QuoteMessage/index.scss
@@ -83,6 +83,13 @@
         max-height: 30px;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        /* Below code is for multiline ellipsis.
+        * These properties are not compatible with some browsers, and will be ignored on the unsupported browser.
+        */
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
       }
     }
 


### PR DESCRIPTION
### Ticket
[CLNP-6496](https://sendbird.atlassian.net/browse/CLNP-6496)

### Changelog
* Support multiline ellipsis of quoted message.
  * Not all browser supports the added css properties. We try to show ellipsis, but if the environment doesn't support it, we maintain the previous behavior.
  * I expect those properties will be ignored on the unsupported browser. AFAIK, firefox is the only major browser doesn't support the properties.

### Screenshot
#### Before
![스크린샷 2025-04-08 오후 4 35 06](https://github.com/user-attachments/assets/2a41673f-5d60-4b04-8195-1e560f43211b)
#### After
![스크린샷 2025-04-08 오후 4 34 42](https://github.com/user-attachments/assets/184cd10b-5d53-42a3-9865-f8f442e55d42)

[CLNP-6496]: https://sendbird.atlassian.net/browse/CLNP-6496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ