### PR TITLE
[CLNP-7450]Fixed a bug did not display read/deliver status icon in public groupChannel

### DIFF
--- a/src/modules/GroupChannel/context/hooks/useMessageActions.ts
+++ b/src/modules/GroupChannel/context/hooks/useMessageActions.ts
@@ -159,7 +159,7 @@ export function useMessageActions(params: Params): MessageActions {
         });
         return message;
       },
-      [buildInternalMessageParams, sendUserMessage, scrollToBottom, processParams],
+      [buildInternalMessageParams, sendUserMessage, scrollToBottom, processParams, currentChannel?.url],
     ),
     sendFileMessage: useCallback(
       async (params) => {
@@ -175,7 +175,7 @@ export function useMessageActions(params: Params): MessageActions {
 
         return message;
       },
-      [buildInternalMessageParams, sendFileMessage, scrollToBottom, processParams],
+      [buildInternalMessageParams, sendFileMessage, scrollToBottom, processParams, currentChannel?.url],
     ),
     sendMultipleFilesMessage: useCallback(
       async (params) => {
@@ -189,7 +189,7 @@ export function useMessageActions(params: Params): MessageActions {
         });
         return message;
       },
-      [buildInternalMessageParams, sendMultipleFilesMessage, scrollToBottom, processParams],
+      [buildInternalMessageParams, sendMultipleFilesMessage, scrollToBottom, processParams, currentChannel?.url],
     ),
     sendVoiceMessage: useCallback(
       async (params: FileMessageCreateParams, duration: number) => {
@@ -211,7 +211,7 @@ export function useMessageActions(params: Params): MessageActions {
         const processedParams = await processParams(onBeforeSendVoiceMessage, internalParams, 'voice');
         return sendFileMessage(processedParams, asyncScrollToBottom);
       },
-      [buildInternalMessageParams, sendFileMessage, scrollToBottom, processParams],
+      [buildInternalMessageParams, sendFileMessage, scrollToBottom, processParams, currentChannel?.url],
     ),
     updateUserMessage: useCallback(
       async (messageId: number, params: UserMessageUpdateParams) => {

--- a/src/ui/MessageStatus/index.tsx
+++ b/src/ui/MessageStatus/index.tsx
@@ -50,7 +50,7 @@ export default function MessageStatus({
   const { stringSet, dateLocale } = useLocalization();
   const status = getOutgoingMessageState(channel, message);
   const hideMessageStatusIcon = channel?.isGroupChannel?.() && (
-    (channel.isSuper || channel.isPublic || channel.isBroadcast)
+    (channel.isSuper || channel.isBroadcast)
     && !(status === OutgoingMessageStates.PENDING || status === OutgoingMessageStates.FAILED)
   );
 


### PR DESCRIPTION
/ PR title (Required)
[fix]: Fixed a bug that did not display the read/deliver status icon in the public groupChannel

// PR description (Optional)
- Message의 read/delivered status를 표시하는 조건이 public channel이 아닌 경우가 포함이 되어 있어서 이 부분 삭제를 했습니다.
iOS의 경우에는 해당 조건이 없습니다.


// Footer (Recommended)
Fixes [CLNP-7450](https://sendbird.atlassian.net/browse/CLNP-7450)

// Changelogs (Recommended)
// Add (internal) at the end of each changelog if internal.
### Changelogs
 - Fixed a bug that did not display the read/deliver status icon in the public groupChannel

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If unsure, ask the members.
This is a reminder of what we look for before merging your code.

- [ ] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can set up a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.
