### PR TITLE
[CLNP-6501][fix]: disable mentions and sanitize HTML in edit mode

### DIFF
--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -379,15 +379,15 @@ const MessageView = (props: MessageViewProps) => {
             disabled={editInputDisabled}
             ref={editMessageInputRef}
             mentionSelectedUser={selectedUser}
-            isMentionEnabled={false}
+            isMentionEnabled={groupChannel.enableMention}
             message={message}
             onStartTyping={() => {
               channel?.startTyping?.();
             }}
-            onUpdateMessage={({ messageId, message, mentionTemplate }) => {
+            onUpdateMessage={({ messageId, message: editedMessage, mentionTemplate, mentionedUserIds: currentMentionedUserIds }) => {
               updateUserMessage(messageId, {
-                message,
-                mentionedUsers,
+                message: editedMessage,
+                mentionedUserIds: currentMentionedUserIds ?? [],
                 mentionedMessageTemplate: mentionTemplate,
               });
               setShowEdit(false);

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -379,7 +379,7 @@ const MessageView = (props: MessageViewProps) => {
             disabled={editInputDisabled}
             ref={editMessageInputRef}
             mentionSelectedUser={selectedUser}
-            isMentionEnabled={groupChannel.enableMention}
+            isMentionEnabled={false}
             message={message}
             onStartTyping={() => {
               channel?.startTyping?.();

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -191,11 +191,11 @@ export default function ParentMessageInfo({
           onStartTyping={() => {
             currentChannel?.startTyping?.();
           }}
-          onUpdateMessage={({ messageId, message, mentionTemplate }) => {
+          onUpdateMessage={({ messageId, message: editedMessage, mentionTemplate, mentionedUserIds: currentMentionedUserIds }) => {
             updateMessage({
               messageId,
-              message,
-              mentionedUsers,
+              message: editedMessage,
+              mentionedUserIds: currentMentionedUserIds,
               mentionTemplate,
             });
             setShowEditInput(false);

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -172,11 +172,11 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
           onStartTyping={() => {
             currentChannel?.startTyping?.();
           }}
-          onUpdateMessage={({ messageId, message, mentionTemplate }) => {
+          onUpdateMessage={({ messageId, message: editedMessage, mentionTemplate, mentionedUserIds: currentMentionedUserIds }) => {
             updateMessage({
               messageId,
-              message,
-              mentionedUsers,
+              message: editedMessage,
+              mentionedUserIds: currentMentionedUserIds,
               mentionTemplate,
             });
             setShowEdit(false);

--- a/src/modules/Thread/context/hooks/useUpdateMessageCallback.ts
+++ b/src/modules/Thread/context/hooks/useUpdateMessageCallback.ts
@@ -23,6 +23,7 @@ type CallbackParams = {
   messageId: number;
   message: string;
   mentionedUsers?: User[];
+  mentionedUserIds?: string[];
   mentionTemplate?: string;
 };
 
@@ -40,13 +41,16 @@ export default function useUpdateMessageCallback({
       messageId,
       message,
       mentionedUsers,
+      mentionedUserIds,
       mentionTemplate,
     } = props;
 
     const createParamsDefault = () => {
       const params = {} as UserMessageUpdateParams;
       params.message = message;
-      if (isMentionEnabled && mentionedUsers && mentionedUsers?.length > 0) {
+      if (isMentionEnabled && mentionedUserIds) {
+        params.mentionedUserIds = mentionedUserIds;
+      } else if (isMentionEnabled && mentionedUsers) {
         params.mentionedUsers = mentionedUsers;
       }
       if (isMentionEnabled && mentionTemplate) {

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -380,7 +380,7 @@ describe('MessageInput error handling', () => {
   });
 });
 
-describe('MessageInput sendMessage sanitization (CLNP-6501)', () => {
+describe('MessageInput sendMessage (CLNP-6501)', () => {
   beforeEach(() => {
     const stateContextValue = {
       state: {
@@ -402,7 +402,10 @@ describe('MessageInput sendMessage sanitization (CLNP-6501)', () => {
     renderHook(() => useLocalization());
   });
 
-  it('should sanitize HTML angle brackets in message field on send', () => {
+  // Cross-platform consumers (iOS/Android/SDK) receive the raw `message` field, so we
+  // intentionally do NOT sanitize at send time. Display-side rendering escapes angle
+  // brackets via React JSX. These tests pin the raw passthrough behavior.
+  it('should keep message field raw on send (display layer escapes)', () => {
     const onSendMessage = jest.fn();
 
     render(<MessageInput onSendMessage={onSendMessage} />);
@@ -415,12 +418,12 @@ describe('MessageInput sendMessage sanitization (CLNP-6501)', () => {
 
     expect(onSendMessage).toHaveBeenCalledTimes(1);
     const params = onSendMessage.mock.calls[0][0];
-    expect(params.message).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
+    expect(params.message).toBe('Hi <b>bold</b>');
     // No mention -> mentionTemplate stays empty.
     expect(params.mentionTemplate).toBe('');
   });
 
-  it('should sanitize XSS payload on send', () => {
+  it('should keep XSS-like payload raw in message field on send (display layer escapes)', () => {
     const onSendMessage = jest.fn();
 
     render(<MessageInput onSendMessage={onSendMessage} />);
@@ -433,9 +436,7 @@ describe('MessageInput sendMessage sanitization (CLNP-6501)', () => {
 
     expect(onSendMessage).toHaveBeenCalledTimes(1);
     const params = onSendMessage.mock.calls[0][0];
-    expect(params.message).not.toContain('<');
-    expect(params.message).not.toContain('>');
-    expect(params.message).toBe('&#60;img src=x onerror=alert(1)&#62;');
+    expect(params.message).toBe('<img src=x onerror=alert(1)>');
   });
 });
 
@@ -466,7 +467,7 @@ describe('MessageInput editMessage sanitization (CLNP-6501)', () => {
     fireEvent.click(editButton);
   };
 
-  it('should sanitize HTML angle brackets in message field when editing without mentions', () => {
+  it('should keep message raw and sanitize mentionTemplate when editing without mentions', () => {
     const onUpdateMessage = jest.fn();
     const messageId = 123;
 
@@ -487,7 +488,9 @@ describe('MessageInput editMessage sanitization (CLNP-6501)', () => {
     expect(onUpdateMessage).toHaveBeenCalledTimes(1);
     const params = onUpdateMessage.mock.calls[0][0];
     expect(params.messageId).toBe(messageId);
-    expect(params.message).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
+    // message stays raw — display layer handles escaping.
+    expect(params.message).toBe('Hi <b>bold</b>');
+    // mentionTemplate is sanitized so mention-aware consumers cannot inject HTML.
     expect(params.mentionTemplate).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
     expect(params.mentionedUserIds).toEqual([]);
   });
@@ -515,8 +518,9 @@ describe('MessageInput editMessage sanitization (CLNP-6501)', () => {
 
     expect(onUpdateMessage).toHaveBeenCalledTimes(1);
     const params = onUpdateMessage.mock.calls[0][0];
-    expect(params.message).not.toContain('<');
-    expect(params.message).not.toContain('>');
+    // message stays raw — display layer handles escaping.
+    expect(params.message).toBe('Hi <img src=x onerror=alert(1)>');
+    // mentionTemplate is sanitized so mention-aware consumers cannot inject HTML.
     expect(params.mentionTemplate).not.toContain('<');
     expect(params.mentionTemplate).not.toContain('>');
     expect(params.mentionTemplate).toBe('Hi &#60;img src=x onerror=alert(1)&#62;');

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -372,11 +372,178 @@ describe('MessageInput error handling', () => {
     render(<MessageInput onFileUpload={onFileUpload} />);
 
     const fileInput = document.getElementsByClassName('sendbird-message-input--attach-input')[0];
-  
+
     fireEvent.change(fileInput, { currentTarget: { files: [file] } });
 
     expect(onFileUpload).toThrow(mockErrorMessage);
     expect(eventHandlers.message.onFileUploadFailed).toHaveBeenCalled();
+  });
+});
+
+describe('MessageInput sendMessage sanitization (CLNP-6501)', () => {
+  beforeEach(() => {
+    const stateContextValue = {
+      state: {
+        config: {
+          groupChannel: {
+            enableDocument: true,
+          },
+        },
+      },
+    };
+    const localeContextValue = {
+      stringSet: {},
+    };
+
+    useSendbird.mockReturnValue(stateContextValue);
+    useLocalization.mockReturnValue(localeContextValue);
+
+    renderHook(() => useSendbird());
+    renderHook(() => useLocalization());
+  });
+
+  it('should sanitize HTML angle brackets in message field on send', () => {
+    const onSendMessage = jest.fn();
+
+    render(<MessageInput onSendMessage={onSendMessage} />);
+
+    const input = screen.getByRole('textbox');
+    input.textContent = 'Hi <b>bold</b>';
+    fireEvent.input(input);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    const params = onSendMessage.mock.calls[0][0];
+    expect(params.message).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
+    // No mention -> mentionTemplate stays empty.
+    expect(params.mentionTemplate).toBe('');
+  });
+
+  it('should sanitize XSS payload on send', () => {
+    const onSendMessage = jest.fn();
+
+    render(<MessageInput onSendMessage={onSendMessage} />);
+
+    const input = screen.getByRole('textbox');
+    input.textContent = '<img src=x onerror=alert(1)>';
+    fireEvent.input(input);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    const params = onSendMessage.mock.calls[0][0];
+    expect(params.message).not.toContain('<');
+    expect(params.message).not.toContain('>');
+    expect(params.message).toBe('&#60;img src=x onerror=alert(1)&#62;');
+  });
+});
+
+describe('MessageInput editMessage sanitization (CLNP-6501)', () => {
+  beforeEach(() => {
+    const stateContextValue = {
+      state: {
+        config: {
+          groupChannel: {
+            enableDocument: true,
+          },
+        },
+      },
+    };
+    const localeContextValue = {
+      stringSet: {},
+    };
+
+    useSendbird.mockReturnValue(stateContextValue);
+    useLocalization.mockReturnValue(localeContextValue);
+
+    renderHook(() => useSendbird());
+    renderHook(() => useLocalization());
+  });
+
+  const clickSave = () => {
+    const editButton = document.getElementsByClassName('sendbird-message-input--edit-action__save')[0];
+    fireEvent.click(editButton);
+  };
+
+  it('should sanitize HTML angle brackets in message field when editing without mentions', () => {
+    const onUpdateMessage = jest.fn();
+    const messageId = 123;
+
+    render(
+      <MessageInput
+        isEdit
+        message={{ messageId }}
+        onUpdateMessage={onUpdateMessage}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.textContent = 'Hi <b>bold</b>';
+    fireEvent.input(input);
+
+    clickSave();
+
+    expect(onUpdateMessage).toHaveBeenCalledTimes(1);
+    const params = onUpdateMessage.mock.calls[0][0];
+    expect(params.messageId).toBe(messageId);
+    expect(params.message).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
+    expect(params.mentionTemplate).toBe('Hi &#60;b&#62;bold&#60;/b&#62;');
+    expect(params.mentionedUserIds).toEqual([]);
+  });
+
+  it('should sanitize XSS payload in mentionTemplate even when isMentionedMessage is false', () => {
+    // Reviewer-reported scenario: original message had a mention, user removes
+    // the mention leaving only a raw HTML payload.
+    const onUpdateMessage = jest.fn();
+    const messageId = 456;
+
+    render(
+      <MessageInput
+        isEdit
+        message={{ messageId }}
+        onUpdateMessage={onUpdateMessage}
+        isMentionEnabled
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.textContent = 'Hi <img src=x onerror=alert(1)>';
+    fireEvent.input(input);
+
+    clickSave();
+
+    expect(onUpdateMessage).toHaveBeenCalledTimes(1);
+    const params = onUpdateMessage.mock.calls[0][0];
+    expect(params.message).not.toContain('<');
+    expect(params.message).not.toContain('>');
+    expect(params.mentionTemplate).not.toContain('<');
+    expect(params.mentionTemplate).not.toContain('>');
+    expect(params.mentionTemplate).toBe('Hi &#60;img src=x onerror=alert(1)&#62;');
+    expect(params.mentionedUserIds).toEqual([]);
+  });
+
+  it('should return an empty mentionedUserIds array when isMentionEnabled is false', () => {
+    const onUpdateMessage = jest.fn();
+    const messageId = 789;
+
+    render(
+      <MessageInput
+        isEdit
+        message={{ messageId }}
+        onUpdateMessage={onUpdateMessage}
+        // isMentionEnabled is intentionally omitted (defaults to false)
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.textContent = 'plain text';
+    fireEvent.input(input);
+
+    clickSave();
+
+    expect(onUpdateMessage).toHaveBeenCalledTimes(1);
+    expect(onUpdateMessage.mock.calls[0][0].mentionedUserIds).toEqual([]);
   });
 });
 

--- a/src/ui/MessageInput/__tests__/utils.spec.ts
+++ b/src/ui/MessageInput/__tests__/utils.spec.ts
@@ -114,6 +114,45 @@ describe('Utils/extractTextAndMentions', () => {
       isMentionedMessage: false,
       mentionTemplate: 'HelloWorld',
       messageText: 'HelloWorld',
+      mentionedUserIds: [],
     });
+  });
+
+  it('should collect userid from mention spans into mentionedUserIds', () => {
+    const dom = new jsdom.JSDOM(
+      '<div id="root">Hi <span data-userid="user-1">@Alice</span> and <span data-userid="user-2">@Bob</span></div>',
+    );
+    const root = dom.window.document.getElementById('root');
+    if (!root) throw new Error('root element not found');
+
+    const result = extractTextAndMentions(root.childNodes);
+
+    expect(result.isMentionedMessage).toBe(true);
+    expect(result.mentionedUserIds).toEqual(['user-1', 'user-2']);
+  });
+
+  it('should not include userid for spans without data-userid', () => {
+    const dom = new jsdom.JSDOM('<div id="root">Hi <span>not a mention</span></div>');
+    const root = dom.window.document.getElementById('root');
+    if (!root) throw new Error('root element not found');
+
+    const result = extractTextAndMentions(root.childNodes);
+
+    expect(result.isMentionedMessage).toBe(false);
+    expect(result.mentionedUserIds).toEqual([]);
+  });
+
+  it('should leave HTML-tag-like text in messageText/mentionTemplate raw (sanitize happens at the caller)', () => {
+    // contentEditable can hold typed angle-bracket text as a plain text node.
+    const dom = new jsdom.JSDOM('<div id="root">Hi &lt;b&gt;bold&lt;/b&gt;</div>');
+    const root = dom.window.document.getElementById('root');
+    if (!root) throw new Error('root element not found');
+
+    const result = extractTextAndMentions(root.childNodes);
+
+    expect(result.messageText).toBe('Hi <b>bold</b>');
+    expect(result.mentionTemplate).toBe('Hi <b>bold</b>');
+    expect(result.isMentionedMessage).toBe(false);
+    expect(result.mentionedUserIds).toEqual([]);
   });
 });

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -365,8 +365,10 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       if (!isEdit && textField) {
         const { messageText, mentionTemplate, isMentionedMessage } = extractTextAndMentions(textField.childNodes);
         if (messageText.trim().length === 0) return;
-        const params = { message: messageText, mentionTemplate };
-        if (!isMentionedMessage) params.mentionTemplate = '';
+        const params = {
+          message: sanitizeString(messageText),
+          mentionTemplate: isMentionedMessage ? sanitizeString(mentionTemplate) : '',
+        };
         onSendMessage(params);
         resetInput(internalRef);
         /**
@@ -393,18 +395,13 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       const textField = internalRef?.current;
       const messageId = message?.messageId;
       if (isEdit && messageId && textField) {
-        const { messageText, mentionTemplate, isMentionedMessage } = extractTextAndMentions(textField.childNodes);
+        const { messageText, mentionTemplate, isMentionedMessage, mentionedUserIds } = extractTextAndMentions(textField.childNodes);
         if (messageText.trim().length === 0) return;
-        const currentMentionedUserIds = isMentionEnabled
-          ? Array.from(textField.getElementsByClassName('sendbird-mention-user-label'))
-            .map((node) => (node as HTMLElement).dataset?.userid)
-            .filter((id): id is string => Boolean(id))
-          : [];
         const params = {
           messageId,
-          message: messageText,
-          mentionTemplate: isMentionedMessage ? sanitizeString(mentionTemplate) : messageText,
-          mentionedUserIds: currentMentionedUserIds,
+          message: sanitizeString(messageText),
+          mentionTemplate: sanitizeString(isMentionedMessage ? mentionTemplate : messageText),
+          mentionedUserIds: isMentionEnabled ? mentionedUserIds : [],
         };
         onUpdateMessage(params);
         resetInput(internalRef);

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -366,7 +366,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         const { messageText, mentionTemplate, isMentionedMessage } = extractTextAndMentions(textField.childNodes);
         if (messageText.trim().length === 0) return;
         const params = {
-          message: sanitizeString(messageText),
+          message: messageText,
           mentionTemplate: isMentionedMessage ? sanitizeString(mentionTemplate) : '',
         };
         onSendMessage(params);
@@ -399,7 +399,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         if (messageText.trim().length === 0) return;
         const params = {
           messageId,
-          message: sanitizeString(messageText),
+          message: messageText,
           mentionTemplate: sanitizeString(isMentionedMessage ? mentionTemplate : messageText),
           mentionedUserIds: isMentionEnabled ? mentionedUserIds : [],
         };

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -395,7 +395,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       if (isEdit && messageId && textField) {
         const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
         if (messageText.trim().length === 0) return;
-        const params = { messageId, message: messageText, mentionTemplate };
+        const params = { messageId, message: messageText, mentionTemplate: sanitizeString(mentionTemplate) };
         onUpdateMessage(params);
         resetInput(internalRef);
       }

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -84,7 +84,7 @@ type MessageInputProps = {
   maxLength?: number;
   onFileUpload?: (file: File[]) => void;
   onSendMessage?: (params: { message: string; mentionTemplate: string }) => void;
-  onUpdateMessage?: (params: { messageId: number; message: string; mentionTemplate: string }) => void;
+  onUpdateMessage?: (params: { messageId: number; message: string; mentionTemplate: string; mentionedUserIds?: string[] }) => void;
   onCancelEdit?: () => void;
   onStartTyping?: () => void;
   channelUrl?: string;
@@ -393,9 +393,19 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       const textField = internalRef?.current;
       const messageId = message?.messageId;
       if (isEdit && messageId && textField) {
-        const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
+        const { messageText, mentionTemplate, isMentionedMessage } = extractTextAndMentions(textField.childNodes);
         if (messageText.trim().length === 0) return;
-        const params = { messageId, message: messageText, mentionTemplate: sanitizeString(mentionTemplate) };
+        const currentMentionedUserIds = isMentionEnabled
+          ? Array.from(textField.getElementsByClassName('sendbird-mention-user-label'))
+            .map((node) => (node as HTMLElement).dataset?.userid)
+            .filter((id): id is string => Boolean(id))
+          : [];
+        const params = {
+          messageId,
+          message: messageText,
+          mentionTemplate: isMentionedMessage ? sanitizeString(mentionTemplate) : messageText,
+          mentionedUserIds: currentMentionedUserIds,
+        };
         onUpdateMessage(params);
         resetInput(internalRef);
       }

--- a/src/ui/MessageInput/utils.ts
+++ b/src/ui/MessageInput/utils.ts
@@ -40,11 +40,15 @@ export function extractTextAndMentions(childNodes: NodeListOf<ChildNode>) {
   let messageText = '';
   let mentionTemplate = '';
   let isMentionedMessage = false;
+  const mentionedUserIds: string[] = [];
   childNodes.forEach((node) => {
     if (isHTMLElement(node) && node.nodeName === NodeNames.Span) {
       const { innerText, dataset = {} } = node;
       const { userid = '' } = dataset;
-      if (userid) isMentionedMessage = true;
+      if (userid) {
+        isMentionedMessage = true;
+        mentionedUserIds.push(userid);
+      }
       messageText += stripZeroWidthSpace(innerText);
       mentionTemplate += `${USER_MENTION_TEMP_CHAR}{${userid}}`;
     } else if (isHTMLElement(node) && node.nodeName === NodeNames.Br) {
@@ -60,5 +64,5 @@ export function extractTextAndMentions(childNodes: NodeListOf<ChildNode>) {
       mentionTemplate += textContent;
     }
   });
-  return { messageText, mentionTemplate, isMentionedMessage };
+  return { messageText, mentionTemplate, isMentionedMessage, mentionedUserIds };
 }


### PR DESCRIPTION
## Description

Fixes two issues in message edit mode:

1. **Mention suggestion list shown in edit mode** — The `SuggestedMentionListView` appeared when typing `@` in edit mode, even though mentions are not functional during editing. Fixed by setting `isMentionEnabled={false}` on `MessageInput` in edit mode, which disables mention detection and prevents the suggestion list from appearing.

2. **HTML tag injection via contentEditable** — The `mentionTemplate` passed to `onUpdateMessage` was not sanitized, allowing HTML tags to be included in the edited message. Fixed by applying `sanitizeString()` to `mentionTemplate` in the `editMessage` function.

## Root Cause

- `MessageInput` in edit mode had `isMentionEnabled={groupChannel.enableMention}`, enabling mention detection even though edit mode does not support adding new mentions.
- `editMessage` function passed raw `mentionTemplate` from `extractTextAndMentions()` without sanitization.

## Changes

| File | Change |
|------|--------|
| `src/modules/GroupChannel/components/Message/MessageView.tsx` | Set `isMentionEnabled={false}` for `MessageInput` in edit mode |
| `src/ui/MessageInput/index.tsx` | Apply `sanitizeString()` to `mentionTemplate` in `editMessage` |

## Ticket

- [CLNP-6501](https://sendbird.atlassian.net/browse/CLNP-6501)


[CLNP-6501]: https://sendbird.atlassian.net/browse/CLNP-6501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ