### PR TITLE
[SBISSUE-18879] `scrollToBottom` doesn't work when send a message in mobile.

### DIFF
--- a/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
+++ b/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
@@ -19,7 +19,6 @@ import useSendbird from '../../../../lib/Sendbird/context/hooks/useSendbird';
 import { GroupChannelContext } from '../GroupChannelProvider';
 import type { GroupChannelState, MessageActions } from '../types';
 import { useMessageActions } from './useMessageActions';
-import { delay } from '../../../../utils/utils';
 
 export interface GroupChannelActions extends MessageActions {
   // Channel actions
@@ -71,8 +70,6 @@ export const useGroupChannel = () => {
     setAnimatedMessageId(null);
     setIsScrollBottomReached(true);
 
-    // wait a bit for scroll ref to be updated
-    await delay();
     if (config.isOnline && state.hasNext()) {
       await state.resetWithStartingPoint(Number.MAX_SAFE_INTEGER);
     }

--- a/src/modules/GroupChannel/context/hooks/useMessageActions.ts
+++ b/src/modules/GroupChannel/context/hooks/useMessageActions.ts
@@ -102,7 +102,7 @@ export function useMessageActions(params: Params): MessageActions {
     () => {
       setTimeout(scrollToBottom, 0);
     },
-    [],
+    [scrollToBottom],
   );
 
   const processParams = useCallback(async <T extends keyof MessageParamsByType>(

--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -537,6 +537,9 @@ const useThread = () => {
     currentChannel,
     stores.sdkStore.initialized,
     parentMessage,
+    threadListState,
+    isReactionEnabled,
+    logger,
   ]);
 
   return { state, actions };


### PR DESCRIPTION
### Ticket
[SBISSUE-18879](https://sendbird.atlassian.net/browse/SBISSUE-18879)

### Changelog
* Fixed a bug where `scrollToBottom` doesn't work when send a message in mobile environment.

[SBISSUE-18879]: https://sendbird.atlassian.net/browse/SBISSUE-18879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ