### PR TITLE
[chore]: auto-approve release PRs via automation

### DIFF
--- a/.github/workflows/approve-by-automation.yml
+++ b/.github/workflows/approve-by-automation.yml
@@ -9,14 +9,21 @@ permissions:
 
 jobs:
   approve-release-pr:
-    if: startsWith(github.head_ref, 'release/v')
+    if: github.base_ref == 'main' && startsWith(github.head_ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - name: Approve release pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr review "${{ github.event.pull_request.number }}" \
+          if ! printf '%s' "$HEAD_REF" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Not an exact release/vX.Y.Z branch ('$HEAD_REF'); skipping auto-approval."
+            exit 0
+          fi
+          gh pr review "$PR_NUMBER" \
             --approve \
-            --body "Auto-approved: release branch PR. Release is gated by the Jira EM approval." \
-            --repo "${{ github.repository }}"
+            --body "Auto-approved: release branch PR (release/vX.Y.Z). Release is gated by the Jira EM approval." \
+            --repo "$REPO"

--- a/.github/workflows/approve-by-automation.yml
+++ b/.github/workflows/approve-by-automation.yml
@@ -1,0 +1,22 @@
+name: Approve by automation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve-release-pr:
+    if: startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve release pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --approve \
+            --body "Auto-approved: release branch PR. Release is gated by the Jira EM approval." \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Adds `approve-by-automation.yml` to auto-approve release PRs (head branch `release/v*`) so the automated release can merge to `main` after the Jira EM approval, without a manual GitHub review.

Without this, the release workflow's `Merge release branch to main` step fails branch protection — `At least 1 approving review is required by reviewers with write access` (hit on the v3.18.0 attempt).

## Scoping & safety

- Approves **only** PRs whose head branch starts with `release/v` — feature PRs are untouched and still need normal human review.
- `permissions: pull-requests: write` (minimum needed to approve).
- Triggers on `opened` / `reopened` / `synchronize` so the approval is re-applied if branch protection dismisses it when the release workflow pushes the CHANGELOG finalize commit.

## Context

- Ported (and scoped) from the `uikit-react-release-test` repo, which had this workflow but it was never carried over to production. (Same class of gap as the missing `is_test` dispatch input.)
- The release gate of record remains the **Jira EM approval** (SDKRLSD ticket); this only handles the mechanical GitHub review gate.

## Note

This relies on the github-actions bot approval counting toward branch protection's required review (works in the test repo). If production branch protection rejects bot approvals, we'll need a PAT or GitHub App instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
