### PR TITLE
[CLNP-7360]Multiple Chat Windows cause unexpected behavior

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -33,7 +33,7 @@ import useSendbird from '../../../lib/Sendbird/context/hooks/useSendbird';
 import useDeepCompareEffect from '../../../hooks/useDeepCompareEffect';
 import { deleteNullish } from '../../../utils/utils';
 
-const initialState = {
+const initialState = () => ({
   currentChannel: null,
   channelUrl: '',
   fetchChannelError: null,
@@ -60,12 +60,12 @@ const initialState = {
   disableMarkAsRead: false,
   scrollBehavior: 'auto',
   scrollPubSub: null,
-} as GroupChannelState;
+} as GroupChannelState);
 
 export const GroupChannelContext = createContext<ReturnType<typeof createStore<GroupChannelState>> | null>(null);
 
 const createGroupChannelStore = (props?: Partial<GroupChannelState>) => createStore({
-  ...initialState,
+  ...initialState(),
   ...props,
 });
 
@@ -378,7 +378,7 @@ const GroupChannelProvider: React.FC<GroupChannelProviderProps> = (props) => {
  * @returns {ReturnType<typeof createStore<GroupChannelState>>}
  */
 const useGroupChannelStore = () => {
-  return useStore(GroupChannelContext, state => state, initialState);
+  return useStore(GroupChannelContext, state => state, initialState());
 };
 
 // Keep this function for backward compatibility.

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -62,7 +62,7 @@ export const GroupChannelListContext = React.createContext<ReturnType<typeof cre
 export interface GroupChannelListState extends GroupChannelListContextType {
 }
 
-const initialState: GroupChannelListState = {
+const initialState = () => ({
   className: '',
   selectedChannelUrl: '',
   disableAutoSelect: false,
@@ -82,13 +82,13 @@ const initialState: GroupChannelListState = {
   refresh: null,
   loadMore: null,
   scrollRef: { current: null },
-};
+} as GroupChannelListState);
 
 /**
  * @returns {ReturnType<typeof createStore<GroupChannelListState>>}
  */
 export const useGroupChannelListStore = () => {
-  return useStore(GroupChannelListContext, state => state, initialState);
+  return useStore(GroupChannelListContext, state => state, initialState());
 };
 
 export const GroupChannelListManager: React.FC<GroupChannelListProviderProps> = ({
@@ -229,7 +229,7 @@ export const GroupChannelListManager: React.FC<GroupChannelListProviderProps> = 
 };
 
 const createGroupChannelListStore = (props?: Partial<GroupChannelListState>) => createStore({
-  ...initialState,
+  ...initialState(),
   ...props,
 });
 

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -59,7 +59,7 @@ export interface ThreadState extends ThreadProviderProps {
   nicknamesMap: Map<string, string>;
 }
 
-const initialState: ThreadState = {
+const initialState = () => ({
   channelUrl: '',
   message: null,
   onHeaderActionClick: undefined,
@@ -86,12 +86,12 @@ const initialState: ThreadState = {
   currentUserId: '',
   typingMembers: [],
   nicknamesMap: null,
-};
+} as ThreadState);
 
 export const ThreadContext = React.createContext<ReturnType<typeof createStore<ThreadState>> | null>(null);
 
 const createThreadStore = (props?: Partial<ThreadState>) => createStore({
-  ...initialState,
+  ...initialState(),
   ...props,
 });
 
@@ -248,5 +248,5 @@ export const useThreadContext = () => {
 };
 
 const useThreadStore = () => {
-  return useStore(ThreadContext, state => state, initialState);
+  return useStore(ThreadContext, state => state, initialState());
 };


### PR DESCRIPTION
[fix]: Multiple Chat Windows cause unexpected behavior

 PR description
- initialState안에 xxxRef들이  Object로 되어 있어서 여러 Provider 인스턴스가 생성될 때 동일한 객체 참조를 공유하는 문제가 있었습니다. 함수로 변경함으로써 각 Provider 인스턴스마다 새로운 초기 상태 객체를 생성하도록 하여 상태 격리 문제를 해결했습니다.

Fixes [CLNP-7360](https://sendbird.atlassian.net/browse/CLNP-7360)

### Changelogs
- Fixed a bug Where Multiple Chat Windows cause unexpected behavior

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.


[CLNP-7360]: https://sendbird.atlassian.net/browse/CLNP-7360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ