### PR TITLE
[CLNP-7430]Custom emoji category rendering issue

### DIFF
--- a/src/ui/ContextMenu/index.scss
+++ b/src/ui/ContextMenu/index.scss
@@ -57,7 +57,6 @@
   top: 100%;
   left: 0;
   min-width: 44px;
-  max-width: 352px;
   max-height: 208px;
   overflow-y: scroll;
   margin: 0px;

--- a/src/ui/MobileMenu/MobileBottomSheet.tsx
+++ b/src/ui/MobileMenu/MobileBottomSheet.tsx
@@ -212,7 +212,7 @@ const MobileBottomSheet: React.FunctionComponent<MobileBottomSheetProps> = (prop
                     {showMenuItemDeleteFinal && <DeleteMenuItem />}
                     {showMenuItemDownload && <DownloadMenuItem />}
                   </>
-              )}ß
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
[fix]: Custom emoji category rendering issue.

Emoji의 갯수가 8개가 넘어가는 경우, EmojiListItems에서 ul의 max-width가 고정이 되어 있어, padding 계산이 제대로 이루어 지지 않는 이슈 수정.

Fixes [CLNP-7430](https://sendbird.atlassian.net/browse/CLNP-7430)

### Changelogs
 - Fixed a bug in the Custom emoji category rendering issue

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.
