### PR TITLE
[CLNP-6505][CLNP-6889][fix]: prevent Thread state reset when another user leaves or is banned

### DIFF
--- a/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
+++ b/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
@@ -132,7 +132,7 @@ export const SuggestedMentionListView = (props: SuggestedMentionListViewProps) =
     lastSearchString,
   ]);
 
-  if (currentMemberList.length === 0) {
+  if (!ableAddMention && currentMemberList.length === 0) {
     return null;
   }
 

--- a/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
+++ b/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
@@ -121,6 +121,8 @@ export const SuggestedMentionListView = (props: SuggestedMentionListViewProps) =
   }, [
     currentChannel?.url,
     // We have to be specific like this or React would not recognize the changes in instances.
+    currentChannel?.members?.length,
+    currentChannel?.members.map((member: Member) => member.userId).join(),
     currentChannel?.members.map((member: Member) => member.nickname).join(),
     currentChannel?.members.map((member: Member) => member.isActive).join(),
     searchString,
@@ -130,7 +132,7 @@ export const SuggestedMentionListView = (props: SuggestedMentionListViewProps) =
     lastSearchString,
   ]);
 
-  if (!ableAddMention && currentMemberList.length === 0) {
+  if (currentMemberList.length === 0) {
     return null;
   }
 

--- a/src/modules/Thread/context/__test__/useHandleChannelEvents.spec.ts
+++ b/src/modules/Thread/context/__test__/useHandleChannelEvents.spec.ts
@@ -154,6 +154,20 @@ describe('useHandleChannelEvents', () => {
     );
   });
 
+  it('should pass channel and user to onUserLeft handler', () => {
+    const mockAddHandler = jest.fn();
+    const sdk = createMockSdk(mockAddHandler);
+    const channel = createMockChannel();
+    const leavingUser = { userId: 'leaving-user' } as User;
+
+    renderChannelEventsHook({ sdk, currentChannel: channel });
+
+    const handler = mockAddHandler.mock.calls[0][1];
+    handler.onUserLeft(channel, leavingUser);
+
+    expect(mockThreadActions.onUserLeft).toHaveBeenCalledWith(channel, leavingUser);
+  });
+
   it('should not add handler when sdk or currentChannel is missing', async () => {
     const mockAddHandler = jest.fn();
     const sdk = createMockSdk(mockAddHandler);

--- a/src/modules/Thread/context/__test__/useHandleChannelEvents.spec.ts
+++ b/src/modules/Thread/context/__test__/useHandleChannelEvents.spec.ts
@@ -154,6 +154,20 @@ describe('useHandleChannelEvents', () => {
     );
   });
 
+  it('should pass channel and user to onUserBanned handler', () => {
+    const mockAddHandler = jest.fn();
+    const sdk = createMockSdk(mockAddHandler);
+    const channel = createMockChannel();
+    const bannedUser = { userId: 'banned-user' } as User;
+
+    renderChannelEventsHook({ sdk, currentChannel: channel });
+
+    const handler = mockAddHandler.mock.calls[0][1];
+    handler.onUserBanned(channel, bannedUser);
+
+    expect(mockThreadActions.onUserBanned).toHaveBeenCalledWith(channel, bannedUser);
+  });
+
   it('should pass channel and user to onUserLeft handler', () => {
     const mockAddHandler = jest.fn();
     const sdk = createMockSdk(mockAddHandler);

--- a/src/modules/Thread/context/__test__/useThread.spec.tsx
+++ b/src/modules/Thread/context/__test__/useThread.spec.tsx
@@ -546,7 +546,7 @@ describe('useThread', () => {
     });
   });
 
-  it('handles onUserBanned action correctly', async () => {
+  it('handles onUserBanned action correctly when current user is banned', async () => {
     const wrapper = ({ children }) => (
       <ThreadProvider channelUrl="test-channel" message={mockParentMessage}>{children}</ThreadProvider>
     );
@@ -562,13 +562,38 @@ describe('useThread', () => {
     const { onUserBanned } = result.current.actions;
 
     await act(() => {
-      onUserBanned();
+      onUserBanned(mockChannel, { userId: 'test-user-id' });
     });
 
     await waitFor(() => {
       expect(result.current.state.channelState).toBe(ChannelStateTypes.NIL);
       expect(result.current.state.threadListState).toBe(ThreadListStateTypes.NIL);
       expect(result.current.state.parentMessageState).toBe(ParentMessageStateTypes.NIL);
+    });
+  });
+
+  it('handles onUserBanned action correctly when another user is banned', async () => {
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={mockParentMessage}>{children}</ThreadProvider>
+    );
+
+    let result;
+    await act(async () => {
+      result = renderHook(() => useThread(), { wrapper }).result;
+
+      waitFor(() => {
+        expect(result.current.state.currentChannel).not.toBe(undefined);
+      });
+    });
+    const { onUserBanned } = result.current.actions;
+
+    await act(() => {
+      onUserBanned(mockChannel, { userId: 'other-user-id' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.channelState).not.toBe(ChannelStateTypes.NIL);
+      expect(result.current.state.currentChannel).not.toBeNull();
     });
   });
 
@@ -592,7 +617,7 @@ describe('useThread', () => {
     });
   });
 
-  it('handles onUserLeft action correctly', async () => {
+  it('handles onUserLeft action correctly when current user has left', async () => {
     const wrapper = ({ children }) => (
       <ThreadProvider channelUrl="test-channel" message={mockParentMessage}>{children}</ThreadProvider>
     );
@@ -608,13 +633,38 @@ describe('useThread', () => {
     const { onUserLeft } = result.current.actions;
 
     await act(() => {
-      onUserLeft();
+      onUserLeft(mockChannel, { userId: 'test-user-id' });
     });
 
     await waitFor(() => {
       expect(result.current.state.channelState).toBe(ChannelStateTypes.NIL);
       expect(result.current.state.threadListState).toBe(ThreadListStateTypes.NIL);
       expect(result.current.state.parentMessageState).toBe(ParentMessageStateTypes.NIL);
+    });
+  });
+
+  it('handles onUserLeft action correctly when another user has left', async () => {
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={mockParentMessage}>{children}</ThreadProvider>
+    );
+
+    let result;
+    await act(async () => {
+      result = renderHook(() => useThread(), { wrapper }).result;
+
+      waitFor(() => {
+        expect(result.current.state.currentChannel).not.toBe(undefined);
+      });
+    });
+    const { onUserLeft } = result.current.actions;
+
+    await act(() => {
+      onUserLeft(mockChannel, { userId: 'other-user-id' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.channelState).not.toBe(ChannelStateTypes.NIL);
+      expect(result.current.state.currentChannel).not.toBeNull();
     });
   });
 

--- a/src/modules/Thread/context/__test__/useThread.spec.tsx
+++ b/src/modules/Thread/context/__test__/useThread.spec.tsx
@@ -587,13 +587,28 @@ describe('useThread', () => {
     });
     const { onUserBanned } = result.current.actions;
 
+    // Channel object reflecting the ban: 'other-user-id' is no longer a member.
+    const channelAfterBan = {
+      url: 'test-channel',
+      members: [{ userId: 'test-user-id', nickname: 'me' }],
+    };
+
     await act(() => {
-      onUserBanned(mockChannel, { userId: 'other-user-id' });
+      onUserBanned(channelAfterBan, { userId: 'other-user-id' });
     });
 
     await waitFor(() => {
+      // Thread state must not be reset when another user is banned.
       expect(result.current.state.channelState).not.toBe(ChannelStateTypes.NIL);
       expect(result.current.state.currentChannel).not.toBeNull();
+      // currentChannel must be updated so the membership change is reflected.
+      expect(result.current.state.currentChannel).toBe(channelAfterBan);
+      expect(
+        result.current.state.currentChannel.members.find((m: { userId: string }) => m.userId === 'other-user-id'),
+      ).toBeUndefined();
+      // nicknamesMap must be regenerated so downstream consumers (e.g. mention list) see the change.
+      expect(result.current.state.nicknamesMap.get('other-user-id')).toBeUndefined();
+      expect(result.current.state.nicknamesMap.get('test-user-id')).toBe('me');
     });
   });
 
@@ -658,13 +673,28 @@ describe('useThread', () => {
     });
     const { onUserLeft } = result.current.actions;
 
+    // Channel object reflecting the leave: 'other-user-id' is no longer a member.
+    const channelAfterLeave = {
+      url: 'test-channel',
+      members: [{ userId: 'test-user-id', nickname: 'me' }],
+    };
+
     await act(() => {
-      onUserLeft(mockChannel, { userId: 'other-user-id' });
+      onUserLeft(channelAfterLeave, { userId: 'other-user-id' });
     });
 
     await waitFor(() => {
+      // Thread state must not be reset when another user leaves.
       expect(result.current.state.channelState).not.toBe(ChannelStateTypes.NIL);
       expect(result.current.state.currentChannel).not.toBeNull();
+      // currentChannel must be updated so the membership change is reflected.
+      expect(result.current.state.currentChannel).toBe(channelAfterLeave);
+      expect(
+        result.current.state.currentChannel.members.find((m: { userId: string }) => m.userId === 'other-user-id'),
+      ).toBeUndefined();
+      // nicknamesMap must be regenerated so downstream consumers (e.g. mention list) see the change.
+      expect(result.current.state.nicknamesMap.get('other-user-id')).toBeUndefined();
+      expect(result.current.state.nicknamesMap.get('test-user-id')).toBe('me');
     });
   });
 

--- a/src/modules/Thread/context/hooks/useHandleChannelEvents.ts
+++ b/src/modules/Thread/context/hooks/useHandleChannelEvents.ts
@@ -73,7 +73,7 @@ export default function useHandleChannelEvents({
         },
         onUserBanned(channel, user) {
           logger.info('Thread | useHandleChannelEvents: onUserBanned', { channel, user });
-          onUserBanned();
+          onUserBanned(channel as GroupChannel, user);
         },
         onUserUnbanned(channel, user) {
           logger.info('Thread | useHandleChannelEvents: onUserUnbanned', { channel, user });

--- a/src/modules/Thread/context/hooks/useHandleChannelEvents.ts
+++ b/src/modules/Thread/context/hooks/useHandleChannelEvents.ts
@@ -81,7 +81,7 @@ export default function useHandleChannelEvents({
         },
         onUserLeft(channel, user) {
           logger.info('Thread | useHandleChannelEvents: onUserLeft', { channel, user });
-          onUserLeft();
+          onUserLeft(channel as GroupChannel, user);
         },
         // channel status change
         onChannelFrozen(channel) {

--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -5,7 +5,7 @@ import { ChannelStateTypes, FileUploadInfoParams, ParentMessageStateTypes, Threa
 import { GroupChannel, Member } from '@sendbird/chat/groupChannel';
 import { CoreMessageType, SendableMessageType } from '../../../utils';
 import { EmojiContainer, User } from '@sendbird/chat';
-import { compareIds } from './utils';
+import { compareIds, getNicknamesMapFromMembers } from './utils';
 import {
   BaseMessage,
   MultipleFilesMessage,
@@ -478,19 +478,33 @@ const useThread = () => {
       };
     }), [store]),
 
-    onUserLeft: useCallback(() => store.setState(state => {
-      return {
-        ...state,
-        channelState: ChannelStateTypes.NIL,
-        threadListState: ThreadListStateTypes.NIL,
-        parentMessageState: ParentMessageStateTypes.NIL,
-        currentChannel: null,
-        parentMessage: null,
-        allThreadMessages: [],
-        hasMorePrev: false,
-        hasMoreNext: false,
-      };
-    }), [store]),
+    onUserLeft: useCallback((channel: GroupChannel, user: User) => {
+      store.setState(state => {
+        if (state.currentChannel?.url !== channel?.url) {
+          return state;
+        }
+        // Only reset state when the current user has left
+        if (state.currentUserId === user?.userId) {
+          return {
+            ...state,
+            channelState: ChannelStateTypes.NIL,
+            threadListState: ThreadListStateTypes.NIL,
+            parentMessageState: ParentMessageStateTypes.NIL,
+            currentChannel: null,
+            parentMessage: null,
+            allThreadMessages: [],
+            hasMorePrev: false,
+            hasMoreNext: false,
+          };
+        }
+        // Another user left: update channel info and nicknames map
+        return {
+          ...state,
+          currentChannel: channel,
+          nicknamesMap: getNicknamesMapFromMembers(channel?.members),
+        };
+      });
+    }, [store]),
 
     onChannelFrozen: useCallback(() => store.setState(state => {
       return {

--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -458,19 +458,33 @@ const useThread = () => {
       };
     }), [store]),
 
-    onUserBanned: useCallback(() => store.setState(state => {
-      return {
-        ...state,
-        channelState: ChannelStateTypes.NIL,
-        threadListState: ThreadListStateTypes.NIL,
-        parentMessageState: ParentMessageStateTypes.NIL,
-        currentChannel: null,
-        parentMessage: null,
-        allThreadMessages: [],
-        hasMorePrev: false,
-        hasMoreNext: false,
-      };
-    }), [store]),
+    onUserBanned: useCallback((channel: GroupChannel, user: User) => {
+      store.setState(state => {
+        if (state.currentChannel?.url !== channel?.url) {
+          return state;
+        }
+        // Only reset state when the current user is banned
+        if (state.currentUserId === user?.userId) {
+          return {
+            ...state,
+            channelState: ChannelStateTypes.NIL,
+            threadListState: ThreadListStateTypes.NIL,
+            parentMessageState: ParentMessageStateTypes.NIL,
+            currentChannel: null,
+            parentMessage: null,
+            allThreadMessages: [],
+            hasMorePrev: false,
+            hasMoreNext: false,
+          };
+        }
+        // Another user banned: update channel info and nicknames map
+        return {
+          ...state,
+          currentChannel: channel,
+          nicknamesMap: getNicknamesMapFromMembers(channel?.members),
+        };
+      });
+    }, [store]),
 
     onUserUnbanned: useCallback(() => store.setState(state => {
       return {


### PR DESCRIPTION
## Description

The `onUserLeft` and `onUserBanned` handlers in the Thread module were unconditionally resetting the entire Thread state (clearing `currentChannel`, `parentMessage`, `allThreadMessages`) regardless of which user triggered the event. This caused:

- **CLNP-6889**: Thread screen goes blank and input is disabled when another user leaves the channel while the mention list is open
- **CLNP-6505**: Cannot send a mention message in Thread after the mentioned user leaves or is banned from the channel

### Root cause

1. `useHandleChannelEvents.ts` called `onUserLeft()` / `onUserBanned()` without passing `channel` or `user` parameters
2. `useThread.ts` actions reset the entire Thread state without checking which user left/was banned
3. The store's `isEqual`-based change detection (in `storeManager.ts`) silently dropped updates when the same channel reference was passed, preventing the mention suggestion list from refreshing

### Changes

**`useThread.ts`** — `onUserBanned` / `onUserLeft` actions:
- Accept `channel` and `user` parameters
- Only reset Thread state when the **current user** leaves/is banned
- When **another user** leaves/is banned, update `currentChannel` and regenerate `nicknamesMap` to ensure the store detects the change

**`useHandleChannelEvents.ts`**:
- Pass `channel` and `user` to `onUserBanned()` / `onUserLeft()` calls

**`SuggestedMentionListView.tsx`**:
- Add `members.length` and `members.userId` to useEffect dependencies for better membership change detection
- Return `null` when `currentMemberList` is empty (previously only checked when `!ableAddMention`)

**`useHandleChannelEvents.spec.ts`**:
- Add tests verifying `channel` and `user` are passed to `onUserBanned` and `onUserLeft` handlers