### PR TITLE
[CLNP-6499][fix]: improve wording for mention limit error message

### DIFF
--- a/src/ui/Label/stringSet.ts
+++ b/src/ui/Label/stringSet.ts
@@ -203,7 +203,7 @@ const stringSet = {
     THREAD__INPUT__REPLY_IN_THREAD: 'Reply in thread',
     // Feature - Mention
     MENTION_NAME__NO_NAME: '(No name)',
-    MENTION_COUNT__OVER_LIMIT: 'You can mention up to %d times at a time.',
+    MENTION_COUNT__OVER_LIMIT: 'You can have up to %d mentions per message.',
     UI__FILE_VIEWER__UNSUPPORT: 'Unsupported message',
     // Feature - Voice Message
     VOICE_RECORDING_PERMISSION_DENIED: `You cannot record the voice since


### PR DESCRIPTION
Fix inaccurate wording in the mention limit warning message.

**Problem:**
When a user reaches the mention limit (default 10) and types `@`, the warning message displayed was misleading:
- Before: "You can mention up to %d times at a time."

**Fix:**
Updated the message to accurately describe the constraint:
- After: "You can have up to %d mentions per message."

Fixes [CLNP-6499](https://sendbird.atlassian.net/browse/CLNP-6499)

### Changelogs
- Fixed inaccurate wording in mention limit warning message from "mention up to %d times at a time" to "have up to %d mentions per message"

### Checklist
- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

[CLNP-6499]: https://sendbird.atlassian.net/browse/CLNP-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ