### PR TITLE
[fix] Layout issues with long messages in Mobile layout only

### DIFF
--- a/src/ui/MessageContent/index.scss
+++ b/src/ui/MessageContent/index.scss
@@ -39,6 +39,7 @@
     display: inline-flex;
     min-width: 40px;
     position: relative;
+    flex-shrink: 0;
 
     .sendbird-message-content__left__avatar {
       bottom: 2px;


### PR DESCRIPTION
[fix]: Layout issues with long messages in Mobile layout only

Fixes [CLNP-6806](https://sendbird.atlassian.net/browse/CLNP-6806)

### Changelogs

- Added flex style option to `sendbird-message-content__left`

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


[CLNP-6806]: https://sendbird.atlassian.net/browse/CLNP-6806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ