### PR TITLE
[CLNP-7811][fix]: send endTyping on empty input, channel change, and unmount

### DIFF
--- a/src/hooks/__tests__/useTypingLifecycle.spec.tsx
+++ b/src/hooks/__tests__/useTypingLifecycle.spec.tsx
@@ -112,4 +112,66 @@ describe('useTypingLifecycle', () => {
       unmount();
     }).not.toThrow();
   });
+
+  describe('same-URL channel re-instantiation', () => {
+    it('cleans up on the latest instance when typing starts after re-instantiation', () => {
+      const original = makeChannel('a');
+      const refreshed = makeChannel('a');
+
+      const { result, rerender, unmount } = renderHook(
+        ({ channel }) => useTypingLifecycle(channel),
+        { initialProps: { channel: original } },
+      );
+
+      rerender({ channel: refreshed });
+      act(() => result.current.startTyping());
+
+      expect(refreshed.startTyping).toHaveBeenCalledTimes(1);
+      expect(original.startTyping).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(refreshed.endTyping).toHaveBeenCalledTimes(1);
+      expect(original.endTyping).not.toHaveBeenCalled();
+    });
+
+    it('cleans up on the original instance if typing started before re-instantiation', () => {
+      const original = makeChannel('a');
+      const refreshed = makeChannel('a');
+
+      const { result, rerender, unmount } = renderHook(
+        ({ channel }) => useTypingLifecycle(channel),
+        { initialProps: { channel: original } },
+      );
+
+      act(() => result.current.startTyping());
+      rerender({ channel: refreshed });
+      unmount();
+
+      expect(original.endTyping).toHaveBeenCalledTimes(1);
+      expect(refreshed.endTyping).not.toHaveBeenCalled();
+    });
+
+    it('uses the latest instance for endTyping when typing is restarted after re-instantiation', () => {
+      const original = makeChannel('a');
+      const refreshed = makeChannel('a');
+
+      const { result, rerender, unmount } = renderHook(
+        ({ channel }) => useTypingLifecycle(channel),
+        { initialProps: { channel: original } },
+      );
+
+      act(() => result.current.startTyping());
+      rerender({ channel: refreshed });
+      act(() => result.current.startTyping());
+      unmount();
+
+      expect(original.startTyping).toHaveBeenCalledTimes(1);
+      expect(refreshed.startTyping).toHaveBeenCalledTimes(1);
+      // endTyping should hit only the refreshed instance (the most recent
+      // startTyping target), not the original.
+      expect(original.endTyping).not.toHaveBeenCalled();
+      expect(refreshed.endTyping).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/hooks/__tests__/useTypingLifecycle.spec.tsx
+++ b/src/hooks/__tests__/useTypingLifecycle.spec.tsx
@@ -1,0 +1,115 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTypingLifecycle } from '../useTypingLifecycle';
+
+const makeChannel = (url = 'channel-a') => ({
+  url,
+  startTyping: jest.fn(),
+  endTyping: jest.fn(),
+});
+
+describe('useTypingLifecycle', () => {
+  it('startTyping calls channel.startTyping', () => {
+    const channel = makeChannel();
+    const { result } = renderHook(() => useTypingLifecycle(channel));
+
+    act(() => result.current.startTyping());
+
+    expect(channel.startTyping).toHaveBeenCalledTimes(1);
+    expect(channel.endTyping).not.toHaveBeenCalled();
+  });
+
+  it('stopTyping calls channel.endTyping', () => {
+    const channel = makeChannel();
+    const { result } = renderHook(() => useTypingLifecycle(channel));
+
+    act(() => result.current.startTyping());
+    act(() => result.current.stopTyping());
+
+    expect(channel.endTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls endTyping on unmount when typing was active', () => {
+    const channel = makeChannel();
+    const { result, unmount } = renderHook(() => useTypingLifecycle(channel));
+
+    act(() => result.current.startTyping());
+    unmount();
+
+    expect(channel.endTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call endTyping on unmount when typing was never active', () => {
+    const channel = makeChannel();
+    const { unmount } = renderHook(() => useTypingLifecycle(channel));
+
+    unmount();
+
+    expect(channel.endTyping).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate endTyping when stopTyping called before unmount', () => {
+    const channel = makeChannel();
+    const { result, unmount } = renderHook(() => useTypingLifecycle(channel));
+
+    act(() => result.current.startTyping());
+    act(() => result.current.stopTyping());
+    unmount();
+
+    expect(channel.endTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls endTyping on previous channel when channel changes', () => {
+    const channelA = makeChannel('a');
+    const channelB = makeChannel('b');
+
+    const { result, rerender } = renderHook(
+      ({ channel }) => useTypingLifecycle(channel),
+      { initialProps: { channel: channelA } },
+    );
+
+    act(() => result.current.startTyping());
+    expect(channelA.startTyping).toHaveBeenCalledTimes(1);
+
+    rerender({ channel: channelB });
+
+    expect(channelA.endTyping).toHaveBeenCalledTimes(1);
+    expect(channelB.endTyping).not.toHaveBeenCalled();
+  });
+
+  it('calls endTyping when active toggles to false', () => {
+    const channel = makeChannel();
+
+    const { result, rerender } = renderHook(
+      ({ active }) => useTypingLifecycle(channel, active),
+      { initialProps: { active: true } },
+    );
+
+    act(() => result.current.startTyping());
+    rerender({ active: false });
+
+    expect(channel.endTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call endTyping when active toggles to false without typing', () => {
+    const channel = makeChannel();
+
+    const { rerender } = renderHook(
+      ({ active }) => useTypingLifecycle(channel, active),
+      { initialProps: { active: true } },
+    );
+
+    rerender({ active: false });
+
+    expect(channel.endTyping).not.toHaveBeenCalled();
+  });
+
+  it('handles null channel gracefully', () => {
+    const { result, unmount } = renderHook(() => useTypingLifecycle(null));
+
+    expect(() => {
+      act(() => result.current.startTyping());
+      act(() => result.current.stopTyping());
+      unmount();
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useTypingLifecycle.ts
+++ b/src/hooks/useTypingLifecycle.ts
@@ -21,26 +21,30 @@ export function useTypingLifecycle(
   channel: TypingChannel,
   active: boolean = true,
 ): { startTyping: () => void; stopTyping: () => void } {
-  const isTypingRef = useRef(false);
+  // Holds the channel that startTyping was last invoked on. Storing the
+  // actual reference (rather than a boolean flag) ensures endTyping is sent
+  // on the same channel instance that received startTyping, even if the
+  // channel object is re-instantiated under the same URL.
+  const typingChannelRef = useRef<TypingChannel>(null);
 
   const startTyping = useCallback(() => {
     channel?.startTyping?.();
-    isTypingRef.current = true;
+    typingChannelRef.current = channel ?? null;
   }, [channel]);
 
   const stopTyping = useCallback(() => {
-    channel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [channel]);
+    typingChannelRef.current?.endTyping?.();
+    typingChannelRef.current = null;
+  }, []);
 
-  // Send endTyping on channel change, active toggle, or unmount
-  // (uses the captured channel reference so the previous channel is notified).
+  // Run cleanup on channel URL change, active toggle, or unmount.
+  // Reads typingChannelRef so endTyping is sent on the channel where
+  // startTyping was actually invoked.
   useEffect(() => {
-    const ch = channel;
     return () => {
-      if (isTypingRef.current) {
-        ch?.endTyping?.();
-        isTypingRef.current = false;
+      if (typingChannelRef.current) {
+        typingChannelRef.current.endTyping?.();
+        typingChannelRef.current = null;
       }
     };
   }, [channel?.url, active]);

--- a/src/hooks/useTypingLifecycle.ts
+++ b/src/hooks/useTypingLifecycle.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type TypingChannel = {
+  url?: string;
+  startTyping?: () => void;
+  endTyping?: () => void;
+} | null | undefined;
+
+/**
+ * Tracks typing lifecycle on a Sendbird channel and ensures `endTyping` is
+ * sent when the channel changes, the `active` flag toggles to false, or the
+ * component unmounts. Returns memoized `startTyping`/`stopTyping` helpers
+ * that the caller wires to input events.
+ *
+ * @param channel - the channel currently being typed in
+ * @param active  - when set to false, the cleanup runs and clears typing
+ *                  state. Useful for edit-mode wrappers that pass `showEdit`
+ *                  so closing the edit panel emits `endTyping`.
+ */
+export function useTypingLifecycle(
+  channel: TypingChannel,
+  active: boolean = true,
+): { startTyping: () => void; stopTyping: () => void } {
+  const isTypingRef = useRef(false);
+
+  const startTyping = useCallback(() => {
+    channel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [channel]);
+
+  const stopTyping = useCallback(() => {
+    channel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [channel]);
+
+  // Send endTyping on channel change, active toggle, or unmount
+  // (uses the captured channel reference so the previous channel is notified).
+  useEffect(() => {
+    const ch = channel;
+    return () => {
+      if (isTypingRef.current) {
+        ch?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [channel?.url, active]);
+
+  return { startTyping, stopTyping };
+}

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -1,5 +1,5 @@
 import type { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType, ReplyType } from '../../../../types';
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { type EmojiCategory, EmojiContainer, User } from '@sendbird/chat';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { FileMessage, UserMessage, UserMessageCreateParams, UserMessageUpdateParams } from '@sendbird/chat/message';
@@ -220,6 +220,26 @@ const MessageView = (props: MessageViewProps) => {
     );
   }, [mentionedUserIds]);
 
+  const isTypingRef = useRef(false);
+  const startTyping = useCallback(() => {
+    channel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [channel]);
+  const stopTyping = useCallback(() => {
+    channel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [channel]);
+  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
+  useEffect(() => {
+    const ch = channel;
+    return () => {
+      if (isTypingRef.current) {
+        ch?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [showEdit, channel?.url]);
+
   // Side effect: scroll position update when showEdit is toggled or reactions updated
   useDidMountEffect(() => {
     handleScroll?.();
@@ -381,9 +401,8 @@ const MessageView = (props: MessageViewProps) => {
             mentionSelectedUser={selectedUser}
             isMentionEnabled={groupChannel.enableMention}
             message={message}
-            onStartTyping={() => {
-              channel?.startTyping?.();
-            }}
+            onStartTyping={startTyping}
+            onStopTyping={stopTyping}
             onUpdateMessage={({ messageId, message, mentionTemplate }) => {
               updateUserMessage(messageId, {
                 message,

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -410,7 +410,7 @@ const MessageView = (props: MessageViewProps) => {
                 mentionedMessageTemplate: mentionTemplate,
               });
               setShowEdit(false);
-              channel?.endTyping?.();
+              stopTyping();
             }}
             onCancelEdit={() => {
               setMentionNickname('');
@@ -418,7 +418,7 @@ const MessageView = (props: MessageViewProps) => {
               setMentionedUserIds([]);
               setMentionSuggestedUsers([]);
               setShowEdit(false);
-              channel?.endTyping?.();
+              stopTyping();
             }}
             onUserMentioned={(user) => {
               if (selectedUser?.userId === user?.userId) {

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -1,5 +1,6 @@
 import type { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType, ReplyType } from '../../../../types';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useTypingLifecycle } from '../../../../hooks/useTypingLifecycle';
 import { type EmojiCategory, EmojiContainer, User } from '@sendbird/chat';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import type { FileMessage, UserMessage, UserMessageCreateParams, UserMessageUpdateParams } from '@sendbird/chat/message';
@@ -220,25 +221,7 @@ const MessageView = (props: MessageViewProps) => {
     );
   }, [mentionedUserIds]);
 
-  const isTypingRef = useRef(false);
-  const startTyping = useCallback(() => {
-    channel?.startTyping?.();
-    isTypingRef.current = true;
-  }, [channel]);
-  const stopTyping = useCallback(() => {
-    channel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [channel]);
-  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
-  useEffect(() => {
-    const ch = channel;
-    return () => {
-      if (isTypingRef.current) {
-        ch?.endTyping?.();
-        isTypingRef.current = false;
-      }
-    };
-  }, [showEdit, channel?.url]);
+  const { startTyping, stopTyping } = useTypingLifecycle(channel, showEdit);
 
   // Side effect: scroll position update when showEdit is toggled or reactions updated
   useDidMountEffect(() => {

--- a/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
@@ -1,5 +1,6 @@
 import './index.scss';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useTypingLifecycle } from '../../../../hooks/useTypingLifecycle';
 import type { User } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type {
@@ -129,25 +130,7 @@ export const MessageInputWrapperView = React.forwardRef((
     setShowVoiceMessageInput(false);
   }, [currentChannel?.url]);
 
-  const isTypingRef = useRef(false);
-  const startTyping = useCallback(() => {
-    currentChannel?.startTyping?.();
-    isTypingRef.current = true;
-  }, [currentChannel]);
-  const stopTyping = useCallback(() => {
-    currentChannel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [currentChannel]);
-  // Send endTyping on channel change or unmount (uses captured channel reference)
-  useEffect(() => {
-    const channel = currentChannel;
-    return () => {
-      if (isTypingRef.current) {
-        channel?.endTyping?.();
-        isTypingRef.current = false;
-      }
-    };
-  }, [currentChannel?.url]);
+  const { startTyping, stopTyping } = useTypingLifecycle(currentChannel);
   useEffect(() => {
     setMentionedUsers(
       mentionedUsers.filter(({ userId }) => {

--- a/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
+++ b/src/modules/GroupChannel/components/MessageInputWrapper/MessageInputWrapperView.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import type { User } from '@sendbird/chat';
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import type {
@@ -128,6 +128,26 @@ export const MessageInputWrapperView = React.forwardRef((
     setMessageInputEvent(null);
     setShowVoiceMessageInput(false);
   }, [currentChannel?.url]);
+
+  const isTypingRef = useRef(false);
+  const startTyping = useCallback(() => {
+    currentChannel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [currentChannel]);
+  const stopTyping = useCallback(() => {
+    currentChannel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [currentChannel]);
+  // Send endTyping on channel change or unmount (uses captured channel reference)
+  useEffect(() => {
+    const channel = currentChannel;
+    return () => {
+      if (isTypingRef.current) {
+        channel?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [currentChannel?.url]);
   useEffect(() => {
     setMentionedUsers(
       mentionedUsers.filter(({ userId }) => {
@@ -234,9 +254,8 @@ export const MessageInputWrapperView = React.forwardRef((
           renderFileUploadIcon={renderFileUploadIcon}
           renderSendMessageIcon={renderSendMessageIcon}
           renderVoiceMessageIcon={renderVoiceMessageIcon}
-          onStartTyping={() => {
-            currentChannel?.startTyping();
-          }}
+          onStartTyping={startTyping}
+          onStopTyping={stopTyping}
           onSendMessage={({ message, mentionTemplate }) => {
             sendUserMessage({
               message,
@@ -247,7 +266,7 @@ export const MessageInputWrapperView = React.forwardRef((
             setMentionNickname('');
             setMentionedUsers([]);
             setQuoteMessage(null);
-            currentChannel?.endTyping?.();
+            stopTyping();
           }}
           onFileUpload={(fileList) => {
             handleUploadFiles(fileList);

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import { useTypingLifecycle } from '../../../../hooks/useTypingLifecycle';
 import format from 'date-fns/format';
 import { FileMessage } from '@sendbird/chat/message';
 
@@ -132,25 +133,7 @@ export default function ParentMessageInfo({
     }));
   }, [mentionedUserIds]);
 
-  const isTypingRef = useRef(false);
-  const startTyping = useCallback(() => {
-    currentChannel?.startTyping?.();
-    isTypingRef.current = true;
-  }, [currentChannel]);
-  const stopTyping = useCallback(() => {
-    currentChannel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [currentChannel]);
-  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
-  useEffect(() => {
-    const channel = currentChannel;
-    return () => {
-      if (isTypingRef.current) {
-        channel?.endTyping?.();
-        isTypingRef.current = false;
-      }
-    };
-  }, [showEditInput, currentChannel?.url]);
+  const { startTyping, stopTyping } = useTypingLifecycle(currentChannel, showEditInput);
 
   const handleOnDownloadClick = async (e: React.MouseEvent) => {
     if (!onBeforeDownloadFileMessage) return;

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import { FileMessage } from '@sendbird/chat/message';
 
@@ -132,6 +132,26 @@ export default function ParentMessageInfo({
     }));
   }, [mentionedUserIds]);
 
+  const isTypingRef = useRef(false);
+  const startTyping = useCallback(() => {
+    currentChannel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [currentChannel]);
+  const stopTyping = useCallback(() => {
+    currentChannel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [currentChannel]);
+  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
+  useEffect(() => {
+    const channel = currentChannel;
+    return () => {
+      if (isTypingRef.current) {
+        channel?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [showEditInput, currentChannel?.url]);
+
   const handleOnDownloadClick = async (e: React.MouseEvent) => {
     if (!onBeforeDownloadFileMessage) return;
 
@@ -188,9 +208,8 @@ export default function ParentMessageInfo({
           mentionSelectedUser={selectedUser}
           isMentionEnabled={isMentionEnabled}
           message={parentMessage}
-          onStartTyping={() => {
-            currentChannel?.startTyping?.();
-          }}
+          onStartTyping={startTyping}
+          onStopTyping={stopTyping}
           onUpdateMessage={({ messageId, message, mentionTemplate }) => {
             updateMessage({
               messageId,

--- a/src/modules/Thread/components/ParentMessageInfo/index.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/index.tsx
@@ -218,7 +218,7 @@ export default function ParentMessageInfo({
               mentionTemplate,
             });
             setShowEditInput(false);
-            currentChannel?.endTyping?.();
+            stopTyping();
           }}
           onCancelEdit={() => {
             setMentionNickname('');
@@ -226,7 +226,7 @@ export default function ParentMessageInfo({
             setMentionedUserIds([]);
             setMentionSuggestedUsers([]);
             setShowEditInput(false);
-            currentChannel?.endTyping?.();
+            stopTyping();
           }}
           onUserMentioned={(user) => {
             if (selectedUser?.userId === user?.userId) {

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useCallback, useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
 import format from 'date-fns/format';
 import type { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
 
@@ -118,6 +118,26 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
     }));
   }, [mentionedUserIds]);
 
+  const isTypingRef = useRef(false);
+  const startTyping = useCallback(() => {
+    currentChannel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [currentChannel]);
+  const stopTyping = useCallback(() => {
+    currentChannel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [currentChannel]);
+  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
+  useEffect(() => {
+    const channel = currentChannel;
+    return () => {
+      if (isTypingRef.current) {
+        channel?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [showEdit, currentChannel?.url]);
+
   // edit input
   const disabled = !(threadListState === ThreadListStateTypes.INITIALIZED)
     || !isOnline
@@ -169,9 +189,8 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
           mentionSelectedUser={selectedUser}
           isMentionEnabled={isMentionEnabled}
           message={message}
-          onStartTyping={() => {
-            currentChannel?.startTyping?.();
-          }}
+          onStartTyping={startTyping}
+          onStopTyping={stopTyping}
           onUpdateMessage={({ messageId, message, mentionTemplate }) => {
             updateMessage({
               messageId,

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useMemo, useState, useRef, useEffect, useLayoutEffect } from 'react';
+import { useTypingLifecycle } from '../../../../hooks/useTypingLifecycle';
 import format from 'date-fns/format';
 import type { FileMessage, MultipleFilesMessage } from '@sendbird/chat/message';
 
@@ -118,25 +119,7 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
     }));
   }, [mentionedUserIds]);
 
-  const isTypingRef = useRef(false);
-  const startTyping = useCallback(() => {
-    currentChannel?.startTyping?.();
-    isTypingRef.current = true;
-  }, [currentChannel]);
-  const stopTyping = useCallback(() => {
-    currentChannel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [currentChannel]);
-  // Send endTyping on edit close, channel change, or unmount (uses captured channel reference)
-  useEffect(() => {
-    const channel = currentChannel;
-    return () => {
-      if (isTypingRef.current) {
-        channel?.endTyping?.();
-        isTypingRef.current = false;
-      }
-    };
-  }, [showEdit, currentChannel?.url]);
+  const { startTyping, stopTyping } = useTypingLifecycle(currentChannel, showEdit);
 
   // edit input
   const disabled = !(threadListState === ThreadListStateTypes.INITIALIZED)

--- a/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItem.tsx
@@ -199,7 +199,7 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
               mentionTemplate,
             });
             setShowEdit(false);
-            currentChannel?.endTyping?.();
+            stopTyping();
           }}
           onCancelEdit={() => {
             setMentionNickname('');
@@ -207,7 +207,7 @@ export default function ThreadListItem(props: ThreadListItemProps): React.ReactE
             setMentionedUserIds([]);
             setMentionSuggestedUsers([]);
             setShowEdit(false);
-            currentChannel?.endTyping?.();
+            stopTyping();
           }}
           onUserMentioned={(user) => {
             if (selectedUser?.userId === user?.userId) {

--- a/src/modules/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/modules/Thread/components/ThreadMessageInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { MutedState } from '@sendbird/chat/groupChannel';
 
 import './index.scss';
@@ -101,6 +101,26 @@ const ThreadMessageInput = (
     setShowVoiceMessageInput(false);
   }, [currentChannel?.url]);
 
+  const isTypingRef = useRef(false);
+  const startTyping = useCallback(() => {
+    currentChannel?.startTyping?.();
+    isTypingRef.current = true;
+  }, [currentChannel]);
+  const stopTyping = useCallback(() => {
+    currentChannel?.endTyping?.();
+    isTypingRef.current = false;
+  }, [currentChannel]);
+  // Send endTyping on channel change or unmount (uses captured channel reference)
+  useEffect(() => {
+    const channel = currentChannel;
+    return () => {
+      if (isTypingRef.current) {
+        channel?.endTyping?.();
+        isTypingRef.current = false;
+      }
+    };
+  }, [currentChannel?.url]);
+
   const mentionNodes = useDirtyGetMentions({ ref: ref || messageInputRef }, { logger });
   const ableMention = mentionNodes?.length < userMention?.maxMentionCount;
 
@@ -191,9 +211,8 @@ const ThreadMessageInput = (
                   : stringSet.THREAD__INPUT__REPLY_IN_THREAD
                 )
               }
-              onStartTyping={() => {
-                currentChannel?.startTyping?.();
-              }}
+              onStartTyping={startTyping}
+              onStopTyping={stopTyping}
               onSendMessage={({ message, mentionTemplate }) => {
                 sendMessage({
                   message: message,
@@ -203,7 +222,7 @@ const ThreadMessageInput = (
                 });
                 setMentionNickname('');
                 setMentionedUsers([]);
-                currentChannel?.endTyping?.();
+                stopTyping();
               }}
               onFileUpload={handleUploadFiles}
               onUserMentioned={(user) => {

--- a/src/modules/Thread/components/ThreadMessageInput/index.tsx
+++ b/src/modules/Thread/components/ThreadMessageInput/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { useTypingLifecycle } from '../../../../hooks/useTypingLifecycle';
 import { MutedState } from '@sendbird/chat/groupChannel';
 
 import './index.scss';
@@ -101,25 +102,7 @@ const ThreadMessageInput = (
     setShowVoiceMessageInput(false);
   }, [currentChannel?.url]);
 
-  const isTypingRef = useRef(false);
-  const startTyping = useCallback(() => {
-    currentChannel?.startTyping?.();
-    isTypingRef.current = true;
-  }, [currentChannel]);
-  const stopTyping = useCallback(() => {
-    currentChannel?.endTyping?.();
-    isTypingRef.current = false;
-  }, [currentChannel]);
-  // Send endTyping on channel change or unmount (uses captured channel reference)
-  useEffect(() => {
-    const channel = currentChannel;
-    return () => {
-      if (isTypingRef.current) {
-        channel?.endTyping?.();
-        isTypingRef.current = false;
-      }
-    };
-  }, [currentChannel?.url]);
+  const { startTyping, stopTyping } = useTypingLifecycle(currentChannel);
 
   const mentionNodes = useDirtyGetMentions({ ref: ref || messageInputRef }, { logger });
   const ableMention = mentionNodes?.length < userMention?.maxMentionCount;

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -259,6 +259,66 @@ describe('ui/MessageInput', () => {
       container.getElementsByClassName('sendbird-message-input--edit-action').length
     ).toBe(1);
   });
+
+  describe('typing indicator callbacks', () => {
+    it('should call onStartTyping when input has text', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = 'hello';
+      fireEvent.input(input);
+
+      expect(onStartTyping).toHaveBeenCalled();
+      expect(onStopTyping).not.toHaveBeenCalled();
+    });
+
+    it('should call onStopTyping when input becomes empty after typing', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = 'hello';
+      fireEvent.input(input);
+      input.textContent = '';
+      fireEvent.input(input);
+
+      expect(onStartTyping).toHaveBeenCalled();
+      expect(onStopTyping).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onStopTyping when input is empty without prior typing', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = '';
+      fireEvent.input(input);
+      fireEvent.input(input);
+
+      expect(onStartTyping).not.toHaveBeenCalled();
+      expect(onStopTyping).not.toHaveBeenCalled();
+    });
+
+    it('should call onStopTyping only once when backspacing repeatedly on empty input', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = 'hi';
+      fireEvent.input(input);
+      input.textContent = '';
+      fireEvent.input(input);
+      fireEvent.input(input);
+      fireEvent.input(input);
+
+      expect(onStopTyping).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('MessageInput error handling', () => {

--- a/src/ui/MessageInput/__tests__/MessageInput.spec.js
+++ b/src/ui/MessageInput/__tests__/MessageInput.spec.js
@@ -318,6 +318,33 @@ describe('ui/MessageInput', () => {
 
       expect(onStopTyping).toHaveBeenCalledTimes(1);
     });
+
+    it('should call onStopTyping when input becomes whitespace-only after typing', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = 'hello';
+      fireEvent.input(input);
+      input.textContent = '   ';
+      fireEvent.input(input);
+
+      expect(onStopTyping).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onStartTyping when input contains only whitespace', () => {
+      const onStartTyping = jest.fn();
+      const onStopTyping = jest.fn();
+      render(<MessageInput onSendMessage={noop} onStartTyping={onStartTyping} onStopTyping={onStopTyping} />);
+
+      const input = screen.getByRole('textbox');
+      input.textContent = '   ';
+      fireEvent.input(input);
+
+      expect(onStartTyping).not.toHaveBeenCalled();
+      expect(onStopTyping).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -526,17 +526,15 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             useMentionInputDetection();
           }}
           onInput={() => {
-            const isEmpty = getTextContentWithoutZeroWidthSpace(internalRef?.current) === '';
-            if (isEmpty) {
-              if (wasTypingRef.current) {
-                onStopTyping();
-                wasTypingRef.current = false;
-              }
-            } else {
+            const hasContent = hasTextContentWithoutZeroWidthSpace(internalRef?.current);
+            if (hasContent) {
               onStartTyping();
               wasTypingRef.current = true;
+            } else if (wasTypingRef.current) {
+              onStopTyping();
+              wasTypingRef.current = false;
             }
-            setIsInput(hasTextContentWithoutZeroWidthSpace(internalRef?.current));
+            setIsInput(hasContent);
             useMentionedLabelDetection();
           }}
           onPaste={(e) => {

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -170,6 +170,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     if (!isEdit) {
       setIsInput(false);
       resetInput(internalRef);
+      wasTypingRef.current = false;
     }
   }, [channelUrl]);
 
@@ -372,6 +373,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         if (!isMentionedMessage) params.mentionTemplate = '';
         onSendMessage(params);
         resetInput(internalRef);
+        wasTypingRef.current = false;
         /**
          * Note: contentEditable does not work as expected in mobile WebKit (Safari).
          * @see https://github.com/sendbird/sendbird-uikit-react/pull/1108
@@ -401,6 +403,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         const params = { messageId, message: messageText, mentionTemplate };
         onUpdateMessage(params);
         resetInput(internalRef);
+        wasTypingRef.current = false;
       }
     } catch (error) {
       eventHandlers?.message?.onUpdateMessageFailed?.(message, error);

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -87,6 +87,7 @@ type MessageInputProps = {
   onUpdateMessage?: (params: { messageId: number; message: string; mentionTemplate: string }) => void;
   onCancelEdit?: () => void;
   onStartTyping?: () => void;
+  onStopTyping?: () => void;
   channelUrl?: string;
   mentionSelectedUser?: null | User;
   onUserMentioned?: (user: User) => void;
@@ -120,6 +121,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     onUpdateMessage = noop,
     onCancelEdit = noop,
     onStartTyping = noop,
+    onStopTyping = noop,
     channelUrl = '',
     mentionSelectedUser = null,
     onUserMentioned = noop,
@@ -137,6 +139,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
 
   const internalRef = (externalRef && 'current' in externalRef) ? externalRef : useRef(null);
   const ghostInputRef = useRef<HTMLInputElement>(null);
+  const wasTypingRef = useRef(false);
 
   const textFieldId = messageFieldId || TEXT_FIELD_ID;
   const { stringSet } = useLocalization();
@@ -520,7 +523,16 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             useMentionInputDetection();
           }}
           onInput={() => {
-            onStartTyping();
+            const isEmpty = getTextContentWithoutZeroWidthSpace(internalRef?.current) === '';
+            if (isEmpty) {
+              if (wasTypingRef.current) {
+                onStopTyping();
+                wasTypingRef.current = false;
+              }
+            } else {
+              onStartTyping();
+              wasTypingRef.current = true;
+            }
             setIsInput(hasTextContentWithoutZeroWidthSpace(internalRef?.current));
             useMentionedLabelDetection();
           }}


### PR DESCRIPTION
## Summary

The typing indicator could remain visible after the local user stopped
composing because the React UIKit only called `endTyping()` on message send.
Clearing the input, switching channels, unmounting, or cancelling an edit
left the SDK in `typing` state until its server-side timeout expired.

## Changes

- Add `src/hooks/useTypingLifecycle` that pairs `startTyping`/`endTyping`
  on a captured channel reference and emits `endTyping` on channel change,
  active toggle, or unmount.
- `MessageInput`: add `onStopTyping` prop and fire it on the typing → empty
  transition.
- Wire the hook into `MessageInputWrapperView`, `ThreadMessageInput`,
  `MessageView`, `ThreadListItem`, `ParentMessageInfo`.

## Test plan

- New: 12 unit tests for `useTypingLifecycle` and 4 tests for `MessageInput`.