### PR TITLE
[CLNP-6463][fix]: fix scroll pagination failing after offline or search query change 

### DIFF
--- a/src/modules/MessageSearch/context/__tests__/useScrollCallback.spec.ts
+++ b/src/modules/MessageSearch/context/__tests__/useScrollCallback.spec.ts
@@ -163,6 +163,7 @@ describe('useScrollCallback', () => {
       }
     });
 
+    // eslint-disable-next-line no-promise-executor-return
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(mockNext).toHaveBeenCalled();

--- a/src/modules/MessageSearch/context/__tests__/useScrollCallback.spec.ts
+++ b/src/modules/MessageSearch/context/__tests__/useScrollCallback.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import useScrollCallback from '../hooks/useScrollCallback';
 import useMessageSearch from '../hooks/useMessageSearch';
 
@@ -16,12 +16,17 @@ describe('useScrollCallback', () => {
   const mockOnResultLoaded = jest.fn();
   const mockGetNextSearchedMessages = jest.fn();
 
+  const originalNavigator = { ...navigator };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(global, 'navigator', {
+      value: { ...originalNavigator, onLine: true },
+      writable: true,
+    });
     (useMessageSearch as jest.Mock).mockReturnValue({
       state: {
         currentMessageSearchQuery: null,
-        hasMoreResult: false,
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -29,27 +34,33 @@ describe('useScrollCallback', () => {
     });
   });
 
-  it('should log warning when there are no more results', () => {
+  it('should log warning when offline', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { ...originalNavigator, onLine: false },
+      writable: true,
+    });
+
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: mockOnResultLoaded },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
     result.current(callback);
 
     expect(mockLogger.warning).toHaveBeenCalledWith(
-      'MessageSearch | useScrollCallback: no more searched results',
-      false,
+      'MessageSearch | useScrollCallback: offline, skip loading more results',
     );
   });
 
-  it('should log warning when there is no currentMessageSearchQuery', () => {
+  it('should log warning when query is already loading', () => {
     (useMessageSearch as jest.Mock).mockReturnValue({
       state: {
-        currentMessageSearchQuery: null,
-        hasMoreResult: true,
+        currentMessageSearchQuery: {
+          hasNext: true,
+          isLoading: true,
+          next: jest.fn(),
+        },
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -59,14 +70,27 @@ describe('useScrollCallback', () => {
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: mockOnResultLoaded },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
     result.current(callback);
 
     expect(mockLogger.warning).toHaveBeenCalledWith(
-      'MessageSearch | useScrollCallback: no currentMessageSearchQuery',
+      'MessageSearch | useScrollCallback: query already in progress',
+    );
+  });
+
+  it('should log warning when there is no currentMessageSearchQuery or no more results', () => {
+    const { result } = renderHook(() => useScrollCallback(
+      { onResultLoaded: mockOnResultLoaded },
+      { logger: mockLogger as any },
+    ));
+
+    const callback = jest.fn();
+    result.current(callback);
+
+    expect(mockLogger.warning).toHaveBeenCalledWith(
+      'MessageSearch | useScrollCallback: no currentMessageSearchQuery or no more results',
     );
   });
 
@@ -78,9 +102,9 @@ describe('useScrollCallback', () => {
       state: {
         currentMessageSearchQuery: {
           hasNext: true,
+          isLoading: false,
           next: mockNext,
         },
-        hasMoreResult: true,
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -90,11 +114,12 @@ describe('useScrollCallback', () => {
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: mockOnResultLoaded },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
-    await result.current(callback);
+    await act(async () => {
+      await result.current(callback);
+    });
 
     expect(mockNext).toHaveBeenCalled();
     expect(mockLogger.info).toHaveBeenCalledWith(
@@ -114,9 +139,9 @@ describe('useScrollCallback', () => {
       state: {
         currentMessageSearchQuery: {
           hasNext: true,
+          isLoading: false,
           next: mockNext,
         },
-        hasMoreResult: true,
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -126,18 +151,18 @@ describe('useScrollCallback', () => {
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: mockOnResultLoaded },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
 
-    try {
-      await result.current(callback);
-    } catch (error) {
-      // execute even if error occurs
-    }
+    await act(async () => {
+      try {
+        await result.current(callback);
+      } catch (error) {
+        // expected
+      }
+    });
 
-    // eslint-disable-next-line no-promise-executor-return
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(mockNext).toHaveBeenCalled();
@@ -157,9 +182,9 @@ describe('useScrollCallback', () => {
       state: {
         currentMessageSearchQuery: {
           hasNext: true,
+          isLoading: false,
           next: mockNext,
         },
-        hasMoreResult: true,
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -169,11 +194,12 @@ describe('useScrollCallback', () => {
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: undefined },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
-    await result.current(callback);
+    await act(async () => {
+      await result.current(callback);
+    });
 
     expect(mockNext).toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(mockMessages, null);
@@ -185,8 +211,8 @@ describe('useScrollCallback', () => {
       state: {
         currentMessageSearchQuery: {
           hasNext: false,
+          isLoading: false,
         },
-        hasMoreResult: true,
       },
       actions: {
         getNextSearchedMessages: mockGetNextSearchedMessages,
@@ -196,14 +222,59 @@ describe('useScrollCallback', () => {
     const { result } = renderHook(() => useScrollCallback(
       { onResultLoaded: mockOnResultLoaded },
       { logger: mockLogger as any },
-    ),
-    );
+    ));
 
     const callback = jest.fn();
     result.current(callback);
 
     expect(mockLogger.warning).toHaveBeenCalledWith(
-      'MessageSearch | useScrollCallback: no currentMessageSearchQuery',
+      'MessageSearch | useScrollCallback: no currentMessageSearchQuery or no more results',
     );
+  });
+
+  it('should use latest query via ref when callback is called', () => {
+    const mockNext1 = jest.fn();
+    const mockNext2 = jest.fn().mockResolvedValue([]);
+
+    // Initial render with query1
+    (useMessageSearch as jest.Mock).mockReturnValue({
+      state: {
+        currentMessageSearchQuery: {
+          hasNext: true,
+          isLoading: false,
+          next: mockNext1,
+        },
+      },
+      actions: {
+        getNextSearchedMessages: mockGetNextSearchedMessages,
+      },
+    });
+
+    const { result, rerender } = renderHook(() => useScrollCallback(
+      { onResultLoaded: mockOnResultLoaded },
+      { logger: mockLogger as any },
+    ));
+
+    // Update to query2
+    (useMessageSearch as jest.Mock).mockReturnValue({
+      state: {
+        currentMessageSearchQuery: {
+          hasNext: true,
+          isLoading: false,
+          next: mockNext2,
+        },
+      },
+      actions: {
+        getNextSearchedMessages: mockGetNextSearchedMessages,
+      },
+    });
+
+    rerender();
+
+    // Callback should use query2 (latest), not query1
+    result.current(jest.fn());
+
+    expect(mockNext1).not.toHaveBeenCalled();
+    expect(mockNext2).toHaveBeenCalled();
   });
 });

--- a/src/modules/MessageSearch/context/hooks/useScrollCallback.ts
+++ b/src/modules/MessageSearch/context/hooks/useScrollCallback.ts
@@ -32,6 +32,9 @@ function useScrollCallback(
   const queryRef = useRef(currentMessageSearchQuery);
   queryRef.current = currentMessageSearchQuery;
 
+  const onResultLoadedRef = useRef(onResultLoaded);
+  onResultLoadedRef.current = onResultLoaded;
+
   return useCallback((cb) => {
     const query = queryRef.current;
 
@@ -44,7 +47,7 @@ function useScrollCallback(
       logger.warning('MessageSearch | useScrollCallback: query already in progress');
       return;
     }
-    
+
     if (query && query.hasNext) {
       query
         .next()
@@ -52,15 +55,15 @@ function useScrollCallback(
           logger.info('MessageSearch | useScrollCallback: succeeded getting searched messages', messages);
           getNextSearchedMessages(messages as ClientSentMessages[]);
           cb(messages, null);
-          if (onResultLoaded && typeof onResultLoaded === 'function') {
-            onResultLoaded(messages as CoreMessageType[], null);
+          if (onResultLoadedRef.current && typeof onResultLoadedRef.current === 'function') {
+            onResultLoadedRef.current(messages as CoreMessageType[], null);
           }
         })
         .catch((error) => {
           logger.warning('MessageSearch | useScrollCallback: failed getting searched messages', error);
           cb(null, error);
-          if (onResultLoaded && typeof onResultLoaded === 'function') {
-            onResultLoaded(null, error);
+          if (onResultLoadedRef.current && typeof onResultLoadedRef.current === 'function') {
+            onResultLoadedRef.current(null, error);
           }
         });
     } else {

--- a/src/modules/MessageSearch/context/hooks/useScrollCallback.ts
+++ b/src/modules/MessageSearch/context/hooks/useScrollCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { SendbirdError } from '@sendbird/chat';
 import type { BaseMessage } from '@sendbird/chat/message';
 import { CoreMessageType } from '../../../../utils';
@@ -23,19 +23,30 @@ function useScrollCallback(
   const {
     state: {
       currentMessageSearchQuery,
-      hasMoreResult,
     },
     actions: {
       getNextSearchedMessages,
     },
   } = useMessageSearch();
 
+  const queryRef = useRef(currentMessageSearchQuery);
+  queryRef.current = currentMessageSearchQuery;
+
   return useCallback((cb) => {
-    if (!hasMoreResult) {
-      logger.warning('MessageSearch | useScrollCallback: no more searched results', hasMoreResult);
+    const query = queryRef.current;
+
+    if (!navigator.onLine) {
+      logger.warning('MessageSearch | useScrollCallback: offline, skip loading more results');
+      return;
     }
-    if (currentMessageSearchQuery && currentMessageSearchQuery.hasNext) {
-      currentMessageSearchQuery
+
+    if (query?.isLoading) {
+      logger.warning('MessageSearch | useScrollCallback: query already in progress');
+      return;
+    }
+    
+    if (query && query.hasNext) {
+      query
         .next()
         .then((messages) => {
           logger.info('MessageSearch | useScrollCallback: succeeded getting searched messages', messages);
@@ -53,9 +64,9 @@ function useScrollCallback(
           }
         });
     } else {
-      logger.warning('MessageSearch | useScrollCallback: no currentMessageSearchQuery');
+      logger.warning('MessageSearch | useScrollCallback: no currentMessageSearchQuery or no more results');
     }
-  }, [currentMessageSearchQuery, hasMoreResult]);
+  }, []);
 }
 
 export default useScrollCallback;


### PR DESCRIPTION
Fix MessageSearch scroll pagination that breaks after going offline or changing the search query.
                                                                                                 
**Root cause:**                                                                                                                                                                            
- `useScrollCallback` captured a stale `currentMessageSearchQuery` in its `useCallback` closure
- When the query object changed (after reconnect or new search), the callback still referenced the old query                                                                               
- `hasMoreResult` state could become stale, blocking further pagination                                                                                                                    
                                                                                                                                                                                           
**Changes (`useScrollCallback.ts`):**                                                                                                                                                      
- Use `useRef` to always access the latest `currentMessageSearchQuery` without re-creating the callback                                                                                    
- Add offline check (`navigator.onLine`) to skip loading when disconnected                                                                                                                 
- Add `isLoading` guard to prevent duplicate concurrent requests                                                                                                                           
- Remove dependency on `hasMoreResult` state; use `query.hasNext` directly from the live query object                                                                                      
- Stabilize `useCallback` with empty dependency array since all state is accessed via ref

**Test changes (useScrollCallback.spec.ts):**
- Updated existing test cases to match new warning messages and removed hasMoreResult references                                                                                           
- Added test: should log warning when offline (navigator.onLine = false)                                                                                                                   
- Added test: should log warning when query is already loading (isLoading: true)                                                                                                           
- Added test: should use latest query via ref when callback is called (verifies stale closure fix)                                                                                         
- Added isLoading field to all mock query objects                                                                                                                                          
- Wrapped async test operations in act() for React state update compatibility                                                                                                  
                                                                                                                                                                                           
Fixes [CLNP-6463](https://sendbird.atlassian.net/browse/CLNP-6463)                                                                                                                         
                                                                                                                                                                                           
### Changelogs                                                                                                                                                                             
- Fixed a bug where MessageSearch scroll pagination stopped working after going offline or changing the search query                                                                       
- Added offline detection to prevent unnecessary search requests when disconnected                                  
- Added loading guard to prevent duplicate concurrent pagination requests                                                                                                                  
                                                                         
### Checklist                                                                                                                                                                              
- [x] **All tests pass locally with my changes**          
- [ ] **I have added tests that prove my fix is effective or that my feature works**                                                                                                       
- [ ] **Public components / utils / props are appropriately exported**                                                                                                                     
- [ ] I have added necessary documentation (if appropriate)

[CLNP-6463]: https://sendbird.atlassian.net/browse/CLNP-6463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ