### PR TITLE
fix: restore Sendbird newInstance handling

### DIFF
--- a/src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx
+++ b/src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx
@@ -55,9 +55,69 @@ describe('SendbirdProvider', () => {
     expect(mockActions.connect).toHaveBeenCalledWith(
       expect.objectContaining({
         appId: 'mockAppId',
+        isNewApp: true,
         userId: 'mockUserId',
       }),
     );
+  });
+
+  it('should preserve the legacy isNewApp behavior across app and user changes', () => {
+    const { rerender } = render(
+      <SendbirdContextProvider appId="mockAppId" userId="mockUserId">
+        <div data-testid="child">Child Component</div>
+      </SendbirdContextProvider>,
+    );
+
+    expect(mockActions.connect).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      appId: 'mockAppId',
+      isNewApp: true,
+      userId: 'mockUserId',
+    }));
+
+    rerender(
+      <SendbirdContextProvider appId="mockAppId" userId="nextUserId">
+        <div data-testid="child">Child Component</div>
+      </SendbirdContextProvider>,
+    );
+
+    expect(mockActions.connect).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      appId: 'mockAppId',
+      isNewApp: false,
+      userId: 'nextUserId',
+    }));
+
+    rerender(
+      <SendbirdContextProvider appId="nextAppId" userId="nextUserId">
+        <div data-testid="child">Child Component</div>
+      </SendbirdContextProvider>,
+    );
+
+    expect(mockActions.connect).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      appId: 'nextAppId',
+      isNewApp: true,
+      userId: 'nextUserId',
+    }));
+  });
+
+  it('should reconnect on StrictMode remount with the same appId and userId', () => {
+    render(
+      <React.StrictMode>
+        <SendbirdContextProvider appId="mockAppId" userId="mockUserId">
+          <div data-testid="child">Child Component</div>
+        </SendbirdContextProvider>
+      </React.StrictMode>,
+    );
+
+    expect(mockActions.connect).toHaveBeenCalledTimes(2);
+    expect(mockActions.connect).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      appId: 'mockAppId',
+      isNewApp: true,
+      userId: 'mockUserId',
+    }));
+    expect(mockActions.connect).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      appId: 'mockAppId',
+      userId: 'mockUserId',
+    }));
   });
 
   it('should call disconnect on unmount', () => {

--- a/src/lib/Sendbird/__tests__/useSendbird.spec.tsx
+++ b/src/lib/Sendbird/__tests__/useSendbird.spec.tsx
@@ -362,10 +362,31 @@ describe('useSendbird', () => {
         appId: 'mockAppId',
         customApiHost: undefined,
         customWebSocketHost: undefined,
+        isNewApp: false,
         sdkInitParams: {},
       });
 
       expect(mockSetupSDK).toHaveBeenCalled();
+    });
+
+    it('should pass isNewApp through to initSDK during connect', async () => {
+      const { result } = renderHook(() => useSendbird(), { wrapper });
+      const mockInitSDK = jest.requireMock('../utils').initSDK;
+
+      await act(async () => {
+        await result.current.actions.connect({
+          logger: mockLogger,
+          userId: 'mockUserId',
+          appId: 'mockAppId',
+          accessToken: 'mockAccessToken',
+          isNewApp: true,
+        });
+      });
+
+      expect(mockInitSDK).toHaveBeenCalledWith(expect.objectContaining({
+        appId: 'mockAppId',
+        isNewApp: true,
+      }));
     });
 
     it('should handle connection failure and trigger onFailed event handler', async () => {

--- a/src/lib/Sendbird/__tests__/utils.spec.ts
+++ b/src/lib/Sendbird/__tests__/utils.spec.ts
@@ -109,6 +109,37 @@ describe('initSDK', () => {
       }),
     );
   });
+
+  it('uses isNewApp to set the newInstance init option', () => {
+    initSDK({
+      appId: 'testAppId',
+      isNewApp: true,
+    });
+
+    expect(SendbirdChat.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'testAppId',
+        newInstance: true,
+      }),
+    );
+  });
+
+  it('preserves an explicit sdkInitParams.newInstance override', () => {
+    initSDK({
+      appId: 'testAppId',
+      isNewApp: false,
+      sdkInitParams: {
+        newInstance: true,
+      },
+    });
+
+    expect(SendbirdChat.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'testAppId',
+        newInstance: true,
+      }),
+    );
+  });
 });
 
 const mockSdk = {

--- a/src/lib/Sendbird/context/SendbirdProvider.tsx
+++ b/src/lib/Sendbird/context/SendbirdProvider.tsx
@@ -100,12 +100,17 @@ const SendbirdContextManager = ({
     appInfoStore,
     actions,
   });
+  const previousAppIdRef = useRef('');
 
   // Reconnect when necessary
   useEffect(() => {
+    const isNewApp = previousAppIdRef.current !== appId;
+    previousAppIdRef.current = appId;
+
     actions.connect({
       appId,
       userId,
+      isNewApp,
       accessToken,
       isUserIdUsedForNickname,
       isMobile,

--- a/src/lib/Sendbird/context/hooks/useSendbird.tsx
+++ b/src/lib/Sendbird/context/hooks/useSendbird.tsx
@@ -178,6 +178,7 @@ export const useSendbird = () => {
       logger,
       userId,
       appId,
+      isNewApp = false,
       accessToken,
       nickname,
       profileUrl,
@@ -197,6 +198,7 @@ export const useSendbird = () => {
 
     const sdk = initSDK({
       appId,
+      isNewApp,
       customApiHost,
       customWebSocketHost,
       sdkInitParams,

--- a/src/lib/Sendbird/utils.ts
+++ b/src/lib/Sendbird/utils.ts
@@ -2,7 +2,7 @@ import SendbirdChat, { DeviceOsPlatform, SendbirdChatWith, SendbirdPlatform, Sen
 import { GroupChannelModule } from '@sendbird/chat/groupChannel';
 import { OpenChannelModule } from '@sendbird/chat/openChannel';
 
-import type { AppInfoStore, CustomExtensionParams, SdkStore, SendbirdState, UserStore } from './types';
+import type { AppInfoStore, CustomExtensionParams, SdkStore, SendbirdChatInitParams, SendbirdState, UserStore } from './types';
 import { LoggerInterface } from '../Logger';
 
 type UpdateAppInfoStoreType = (state: SendbirdState, payload: AppInfoStore) => SendbirdState;
@@ -47,21 +47,24 @@ export const updateUserStore: UpdateUserStoreType = (state, payload) => {
 
 export function initSDK({
   appId,
+  isNewApp = false,
   customApiHost,
   customWebSocketHost,
   sdkInitParams = {},
 }: {
   appId: string;
+  isNewApp?: boolean;
   customApiHost?: string;
   customWebSocketHost?: string;
-  sdkInitParams?: Record<string, any>;
+  sdkInitParams?: SendbirdChatInitParams;
 }) {
-  const params = Object.assign(sdkInitParams, {
+  const params = {
+    ...sdkInitParams,
     appId,
     modules: [new GroupChannelModule(), new OpenChannelModule()],
-    // newInstance: isNewApp,
+    newInstance: typeof sdkInitParams.newInstance !== 'undefined' ? sdkInitParams.newInstance : isNewApp,
     localCacheEnabled: typeof sdkInitParams.localCacheEnabled !== 'undefined' ? sdkInitParams.localCacheEnabled : true,
-  });
+  };
 
   if (customApiHost) params.customApiHost = customApiHost;
   if (customWebSocketHost) params.customWebSocketHost = customWebSocketHost;


### PR DESCRIPTION
## Summary
Restores the legacy `isNewApp -> newInstance` behavior in the migrated `SendbirdProvider` flow.

## Why
During the `SendbirdProvider` migration, the old `useConnect` logic that detected app changes and passed `isNewApp` into SDK initialization was removed. The migrated path left `newInstance` commented out in `initSDK`, which regressed the previous behavior.

## What changed
- Reintroduced legacy `appId` change tracking in `SendbirdContextManager`
- Propagated `isNewApp` through `actions.connect()` into `initSDK()`
- Restored `newInstance: isNewApp` in `SendbirdChat.init()`
- Added regression coverage for provider behavior, connect propagation, and SDK init params

## Validation
- `yarn test -- src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx src/lib/Sendbird/__tests__/useSendbird.spec.tsx src/lib/Sendbird/__tests__/utils.spec.ts --runInBand`
- `yarn eslint src/lib/Sendbird/context/SendbirdProvider.tsx src/lib/Sendbird/context/hooks/useSendbird.tsx src/lib/Sendbird/utils.ts src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx src/lib/Sendbird/__tests__/useSendbird.spec.tsx src/lib/Sendbird/__tests__/utils.spec.ts`

## Impact
This restores the pre-migration SDK initialization behavior when switching to a different `appId`, while keeping regression tests around the migrated provider path.