### PR TITLE
[fix]: declare is_test input in release workflow dispatch

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release Ticket Key (e.g., UIKIT-1234)'
         required: true
         type: string
+      is_test:
+        description: 'Sent by the SDK Release automation; declared so the dispatch is accepted'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

The SDK Release Jira automation dispatches `release-workflow.yml` with an `is_test` input in addition to `release_ticket_key`. The workflow declared only `release_ticket_key`, so GitHub rejected the dispatch with `422 Unexpected inputs provided: ["is_test"]` — the workflow never started and the v3.18.0 release ticket (SDKRLSD-2136) auto-rolled back to Conditional Release Approved.

This declares `is_test` (boolean, default `false`) so the dispatch is accepted. It must land on `main`, since `workflow_dispatch` inputs are validated against the workflow definition on the default branch.

## Context

- Release ticket: SDKRLSD-2136
- Dispatch error: `422 Unexpected inputs provided: ["is_test"]`

## Follow-up

The production workflow diverged from the canonical SDK release template (the test repo also declared `skip_npm` / `npm_dry_run`). A broader alignment review with the release-platform team may be worthwhile; this PR is the minimal change to unblock the v3.18.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
