### PR TITLE
Merge docs-validation into release docs workflow

### DIFF
--- a/.github/workflows/notify-docs-update.yml
+++ b/.github/workflows/notify-docs-update.yml
@@ -1,39 +1,60 @@
-# Template: SDK Release Documentation Notification
+# SDK Release Documentation Pipeline
 #
-# Copy this workflow to your SDK repository and configure the SDK_TYPE variable.
-# When a release is published, it will notify the sendbird-docs repository to
-# generate documentation updates based on the release notes.
+# When a release is published, this workflow:
+# 1. Triggers docs validation (claude-docs-validation) on client-workflows
+# 2. Notifies sendbird-docs to generate documentation update PRs
 #
-# Required setup:
-# 1. Copy this file to your SDK repo: .github/workflows/notify-docs-update.yml
-# 2. Update the SDK_TYPE environment variable to match your SDK
-# 3. Create a GitHub Personal Access Token with 'repo' scope
-# 4. Add the token as a secret named DOCS_REPO_TOKEN in your SDK repo
+# Can also be triggered manually via workflow_dispatch for re-runs.
 #
-# SDK_TYPE options:
-#   - chat-sdk-javascript
-#   - chat-sdk-ios
-#   - chat-sdk-android
-#   - chat-sdk-flutter
-#   - chat-sdk-unity
-#   - uikit-react
-#   - uikit-react-native
-#   - uikit-ios
-#   - uikit-android
-#   - uikit-swiftui
+# Required secrets:
+#   DOCS_REPO_TOKEN       - GitHub token with repo access to sendbird-docs
+#   SDK_REPO_TOKEN        - GitHub token with repo access to client-workflows
 
-name: Notify Docs Repository on Release
+name: Release Docs Pipeline
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., v3.17.0)'
+        required: true
+        type: string
 
 env:
-  # UPDATE THIS: Set to your SDK type (see options above)
   SDK_TYPE: uikit-react
+  PLATFORM: react
   DOCS_REPO: sendbird/sendbird-docs
 
 jobs:
+  docs-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs validation
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SDK_REPO_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'sendbird',
+              repo: 'client-workflows',
+              workflow_id: 'claude-docs-validation.yml',
+              ref: 'main',
+              inputs: {
+                sdk_type: '${{ env.SDK_TYPE }}',
+                platform: '${{ env.PLATFORM }}',
+                release_tag: '${{ github.event.release.tag_name || inputs.release_tag }}',
+                source_repo: '${{ github.repository }}'
+              }
+            });
+      - name: Summary
+        run: |
+          echo "## Docs Validation Triggered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **SDK:** ${{ env.SDK_TYPE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release:** ${{ github.event.release.tag_name || inputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
+
   notify-docs:
     runs-on: ubuntu-latest
     steps:
@@ -41,9 +62,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
         run: |
-          # Extract repository info
           SDK_REPO="${{ github.repository }}"
-          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          RELEASE_TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
           RELEASE_URL="${{ github.event.release.html_url }}"
 
           echo "Triggering docs update for:"
@@ -51,7 +71,6 @@ jobs:
           echo "  Release Tag: $RELEASE_TAG"
           echo "  SDK Type: $SDK_TYPE"
 
-          # Trigger repository_dispatch event on docs repo
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
@@ -73,8 +92,6 @@ jobs:
         run: |
           echo "## Documentation Update Triggered" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "A documentation update request has been sent to the docs repository." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **SDK:** ${{ env.SDK_TYPE }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release:** ${{ github.event.release.tag_name || inputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Docs Repo:** ${{ env.DOCS_REPO }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- `notify-docs-update.yml`에 docs-validation job 통합, 별도 `release-docs-check.yml` 불필요
- `workflow_dispatch` 트리거 추가 (수동 재실행 지원)
- `pull_request: [closed]` / `issue_comment: [created]` 트리거 제거 → 불필요한 실패 Actions 기록 방지

## Changes
기존 두 워크플로우를 하나로 통합:

| Before | After |
|---|---|
| `notify-docs-update.yml` — sendbird-docs dispatch only | `notify-docs-update.yml` — docs-validation + sendbird-docs dispatch |
| `release-docs-check.yml` (PR #1411, 미머지) — docs-validation dispatch | 제거 (PR #1411 close 예정) |

## Triggers
- `release: [published]` — 릴리즈 게시 시 자동 실행
- `workflow_dispatch` — Actions 탭에서 수동 실행

## Test plan
- [ ] Release published 시 두 job 모두 트리거 확인
- [ ] workflow_dispatch로 수동 실행 확인
- [ ] PR close / issue_comment로는 트리거되지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)