### PR TITLE
[CLNP-6644] Thread messages are not loaded when the scroll at the top

### DIFF
--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -537,6 +537,9 @@ const useThread = () => {
     currentChannel,
     stores.sdkStore.initialized,
     parentMessage,
+    threadListState,
+    isReactionEnabled,
+    logger,
   ]);
 
   return { state, actions };


### PR DESCRIPTION
### Ticket
[CLNP-6644](https://sendbird.atlassian.net/browse/CLNP-6644)

### Changelog
* Fix the bug where thread messages are not loaded when the scroll at the top
  * dependency list has some missing elements.

[CLNP-6644]: https://sendbird.atlassian.net/browse/CLNP-6644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ