### PR TITLE
fix RTL syntax

### DIFF
--- a/src/ui/Checkbox/index.scss
+++ b/src/ui/Checkbox/index.scss
@@ -79,4 +79,4 @@
     transform: rotate(45deg);
   }
 }
-/**rtl:end:ignore**/
+/*rtl:end:ignore*/


### PR DESCRIPTION
The current syntax is not correct, resulting in the string not being stripped after compilation. This may result in incorrect syntax on consumer apps.

From RTL's [docs](https://rtlcss.com/learn/usage-guide/control-directives/index.html), the expected control directive is `/*rtl:begin:ignore*/` instead of  `/**rtl:begin:ignore**/`