### PR TITLE
refactor(group-channel): Phase 5.1 unread dispatch + read hook infra (stacked on #1428)

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/getMessagePartsInfo.ts
+++ b/src/modules/GroupChannel/components/MessageList/getMessagePartsInfo.ts
@@ -15,7 +15,12 @@ export interface GetMessagePartsInfoProps {
   currentChannel?: GroupChannel | null;
   replyType?: string;
   hasPrevious?: boolean;
-  firstUnreadMessageId?: number | string | undefined;
+  // Phase 5.1.c — narrowed from `number | string` per audit (R-5 in
+  // .agentic/p0-phase-5-1/plan.md): all internal writers pass `number`
+  // (or `undefined`); the `string` union was unreachable defensive over-
+  // typing. `null` added to align with reducer-side return types ahead
+  // of a future consumer migration cycle.
+  firstUnreadMessageId?: number | null | undefined;
   isUnreadMessageExistInChannel?: React.MutableRefObject<boolean>;
 }
 

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -44,6 +44,8 @@ import {
   mapOnMessagesReceived,
   mapOnMessagesUpdated,
 } from '../internal/runtime/adapter';
+import { createUnreadStore, dispatchToUnreadStore } from '../internal/unread/integration';
+import type { UnreadEvent } from '../internal/unread/reducer';
 
 const initialState = () => ({
   currentChannel: null,
@@ -196,6 +198,40 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     }
   }, [logger]);
 
+  // Phase 5.1.a — Unread reducer store. Dual-write strategy (spec §AC-4):
+  // dispatch fires alongside the legacy `setNewMessageIds` /
+  // `setFirstUnreadMessageId` calls. Phase 5.1.b/c switch consumer reads
+  // over to this store via `useUnreadSelector`; the legacy state slice is
+  // retained until Phase 5.2 has a verification window.
+  //
+  // MESSAGES_DELETED is intentionally NOT dispatched — `@sendbird/uikit-tools@0.1.0`
+  // does not expose `onMessagesDeleted` (Plan §1). Re-evaluate when the
+  // uikit-tools bump (separate follow-up) ships that callback.
+  const unreadStoreRef = useRef(createUnreadStore());
+
+  // Thunk-guarded dispatch — see runtimeDispatch (W1). A bug in the
+  // reducer or in a caller-supplied factory MUST NOT prevent the legacy
+  // callback from continuing.
+  const unreadDispatch = useCallback((makeEvent: () => UnreadEvent, isAtBottom?: boolean) => {
+    try {
+      const event = makeEvent();
+      return dispatchToUnreadStore(
+        unreadStoreRef.current,
+        event,
+        { isAtBottom: isAtBottom ?? true },
+        (error, failedEvent) => {
+          logger?.warning?.('GroupChannelProvider: unread dispatch failed (reducer)', {
+            eventType: failedEvent.type,
+            error,
+          });
+        },
+      );
+    } catch (error) {
+      logger?.warning?.('GroupChannelProvider: unread dispatch failed (mapper)', error);
+      return unreadStoreRef.current.getState();
+    }
+  }, [logger]);
+
   // ScrollHandler initialization
   const {
     scrollRef,
@@ -241,13 +277,21 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
           source: source || 'unknown',
         });
         markAsUnreadSourceRef.current = source || 'internal';
+        // Phase 5.1.a — record the user-chosen unread anchor in the
+        // reducer. Only fires after the SDK call succeeds so the local
+        // and server states agree.
+        unreadDispatch(() => ({
+          type: 'MARK_AS_UNREAD_SET',
+          messageId: message.messageId,
+          createdAt: message.createdAt,
+        }));
       } else {
         logger?.error?.('GroupChannelProvider: markAsUnread method not available in current SDK version');
       }
     } catch (error) {
       logger?.error?.('GroupChannelProvider: markAsUnread failed', error);
     }
-  }, [state.currentChannel, logger, config.groupChannel.enableMarkAsUnread]);
+  }, [state.currentChannel, logger, config.groupChannel.enableMarkAsUnread, unreadDispatch]);
 
   // Message Collection setup
   const messageDataSource = useGroupChannelMessages(sdkStore.sdk, state.currentChannel!, {
@@ -267,6 +311,17 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
       // coreTs callback uses SendbirdMessage[] (broader than SendableMessageType);
       // the adapter mapper accepts the broader shape via structural cast.
       runtimeDispatch(() => mapOnMessagesReceived(messages as never));
+
+      // Phase 5.1.a — Unread dispatch. fromCurrentUser is true only when
+      // ALL messages in the burst are from the current user; conservative
+      // so a mixed burst still grows the unread counter.
+      const fromCurrentUser = messages.length > 0
+        && messages.every((m: any) => m.sender?.userId === userId);
+      unreadDispatch(() => ({
+        type: 'MESSAGES_RECEIVED',
+        messages: messages.map((m: any) => ({ messageId: m.messageId, createdAt: m.createdAt })),
+        fromCurrentUser,
+      }), isScrollBottomReached);
       if (isScrollBottomReached
         && isContextMenuClosed()
         // Note: this shouldn't happen ideally, but it happens on re-rendering GroupChannelManager
@@ -295,11 +350,14 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     // reducer-only until a follow-up cycle ships those callbacks.
     onChannelDeleted: () => {
       runtimeDispatch(() => mapOnChannelDeleted());
+      // Phase 5.1.a — channel cleared → reset unread tracking.
+      unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: '' }));
       actions.setCurrentChannel(null);
       onBackClick?.();
     },
     onCurrentUserBanned: () => {
       runtimeDispatch(() => mapOnCurrentUserBanned());
+      unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: '' }));
       actions.setCurrentChannel(null);
       onBackClick?.();
     },
@@ -314,11 +372,37 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
         && ctx.userIds.includes(userId)
       ) {
         actions.setReadStateChanged('read');
+        // Phase 5.1.a — remote read confirmation → clear local unread.
+        unreadDispatch(() => ({
+          type: 'READ_CONFIRMED',
+          channelUrl: channel.url,
+          at: Date.now(),
+        }));
+      }
+      // Phase 5.1.a — channel reference may switch (e.g. operator change);
+      // fire CHANNEL_CHANGED only when the url actually changes to avoid
+      // unnecessary state churn on no-op updates.
+      if (state.currentChannel?.url !== channel.url) {
+        unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: channel.url }));
       }
       actions.setCurrentChannel(channel);
     },
     logger: logger as any,
   });
+
+  // Phase 5.1.a — scroll-edge → unread reducer wiring. Dispatches
+  // USER_REACHED_BOTTOM / USER_LEFT_BOTTOM whenever the legacy
+  // `state.isScrollBottomReached` flag flips. Runs on initial mount as
+  // well (isScrollBottomReached defaults to true → fires
+  // USER_REACHED_BOTTOM, which the reducer treats as a no-op when state
+  // is already `clean`).
+  useEffect(() => {
+    if (isScrollBottomReached) {
+      unreadDispatch(() => ({ type: 'USER_REACHED_BOTTOM', at: Date.now() }));
+    } else {
+      unreadDispatch(() => ({ type: 'USER_LEFT_BOTTOM', at: Date.now() }));
+    }
+  }, [isScrollBottomReached, unreadDispatch]);
 
   // Channel initialization
   useAsyncEffect(async () => {
@@ -327,6 +411,10 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
         const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
         // Phase 2 dispatch — additive, before legacy actions.setCurrentChannel.
         runtimeDispatch(() => mapChannelReady(channel));
+        // Phase 5.1.a — fresh channel mount → reset unread tracking under
+        // the new url. Dispatched synchronously so consumer reads on the
+        // next render observe a clean state (Plan §R-2).
+        unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: channel.url }));
         actions.setCurrentChannel(channel);
       } catch (error) {
         // Phase 2 dispatch — additive, before legacy actions.handleChannelError.

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -210,9 +210,29 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   // uikit-tools bump (separate follow-up) ships that callback.
   const unreadStoreRef = useRef(createUnreadStore());
 
+  // Tracks the last channelUrl observed by the unread store so repeated
+  // CHANNEL_CHANGED dispatches (e.g. mount-time + a stale onChannelUpdated
+  // closure firing before the legacy setCurrentChannel has flushed) collapse
+  // to a single transition. Idempotent regardless, but avoids dev-hook
+  // double-fire and any future subscriber re-render.
+  const unreadChannelUrlRef = useRef<string | null>(null);
+
   // Thunk-guarded dispatch — see runtimeDispatch (W1). A bug in the
   // reducer or in a caller-supplied factory MUST NOT prevent the legacy
   // callback from continuing.
+  const dispatchChannelChanged = useCallback((channelUrl: string) => {
+    if (unreadChannelUrlRef.current === channelUrl) return;
+    unreadChannelUrlRef.current = channelUrl;
+    return dispatchToUnreadStore(
+      unreadStoreRef.current,
+      { type: 'CHANNEL_CHANGED', channelUrl },
+      undefined,
+      (error) => {
+        logger?.warning?.('GroupChannelProvider: unread CHANNEL_CHANGED failed', { error });
+      },
+    );
+  }, [logger]);
+
   const unreadDispatch = useCallback((makeEvent: () => UnreadEvent, isAtBottom?: boolean) => {
     try {
       const event = makeEvent();
@@ -313,16 +333,23 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
       // the adapter mapper accepts the broader shape via structural cast.
       runtimeDispatch(() => mapOnMessagesReceived(messages as never));
 
-      // Phase 5.1.a — Unread dispatch. fromCurrentUser is true only when
-      // ALL messages in the burst are from the current user; conservative
-      // so a mixed burst still grows the unread counter.
-      const fromCurrentUser = messages.length > 0
-        && messages.every((m: any) => m.sender?.userId === userId);
-      unreadDispatch(() => ({
-        type: 'MESSAGES_RECEIVED',
-        messages: messages.map((m: any) => ({ messageId: m.messageId, createdAt: m.createdAt })),
-        fromCurrentUser,
-      }), isScrollBottomReached);
+      // Phase 5.1.a — Unread dispatch. Filter out current-user messages
+      // BEFORE dispatch so they never enter the unread set (review I-2).
+      // Prior `messages.every(...)` collapsed mixed bursts to
+      // `fromCurrentUser: false`, which would have grown the set with my
+      // own messageId — wrong the moment a consumer reads from the set.
+      // After filtering, the remaining burst is by definition non-self,
+      // so `fromCurrentUser: false` is correct.
+      const peerMessages = messages.filter(
+        (m) => (m as { sender?: { userId?: string } }).sender?.userId !== userId,
+      );
+      if (peerMessages.length > 0) {
+        unreadDispatch(() => ({
+          type: 'MESSAGES_RECEIVED',
+          messages: peerMessages.map((m) => ({ messageId: m.messageId, createdAt: m.createdAt })),
+          fromCurrentUser: false,
+        }), isScrollBottomReached);
+      }
       if (isScrollBottomReached
         && isContextMenuClosed()
         // Note: this shouldn't happen ideally, but it happens on re-rendering GroupChannelManager
@@ -351,14 +378,15 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     // reducer-only until a follow-up cycle ships those callbacks.
     onChannelDeleted: () => {
       runtimeDispatch(() => mapOnChannelDeleted());
-      // Phase 5.1.a — channel cleared → reset unread tracking.
-      unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: '' }));
+      // Phase 5.1.a — channel cleared → reset unread tracking (idempotent
+      // via unreadChannelUrlRef).
+      dispatchChannelChanged('');
       actions.setCurrentChannel(null);
       onBackClick?.();
     },
     onCurrentUserBanned: () => {
       runtimeDispatch(() => mapOnCurrentUserBanned());
-      unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: '' }));
+      dispatchChannelChanged('');
       actions.setCurrentChannel(null);
       onBackClick?.();
     },
@@ -380,12 +408,10 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
           at: Date.now(),
         }));
       }
-      // Phase 5.1.a — channel reference may switch (e.g. operator change);
-      // fire CHANNEL_CHANGED only when the url actually changes to avoid
-      // unnecessary state churn on no-op updates.
-      if (state.currentChannel?.url !== channel.url) {
-        unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: channel.url }));
-      }
+      // Phase 5.1.a — fire CHANNEL_CHANGED only when the url actually
+      // changes. dispatchChannelChanged handles its own idempotency via
+      // unreadChannelUrlRef, so this is purely a perf early-out.
+      dispatchChannelChanged(channel.url);
       actions.setCurrentChannel(channel);
     },
     logger: logger as any,
@@ -413,9 +439,9 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
         // Phase 2 dispatch — additive, before legacy actions.setCurrentChannel.
         runtimeDispatch(() => mapChannelReady(channel));
         // Phase 5.1.a — fresh channel mount → reset unread tracking under
-        // the new url. Dispatched synchronously so consumer reads on the
-        // next render observe a clean state (Plan §R-2).
-        unreadDispatch(() => ({ type: 'CHANNEL_CHANGED', channelUrl: channel.url }));
+        // the new url. dispatchChannelChanged collapses repeat fires
+        // through unreadChannelUrlRef (Plan §R-2, review I-1).
+        dispatchChannelChanged(channel.url);
         actions.setCurrentChannel(channel);
       } catch (error) {
         // Phase 2 dispatch — additive, before legacy actions.handleChannelError.

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -46,6 +46,7 @@ import {
 } from '../internal/runtime/adapter';
 import { createUnreadStore, dispatchToUnreadStore } from '../internal/unread/integration';
 import type { UnreadEvent } from '../internal/unread/reducer';
+import { GroupChannelUnreadContext } from './GroupChannelUnreadContext';
 
 const initialState = () => ({
   currentChannel: null,
@@ -575,7 +576,15 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     messageDataSource.messages.map(it => it.serialize()),
   ]);
 
-  return children;
+  // Phase 5.1.b — expose the unread store to consumer subscriptions
+  // (useUnreadSelector). The context value is the same store ref for
+  // the lifetime of this manager mount; consumers re-render only when
+  // their selector output changes (useSyncExternalStore semantics).
+  return (
+    <GroupChannelUnreadContext.Provider value={unreadStoreRef.current}>
+      {children}
+    </GroupChannelUnreadContext.Provider>
+  );
 };
 
 const GroupChannelProvider: React.FC<GroupChannelProviderProps> = (props) => {

--- a/src/modules/GroupChannel/context/GroupChannelUnreadContext.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelUnreadContext.tsx
@@ -1,0 +1,18 @@
+/**
+ * React context for the GroupChannel unread reducer store.
+ *
+ * Phase 5.1.b of the P0 runtime-coupling refactor (Plan §5.1.b).
+ *
+ * The store itself lives in `GroupChannelManager` (see
+ * `GroupChannelProvider.tsx`) — this context is the read boundary:
+ * consumers subscribe via `useUnreadSelector` rather than touching the
+ * store directly.
+ *
+ * Module-private — NOT re-exported from `src/index.ts`. BC-2 verifies the
+ * public dts export set is unchanged.
+ */
+import { createContext } from 'react';
+import type { Store } from '../../../utils/storeManager';
+import type { UnreadState } from '../internal/unread/model';
+
+export const GroupChannelUnreadContext = createContext<Store<UnreadState> | null>(null);

--- a/src/modules/GroupChannel/context/hooks/__tests__/useUnreadSelector.spec.tsx
+++ b/src/modules/GroupChannel/context/hooks/__tests__/useUnreadSelector.spec.tsx
@@ -1,0 +1,153 @@
+/**
+ * Phase 5.1.b — useUnreadSelector subscription hook.
+ *
+ * Covers:
+ *   - Narrow-slice subscription (re-renders only when selector output
+ *     changes per Object.is)
+ *   - Provider boundary (throws outside provider)
+ *   - Equality-fn override for derived shapes
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { GroupChannelUnreadContext } from '../../GroupChannelUnreadContext';
+import { useUnreadSelector } from '../useUnreadSelector';
+import { createUnreadStore, dispatchToUnreadStore } from '../../../internal/unread/integration';
+import {
+  selectFirstUnreadMessageId,
+  selectFirstUnreadCreatedAt,
+  selectIsMessageUnread,
+} from '../../../internal/unread/selectors';
+
+function renderWithStore(node: React.ReactElement, store = createUnreadStore()) {
+  const utils = render(
+    <GroupChannelUnreadContext.Provider value={store}>
+      {node}
+    </GroupChannelUnreadContext.Provider>,
+  );
+  return { ...utils, store };
+}
+
+describe('Phase 5.1.b — useUnreadSelector', () => {
+  it('returns the initial selector output on first render', () => {
+    let observed: number | null | undefined;
+    const Probe = () => {
+      observed = useUnreadSelector(selectFirstUnreadMessageId);
+      return null;
+    };
+    renderWithStore(<Probe />);
+    expect(observed).toBeNull();
+  });
+
+  it('re-renders only when the selector output changes', () => {
+    let renders = 0;
+    let observed: number | null | undefined;
+    const Probe = () => {
+      renders++;
+      observed = useUnreadSelector(selectFirstUnreadMessageId);
+      return null;
+    };
+    const { store } = renderWithStore(<Probe />);
+
+    expect(renders).toBe(1);
+    expect(observed).toBeNull();
+
+    // Dispatch that DOES change firstUnreadMessageId.
+    act(() => {
+      dispatchToUnreadStore(
+        store,
+        { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 1, createdAt: 100 }], fromCurrentUser: false },
+        { isAtBottom: false },
+      );
+    });
+    expect(renders).toBe(2);
+    expect(observed).toBe(1);
+
+    // Dispatch that does NOT change firstUnreadMessageId (same anchor;
+    // count grows but selector returns same primitive).
+    act(() => {
+      dispatchToUnreadStore(
+        store,
+        { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 2, createdAt: 200 }], fromCurrentUser: false },
+        { isAtBottom: false },
+      );
+    });
+    // No re-render because selectFirstUnreadMessageId still returns 1.
+    expect(renders).toBe(2);
+    expect(observed).toBe(1);
+  });
+
+  it('throws when used outside a GroupChannelUnreadContext provider', () => {
+    const Probe = () => {
+      useUnreadSelector(selectFirstUnreadMessageId);
+      return null;
+    };
+    // Suppress the React error boundary noise.
+    const origError = console.error;
+    console.error = jest.fn();
+    try {
+      expect(() => render(<Probe />)).toThrow(/useStoreSelector must be used within/);
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  it('selectIsMessageUnread tracks unread set membership', () => {
+    let observedFor1: boolean | undefined;
+    const Probe1 = () => {
+      observedFor1 = useUnreadSelector((s) => selectIsMessageUnread(s, { messageId: 1 }));
+      return null;
+    };
+    const { store } = renderWithStore(<Probe1 />);
+    expect(observedFor1).toBe(false);
+
+    act(() => {
+      dispatchToUnreadStore(
+        store,
+        { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 1, createdAt: 100 }], fromCurrentUser: false },
+        { isAtBottom: false },
+      );
+    });
+    expect(observedFor1).toBe(true);
+
+    // A separate mount with a different messageId — NOT a rerender with
+    // a new prop. Inline selectors that close over props rely on a fresh
+    // mount because the selector swap intentionally reuses the memoized
+    // snapshot when the raw store state has not changed (zustand idiom;
+    // see useStoreSelector JSDoc).
+    let observedFor99: boolean | undefined;
+    const Probe99 = () => {
+      observedFor99 = useUnreadSelector((s) => selectIsMessageUnread(s, { messageId: 99 }));
+      return null;
+    };
+    render(
+      <GroupChannelUnreadContext.Provider value={store}>
+        <Probe99 />
+      </GroupChannelUnreadContext.Provider>,
+    );
+    expect(observedFor99).toBe(false);
+  });
+
+  it('honors custom equalityFn — derived object selectors stay stable', () => {
+    let renders = 0;
+    const Probe = () => {
+      renders++;
+      // Selector synthesizes a new object each call; without the custom
+      // equality, identity would diverge on every dispatch.
+      useUnreadSelector(
+        (s) => ({ anchor: selectFirstUnreadMessageId(s), at: selectFirstUnreadCreatedAt(s) }),
+        (a, b) => a.anchor === b.anchor && a.at === b.at,
+      );
+      return null;
+    };
+    const { store } = renderWithStore(<Probe />);
+    expect(renders).toBe(1);
+
+    // Dispatch that changes nothing observable to this selector.
+    act(() => {
+      dispatchToUnreadStore(store, { type: 'USER_REACHED_BOTTOM', at: 500 });
+    });
+    // No re-render — selector output equal under the custom predicate.
+    expect(renders).toBe(1);
+  });
+});

--- a/src/modules/GroupChannel/context/hooks/useUnreadSelector.ts
+++ b/src/modules/GroupChannel/context/hooks/useUnreadSelector.ts
@@ -10,6 +10,19 @@
  * results because the memo cache only re-runs the selector when the raw
  * snapshot reference changes (see `useStoreSelector` JSDoc).
  *
+ * @example Module-level selector (preferred)
+ * ```ts
+ * const count = useUnreadSelector(selectUnreadCount);
+ * ```
+ *
+ * @example Selector that closes over a prop — STABILIZE with useCallback
+ * so prop changes invalidate the memo cache:
+ * ```ts
+ * const isUnread = useUnreadSelector(
+ *   useCallback((s) => selectIsMessageUnread(s, { messageId }), [messageId]),
+ * );
+ * ```
+ *
  * Internal — NOT re-exported from `src/index.ts`.
  */
 import { useStoreSelector, type EqualityFn } from '../../../../hooks/useStore';

--- a/src/modules/GroupChannel/context/hooks/useUnreadSelector.ts
+++ b/src/modules/GroupChannel/context/hooks/useUnreadSelector.ts
@@ -1,0 +1,24 @@
+/**
+ * Narrow-slice subscription hook over the unread reducer store.
+ *
+ * Phase 5.1.b of the P0 runtime-coupling refactor (Plan §5.1.b).
+ *
+ * Wraps `useStoreSelector` with the module-private
+ * `GroupChannelUnreadContext`. Selectors should be **module-level
+ * functions or `useCallback`-stabilized** — inline arrow selectors that
+ * close over render-scope variables can produce stale-on-first-commit
+ * results because the memo cache only re-runs the selector when the raw
+ * snapshot reference changes (see `useStoreSelector` JSDoc).
+ *
+ * Internal — NOT re-exported from `src/index.ts`.
+ */
+import { useStoreSelector, type EqualityFn } from '../../../../hooks/useStore';
+import type { UnreadState } from '../../internal/unread/model';
+import { GroupChannelUnreadContext } from '../GroupChannelUnreadContext';
+
+export function useUnreadSelector<TSelected>(
+  selector: (state: UnreadState) => TSelected,
+  equalityFn?: EqualityFn<TSelected>,
+): TSelected {
+  return useStoreSelector(GroupChannelUnreadContext, selector, equalityFn);
+}

--- a/src/modules/GroupChannel/internal/unread/__tests__/integration.spec.ts
+++ b/src/modules/GroupChannel/internal/unread/__tests__/integration.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Phase 5.1.a — unread integration smoke tests.
+ *
+ * Mirrors `internal/runtime/__tests__/integration.spec.ts` for the
+ * unread store. Covers the basic dispatch path plus the parallel-only
+ * (W1) invariant inherited from Phase 2.
+ */
+import {
+  createUnreadStore,
+  dispatchToUnreadStore,
+  UNREAD_DISPATCH_HOOK_GLOBAL_KEY,
+  type UnreadDispatchHookPayload,
+} from '../integration';
+
+describe('Phase 5.1.a — unread integration', () => {
+  afterEach(() => {
+    delete (globalThis as any)[UNREAD_DISPATCH_HOOK_GLOBAL_KEY];
+  });
+
+  it('createUnreadStore returns a store at the initial state', () => {
+    const store = createUnreadStore();
+    const s = store.getState();
+    expect(s.mode).toBe('clean');
+    expect(s.firstUnreadMessageId).toBeNull();
+    expect(s.firstUnreadCreatedAt).toBeNull();
+    expect(s.unreadCount).toBe(0);
+    expect(s.unreadMessageIds.size).toBe(0);
+  });
+
+  it('dispatchToUnreadStore applies the reducer and updates the store state', () => {
+    const store = createUnreadStore();
+    const next = dispatchToUnreadStore(
+      store,
+      { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 1, createdAt: 100 }], fromCurrentUser: false },
+      { isAtBottom: false },
+    );
+    expect(next.unreadCount).toBe(1);
+    expect(next.firstUnreadMessageId).toBe(1);
+    // applyStorePatch spreads into a new object, so the store reference
+    // differs from the reducer output — assert structural parity instead.
+    expect(store.getState()).toEqual(next);
+  });
+
+  it('dispatchToUnreadStore fires the global hook with event/context/state', () => {
+    const store = createUnreadStore();
+    const captured: UnreadDispatchHookPayload[] = [];
+    (globalThis as any)[UNREAD_DISPATCH_HOOK_GLOBAL_KEY] = (p: UnreadDispatchHookPayload) => captured.push(p);
+
+    dispatchToUnreadStore(store, { type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' });
+    dispatchToUnreadStore(
+      store,
+      { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 1, createdAt: 100 }], fromCurrentUser: false },
+      { isAtBottom: false },
+    );
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].event.type).toBe('CHANNEL_CHANGED');
+    expect(captured[1].event.type).toBe('MESSAGES_RECEIVED');
+    expect(captured[1].context.isAtBottom).toBe(false);
+  });
+
+  it('hook errors are swallowed so production callers are never affected', () => {
+    const store = createUnreadStore();
+    (globalThis as any)[UNREAD_DISPATCH_HOOK_GLOBAL_KEY] = () => { throw new Error('hook explode'); };
+    expect(() => {
+      dispatchToUnreadStore(store, { type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' });
+    }).not.toThrow();
+  });
+
+  it('subscribers are notified on state-changing dispatch', () => {
+    const store = createUnreadStore();
+    const spy = jest.fn();
+    store.subscribe(spy);
+    dispatchToUnreadStore(
+      store,
+      { type: 'MESSAGES_RECEIVED', messages: [{ messageId: 1, createdAt: 100 }], fromCurrentUser: false },
+      { isAtBottom: false },
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  // Inherits the W1 parallel-only invariant from Phase 2 (runtime). A
+  // malformed MARK_AS_UNREAD_SET event with `messageId: undefined` would
+  // not throw at the reducer (it just stores it). We instead pass an
+  // event with `type` outside the union and force the reducer through
+  // its default branch (still does not throw — same shape as runtime).
+  // To provoke a real throw we Object.freeze the store and then dispatch:
+  // applyStorePatch's hasStateChanged path runs lodash isEqual on the
+  // result, which is safe; but `applyStorePatch` itself calls
+  // `store.setState` which we can monkey-patch to throw — covered by a
+  // jest.spyOn on the store helper.
+  describe('parallel-only invariant (W1)', () => {
+    it('reducer/patch exceptions are swallowed and onError is invoked', () => {
+      const store = createUnreadStore();
+      const realSetState = store.setState;
+      // Force the patch path to throw — simulates a future bug where
+      // a downstream notifier mutates and breaks.
+      store.setState = jest.fn(() => { throw new Error('forced setState failure'); }) as any;
+      const onError = jest.fn();
+
+      const before = store.getState();
+      let returned: ReturnType<typeof dispatchToUnreadStore> | undefined;
+      expect(() => {
+        returned = dispatchToUnreadStore(
+          store,
+          { type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' },
+          undefined,
+          onError,
+        );
+      }).not.toThrow();
+
+      // Return value is the unchanged prior state.
+      expect(returned).toBe(before);
+      expect(onError).toHaveBeenCalledTimes(1);
+      const [errArg, eventArg] = onError.mock.calls[0];
+      expect(errArg).toBeInstanceOf(Error);
+      expect((errArg as Error).message).toBe('forced setState failure');
+      expect(eventArg).toEqual({ type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' });
+
+      store.setState = realSetState;
+    });
+
+    it('onError throwing does not propagate either', () => {
+      const store = createUnreadStore();
+      store.setState = jest.fn(() => { throw new Error('boom'); }) as any;
+      expect(() => {
+        dispatchToUnreadStore(
+          store,
+          { type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' },
+          undefined,
+          () => { throw new Error('onError exploded'); },
+        );
+      }).not.toThrow();
+    });
+
+    it('dispatch with no onError still swallows', () => {
+      const store = createUnreadStore();
+      store.setState = jest.fn(() => { throw new Error('boom'); }) as any;
+      expect(() => {
+        dispatchToUnreadStore(store, { type: 'CHANNEL_CHANGED', channelUrl: 'ch-x' });
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/modules/GroupChannel/internal/unread/integration.ts
+++ b/src/modules/GroupChannel/internal/unread/integration.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration glue for the GroupChannel unread reducer.
+ *
+ * Phase 5.1 of the P0 runtime-coupling refactor (Plan §5.1.a).
+ *
+ * Provides:
+ *   - `createUnreadStore(): Store<UnreadState>` — produces a
+ *     `createStore`-based handle seeded with `createInitialUnreadState()`.
+ *   - `dispatchToUnreadStore(store, event, context?, onError?)` — pure
+ *     helper that runs the reducer with the optional context hint, writes
+ *     the new state via `applyStorePatch`, and fires the dev/test
+ *     instrumentation hook so consumer specs can observe.
+ *
+ * **Parallel-only invariant** (inherited from W1, Plan §2.4 + spec §AC-8):
+ * A fault in the reducer or store layer MUST NOT prevent the legacy
+ * GroupChannelProvider callback from continuing. Any exception is caught
+ * here and surfaced via the optional `onError` callback. Hook exceptions
+ * are likewise caught.
+ *
+ * Internal — not exported via `src/index.ts`. BC-4 / BC-5 verify.
+ */
+import { createStore, applyStorePatch, type Store } from '../../../../utils/storeManager';
+import { unreadReducer, type UnreadEvent, type UnreadReducerContext } from './reducer';
+import { createInitialUnreadState, type UnreadState } from './model';
+
+/** Shape of the global dev/test dispatch instrumentation hook. */
+export type UnreadDispatchHookPayload = {
+  event: UnreadEvent;
+  context: UnreadReducerContext;
+  state: UnreadState;
+};
+
+export type UnreadDispatchHook = (payload: UnreadDispatchHookPayload) => void;
+
+/** Hook key on `globalThis` — read by tests to inspect dispatches. */
+export const UNREAD_DISPATCH_HOOK_GLOBAL_KEY = '__GROUP_CHANNEL_UNREAD_DISPATCH_HOOK__' as const;
+
+const DEFAULT_CONTEXT: UnreadReducerContext = { isAtBottom: true };
+
+/**
+ * Build the unread store. Returns the underlying `Store` so consumers
+ * can `subscribe` (the read hook in Phase 5.1.b will).
+ */
+export function createUnreadStore(seed?: Partial<UnreadState>): Store<UnreadState> {
+  return createStore<UnreadState>({ ...createInitialUnreadState(), ...(seed ?? {}) });
+}
+
+/**
+ * Apply a single event to the unread store. Pure transition through
+ * `unreadReducer`, then `applyStorePatch` to write the new state
+ * (equality short-circuit honored), then fire the instrumentation hook
+ * if present.
+ *
+ * Returns the resulting `UnreadState` so the caller can route effects
+ * synchronously without an extra `store.getState()`. On failure returns
+ * the unchanged previous state.
+ */
+export function dispatchToUnreadStore(
+  store: Store<UnreadState>,
+  event: UnreadEvent,
+  context: UnreadReducerContext = DEFAULT_CONTEXT,
+  onError?: (error: unknown, event: UnreadEvent) => void,
+): UnreadState {
+  const before = store.getState();
+  let next: UnreadState;
+  try {
+    next = unreadReducer(before, event, context);
+    applyStorePatch(store, next as Partial<UnreadState>, event.type);
+  } catch (error) {
+    if (onError) {
+      try {
+        onError(error, event);
+      } catch {
+        // onError must never propagate — see Plan §5.1.a / W1 rationale.
+      }
+    }
+    return before;
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    const hook = (globalThis as unknown as { [UNREAD_DISPATCH_HOOK_GLOBAL_KEY]?: UnreadDispatchHook })[
+      UNREAD_DISPATCH_HOOK_GLOBAL_KEY
+    ];
+    if (typeof hook === 'function') {
+      try {
+        hook({ event, context, state: next });
+      } catch {
+        // Swallow hook errors so they never affect production callers.
+      }
+    }
+  }
+  return next;
+}

--- a/src/modules/GroupChannel/internal/unread/integration.ts
+++ b/src/modules/GroupChannel/internal/unread/integration.ts
@@ -53,7 +53,10 @@ export function createUnreadStore(seed?: Partial<UnreadState>): Store<UnreadStat
  *
  * Returns the resulting `UnreadState` so the caller can route effects
  * synchronously without an extra `store.getState()`. On failure returns
- * the unchanged previous state.
+ * the unchanged previous state — note this differs from
+ * `dispatchToRuntime` which returns an empty `SideEffect[]` on failure;
+ * each return type is the unit appropriate to its caller's contract
+ * (state read-back here, effect routing there).
  */
 export function dispatchToUnreadStore(
   store: Store<UnreadState>,

--- a/src/modules/GroupChannel/internal/unread/selectors.ts
+++ b/src/modules/GroupChannel/internal/unread/selectors.ts
@@ -48,6 +48,19 @@ export const selectFirstUnreadCreatedAt = (s: UnreadState): number | null => s.f
 export const selectLastReadAt = (s: UnreadState): number | null => s.lastReadAt;
 
 /**
+ * True when the given message contributes to the unread count — i.e. it
+ * is one of the messages received while the user was away from the
+ * bottom (or pinned via mark-as-unread). Replaces the legacy
+ * `newMessageIds?.includes(message.messageId)` check at MessageView and
+ * is identity-stable per `Object.is` (returns a primitive).
+ *
+ * Phase 5.1.b — consumed by `MessageView` via `useUnreadSelector`.
+ */
+export function selectIsMessageUnread(s: UnreadState, message: SelectorMessage): boolean {
+  return s.unreadMessageIds.has(message.messageId);
+}
+
+/**
  * The separator renders ABOVE the first unread message — so for a given
  * candidate message, return true iff its id matches the anchor.
  */


### PR DESCRIPTION
## Summary

Phase 5.1 of the P0 runtime-coupling refactor (stacked on #1428). Lands the **dispatch-side and read-hook infrastructure** for the UnreadReducer that Phase 4 (#1428) ships as parity-only. Consumer reads remain on legacy state — see "Mid-cycle scope reduction" below.

- **Spec / Plan / Review**: `.agentic/p0-phase-5-1/{spec.md, plan.md, review/code-review.md}`
- **Cycle artifact**: status.json, mid-cycle decisions captured

## Phase-by-phase (4 commits)

| Phase | Commit | What |
|---|---|---|
| 5.1.a | `8facc8bb` | `internal/unread/integration.ts` + Provider `unreadDispatch` thunk (6 events wired) + 8 W1 invariant tests |
| 5.1.b | `9ceeae3a` | `GroupChannelUnreadContext` + `useUnreadSelector` + `selectIsMessageUnread` + 5 unit tests |
| 5.1.c | `4c414cbb` | REDUCED scope — type narrow of `getMessagePartsInfo.firstUnreadMessageId` only |
| G3 fix | `1fa01fa8` | 5 review improvements (I-1 idempotency / I-2 own-msg filter / I-3 typing / I-6 docs / I-7 JSDoc) |

## Mid-cycle scope reduction (important for reviewers)

Original 5.1.c planned to cut three consumer reads (`MessageView.newMessageIds`, `MessageList.unreadSinceDate`, `MessageList.finalFirstUnreadMessageId`) over to the new reducer-backed selectors. Mid-cycle audit revealed all three legacy fields encode semantics distinct from the Phase 4 reducer:

| Site | Legacy model | Reducer model | Conflict |
|------|--------------|---------------|----------|
| `newMessageIds` | gated by `isAutoscrollMessageOverflowToTop`; drives autoscroll | unconditional MESSAGES_RECEIVED | broader set → autoscroll fires more often |
| `unreadSinceDate` | `new Date()` wall clock at leave-bottom | `firstUnreadCreatedAt` = message epoch | UI label semantics differ |
| `finalFirstUnreadMessageId` | `currentChannel.myLastRead + 1` (server truth) + manual ref | session-local since-leave-bottom anchor | server-truth vs UIKit-session |

Phase 4's parity test compares the reducer against a simplified hand-rolled legacy model — it does NOT verify behavioral equivalence with real consumer code. Cutting any of the reads would be a **behavior change**, not a refactor.

This PR lands the dispatch + read-hook **infrastructure** with zero consumer impact, leaving the semantic decision to Phase 5.2.

## What ships in this PR

1. **Dispatch wiring** (`GroupChannelProvider`): `unreadStoreRef` + thunk-guarded `unreadDispatch(makeEvent, isAtBottom?)` + `dispatchChannelChanged(url)` (idempotent via `unreadChannelUrlRef`). 6 of 7 reducer events wired (MESSAGES_DELETED skipped — `@sendbird/uikit-tools@0.1.0` lacks `onMessagesDeleted`). All dispatches are additive to legacy state writes (dual-write).
2. **Read API** (module-private): `GroupChannelUnreadContext` + `useUnreadSelector<T>(selector, equalityFn?)`. NOT re-exported from `src/index.ts`.
3. **Selector**: `selectIsMessageUnread(s, message)` — primitive `boolean` return for identity stability.
4. **Type narrowing**: `getMessagePartsInfo.firstUnreadMessageId?: number | string | undefined` → `number | null | undefined`. All call sites already conform.

## Parallel-only invariant (W1 inheritance)

`dispatchToUnreadStore` mirrors `dispatchToRuntime`: try/catch around reducer + applyStorePatch, `onError` callback, hook error swallow. `unreadDispatch` thunk additionally catches mapper throws. Verified by 3 cases in `internal/unread/__tests__/integration.spec.ts` (forced setState failure → swallow + onError + state preserved + no-onError safe).

## BC invariants (all PASS)

- BC-1 `package.json` public fields unchanged
- BC-2 `dist/types/index.d.ts` export set unchanged
- BC-3 Context shape baseline well-formed
- BC-4 dts does NOT re-export from `internal/`
- BC-5 No external source imports from `internal/`
- BC-6 `scrollPubSub` topic + payload set unchanged

## Test plan

- [x] `./scripts/bc-check.sh` — BC-1 ~ BC-6 all PASS
- [x] `yarn jest` — 196/198 PASS (2 pre-existing skipped, 0 fail), 1125 tests + 10 skipped — +13 new specs over #1428 baseline
- [x] 5× deterministic re-run of P0 internal/unread + Phase 5.1 specs (5 suites / 50 tests) — stable
- [x] `yarn build` clean (pre-existing warnings only)
- [x] G3 code review (deep, js-agent) — Ship verdict, all 5 follow-up items applied

## Phase 5.2 hand-off (must read before consumer migration)

The infrastructure landed here cannot drive consumer reads until the reducer semantics are reconciled with real consumer expectations. Phase 5.2 should:

1. **Audit the reducer's anchor semantics** against the actual MessageList consumer pipeline (myLastRead-based vs session-local).
2. **Decide whether the reducer's session-local model is the desired consumer model** (intentional product improvement) or whether the reducer should be redesigned to match server-truth.
3. **Replace Phase 4's parity test** with one that compares against real consumer outputs, not a hand-rolled simplified legacy model.
4. **Address the `fromCurrentUser` semantic** explicitly during cut-read (this PR already fixes the most painful version via filter-before-dispatch).

## Out of scope (intentional)

- Consumer cut-reads (deferred per mid-cycle decision)
- `MESSAGES_DELETED` wiring (pending uikit-tools version bump)
- ScrollController / RuntimeStore consumer migration (separate cycles)
- Legacy state slice removal (`newMessageIds`, `firstUnreadMessageId`) — still authoritative

## Stacking note

Base = `refactor/p0-phase-4-unread-reducer` (PR #1428). Once #1428 merges to main, this PR's base will be updated and rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)