### PR TITLE
[CLNP-6813] Set initial value for initialized and loading

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -39,6 +39,8 @@ const initialState = {
   fetchChannelError: null,
   nicknamesMap: new Map(),
 
+  initialized: false,
+  loading: true,
   messages: [],
   quoteMessage: null,
   animatedMessageId: null,


### PR DESCRIPTION
[fix]: Set initial value for initialized and loading

iFood 쪽에서 요구한 사항 중 저 플래그 state들의 기본값을 undefined가 아닌 값으로 바꿔달라는 요청이 있어서 작업했습니다.

Fixes [CLNP-6813](https://sendbird.atlassian.net/browse/CLNP-6813)

### Changelogs

- `GroupChannelProvider` has `loading` and `initialized` flag states as non-`undefined` value

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.


[CLNP-6813]: https://sendbird.atlassian.net/browse/CLNP-6813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ