### PR TITLE
chore: migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -60,12 +60,14 @@ jobs:
           yarn install
           yarn build
       - name: Publish to npm
+        env:
+          NPM_TAG: ${{ github.event.inputs.npm_tag }}
         run: |
           cd ./dist
-          if [ -z "${{ github.event.inputs.npm_tag }}" ]; then
+          if [ -z "$NPM_TAG" ]; then
             npm publish --access=public --provenance
           else
-            npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public --provenance
+            npm publish --tag "$NPM_TAG" --access=public --provenance
             echo "npm_tag is provided; Skipping the rest of the steps."
             echo "SKIP_REST=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -29,8 +29,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 18
           cache: 'yarn'
+      - name: Update npm to latest
+        run: npm install -g npm@latest
       - name: Check if the release branch exists
         run: |
           set -x

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24
           cache: 'yarn'
       - name: Check if the release branch exists
         run: |
@@ -59,11 +62,10 @@ jobs:
       - name: Publish to npm
         run: |
           cd ./dist
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > .npmrc
           if [ -z "${{ github.event.inputs.npm_tag }}" ]; then
-            npm publish --access=public
+            npm publish --access=public --provenance
           else
-            npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public
+            npm publish --tag ${{ github.event.inputs.npm_tag }} --access=public --provenance
             echo "npm_tag is provided; Skipping the rest of the steps."
             echo "SKIP_REST=true" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
chore: migrate npm publish to OIDC trusted publishing

- Remove npm_token secret and .npmrc auth setup
- Add OIDC permissions (id-token: write) for trusted publishing
- Add `--provenance` flag for public repo attestation
- Bump Node.js from 18 to 24 (npm 11+ required for OIDC)

### Changelogs
- Build configuration change (internal)

### Checklist

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

npm package settings에서 GitHub Actions OIDC trusted publisher 연동 필요:
- Workflow: `package-publish.yml`