### PR TITLE
ci: fix docs repo name and add error handling

### DIFF
--- a/.github/workflows/notify-docs-update.yml
+++ b/.github/workflows/notify-docs-update.yml
@@ -31,7 +31,7 @@ on:
 env:
   # UPDATE THIS: Set to your SDK type (see options above)
   SDK_TYPE: uikit-react
-  DOCS_REPO: sendbird/sendbird-docs
+  DOCS_REPO: sendbird/SendBird-Docs
 
 jobs:
   notify-docs:
@@ -52,7 +52,7 @@ jobs:
           echo "  SDK Type: $SDK_TYPE"
 
           # Trigger repository_dispatch event on docs repo
-          curl -X POST \
+          HTTP_STATUS=$(curl -s -o /tmp/dispatch_response.txt -w "%{http_code}" -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -65,9 +65,15 @@ jobs:
                 \"sdk_type\": \"${{ env.SDK_TYPE }}\",
                 \"release_url\": \"$RELEASE_URL\"
               }
-            }"
+            }")
 
-          echo "Documentation update triggered successfully!"
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "Documentation update triggered successfully! (HTTP $HTTP_STATUS)"
+          else
+            echo "Failed to trigger documentation update (HTTP $HTTP_STATUS)"
+            cat /tmp/dispatch_response.txt
+            exit 1
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- Fix incorrect docs repository name (`sendbird/sendbird-docs` → `sendbird/SendBird-Docs`)
- Add HTTP status code error handling to the dispatch API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)