### PR TITLE
[CLNP-7018][fix]: reset voice player playback position on channel change

### DIFF
--- a/src/hooks/VoicePlayer/index.tsx
+++ b/src/hooks/VoicePlayer/index.tsx
@@ -36,6 +36,7 @@ export interface VoicePlayerContext {
   play: (props: VoicePlayerPlayProps) => void;
   pause: (groupKey?: string) => void;
   stop: (text?: string) => void;
+  reset: (groupKey: string) => void;
   voicePlayerStore: VoicePlayerInitialState;
 }
 
@@ -52,6 +53,7 @@ const Context = createContext<VoicePlayerContext>({
   play: noop,
   pause: noop,
   stop: noop,
+  reset: noop,
   voicePlayerStore: VoicePlayerStoreDefaultValue,
 });
 
@@ -73,6 +75,16 @@ export const VoicePlayerProvider = ({
       logger.info('VoicePlayer: Pause playing(by text).');
       pause(currentGroupKey);
     }
+  };
+
+  const reset = (groupKey: string) => {
+    if (groupKey === currentGroupKey && currentPlayer) {
+      currentPlayer.pause();
+    }
+    voicePlayerDispatcher({
+      type: RESET_AUDIO_UNIT,
+      payload: { groupKey },
+    });
   };
 
   const pause = (groupKey?: string) => {
@@ -210,6 +222,7 @@ export const VoicePlayerProvider = ({
       play,
       pause,
       stop,
+      reset,
       voicePlayerStore,
     }}>
       {/**

--- a/src/hooks/VoicePlayer/useVoicePlayer.tsx
+++ b/src/hooks/VoicePlayer/useVoicePlayer.tsx
@@ -35,6 +35,7 @@ export const useVoicePlayer = ({
     play,
     pause,
     stop,
+    reset,
     voicePlayerStore,
   } = useVoicePlayerContext();
   const { isRecordable } = useVoiceRecorderContext();
@@ -62,9 +63,10 @@ export const useVoicePlayer = ({
   useEffect(() => {
     return () => {
       if (audioFile || audioFileUrl) {
-        // Can't get the current AudioPlayer through the React hooks(useReducer or useState) in this scope
+        // Pause via DOM because reset() captured in this closure has stale currentPlayer
         const voiceAudioPlayerElement = document.getElementById(VOICE_PLAYER_AUDIO_ID);
         (voiceAudioPlayerElement as HTMLAudioElement)?.pause?.();
+        reset?.(groupKey);
       }
     };
   }, []);

--- a/src/hooks/VoicePlayer/useVoicePlayer.tsx
+++ b/src/hooks/VoicePlayer/useVoicePlayer.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useVoicePlayerContext } from '.';
 import { VOICE_PLAYER_AUDIO_ID, VOICE_MESSAGE_MIME_TYPE } from '../../utils/consts';
 import { useVoiceRecorderContext } from '../VoiceRecorder';
 
-import { AudioUnitDefaultValue, VoicePlayerStatusType } from './dux/initialState';
+import { AudioUnitDefaultValue, VOICE_PLAYER_STATUS, VoicePlayerStatusType } from './dux/initialState';
 import { generateGroupKey } from './utils';
 
 export interface UseVoicePlayerProps {
@@ -40,6 +40,8 @@ export const useVoicePlayer = ({
   } = useVoicePlayerContext();
   const { isRecordable } = useVoiceRecorderContext();
   const currentAudioUnit = voicePlayerStore?.audioStorage?.[groupKey] || AudioUnitDefaultValue();
+  const currentAudioUnitRef = useRef(currentAudioUnit);
+  currentAudioUnitRef.current = currentAudioUnit;
 
   const playVoicePlayer = () => {
     if (!isRecordable) {
@@ -66,7 +68,10 @@ export const useVoicePlayer = ({
         // Pause via DOM because reset() captured in this closure has stale currentPlayer
         const voiceAudioPlayerElement = document.getElementById(VOICE_PLAYER_AUDIO_ID);
         (voiceAudioPlayerElement as HTMLAudioElement)?.pause?.();
-        reset?.(groupKey);
+        const status = currentAudioUnitRef.current?.playingStatus;
+        if (status && status !== VOICE_PLAYER_STATUS.IDLE) {
+          reset?.(groupKey);
+        }
       }
     };
   }, []);


### PR DESCRIPTION
## Description

When switching channels during voice message playback, the audio was paused but the playback position (`playbackTime`) was not reset to zero. Returning to the original channel showed the playback bar stuck at the mid-position.

### Root cause

`useVoicePlayer`'s cleanup effect only called `HTMLAudioElement.pause()` via DOM access. This stopped the audio but did not reset the reducer state — `playbackTime` remained at the last position because the `ON_VOICE_PLAYER_PAUSE` reducer only resets `playbackTime` when `duration === currentTime` (i.e., playback completed naturally).

### Changes

**`VoicePlayerProvider` (`index.tsx`)**:
- Add `reset(groupKey)` function that pauses the current player (if matching) and dispatches `RESET_AUDIO_UNIT` to reset `playbackTime` to 0 and status to IDLE

**`useVoicePlayer.tsx`**:
- Call `reset(groupKey)` in the cleanup effect alongside the existing DOM `pause()` to ensure both the audio element stops and the reducer state is fully reset
- DOM `pause()` is kept because the `reset` function captured in the `[]` deps closure has a stale `currentPlayer` reference