### PR TITLE
refactor(group-channel): Phase 5.2.b Hybrid hydration + consumer cut-read (stacked on #1430)

### DIFF
--- a/src/__tests__/p0-baseline/context-shape-baseline.json
+++ b/src/__tests__/p0-baseline/context-shape-baseline.json
@@ -34,7 +34,6 @@
     "markAsReadAll": "function",
     "markAsUnread": "function",
     "setReadStateChanged": "function",
-    "setFirstUnreadMessageId": "function",
     "setNewMessageIds": "function",
     "setQuoteMessage": "function",
     "scrollToBottom": "function",

--- a/src/modules/GroupChannel/components/MessageList/__tests__/unreadSeparator.integration.spec.tsx
+++ b/src/modules/GroupChannel/components/MessageList/__tests__/unreadSeparator.integration.spec.tsx
@@ -1,0 +1,221 @@
+/**
+ * Phase 5.2.b.c — UnreadReducer ↔ consumer integration.
+ *
+ * Scoped down from the original AC-5 (which proposed mounting the full
+ * `<GroupChannelProvider>` stack with mocked SDK + collection). The
+ * Provider's dependency chain (useSendbird, useGroupChannelMessages,
+ * useGroupChannelHandler, scroll plumbing) is too heavy for a unit-style
+ * jest mount — initial attempt OOM'd. Per Plan §5 risk mitigation, we
+ * fall back to exercising the same observable behavior via:
+ *
+ *   1. The reducer + integration helper (5.2.b.a/5.2.b.b code path)
+ *   2. The `useUnreadSelector` hook reading through the context
+ *
+ * This covers the contract MessageList.firstUnreadMessage (5.2.b.c) now
+ * depends on: dispatch → reducer state → selector output. The
+ * Provider's `useEffect` shape itself is straightforward and is already
+ * type-checked + built; a future cycle can add a full app-shell spec if
+ * the integration risk merits it.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { GroupChannelUnreadContext } from '../../../context/GroupChannelUnreadContext';
+import { useUnreadSelector } from '../../../context/hooks/useUnreadSelector';
+import {
+  createUnreadStore,
+  dispatchToUnreadStore,
+} from '../../../internal/unread/integration';
+import {
+  selectFirstUnreadMessageId,
+  selectFirstUnreadCreatedAt,
+  selectUnreadCount,
+  selectUnreadMode,
+} from '../../../internal/unread/selectors';
+
+type Observed = {
+  firstUnreadMessageId: number | null;
+  firstUnreadCreatedAt: number | null;
+  unreadCount: number;
+  mode: ReturnType<typeof selectUnreadMode>;
+};
+
+let observed: Observed = {
+  firstUnreadMessageId: null,
+  firstUnreadCreatedAt: null,
+  unreadCount: 0,
+  mode: 'clean',
+};
+
+const Probe: React.FC = () => {
+  observed = {
+    firstUnreadMessageId: useUnreadSelector(selectFirstUnreadMessageId),
+    firstUnreadCreatedAt: useUnreadSelector(selectFirstUnreadCreatedAt),
+    unreadCount: useUnreadSelector(selectUnreadCount),
+    mode: useUnreadSelector(selectUnreadMode),
+  };
+  return null;
+};
+
+function mount(store = createUnreadStore()) {
+  return render(
+    <GroupChannelUnreadContext.Provider value={store}>
+      <Probe />
+    </GroupChannelUnreadContext.Provider>,
+  );
+}
+
+describe('Phase 5.2.b.c — UnreadReducer ↔ consumer integration', () => {
+  beforeEach(() => {
+    observed = { firstUnreadMessageId: null, firstUnreadCreatedAt: null, unreadCount: 0, mode: 'clean' };
+  });
+
+  it('mount with no dispatch → consumer sees clean state', () => {
+    mount();
+    expect(observed.mode).toBe('clean');
+    expect(observed.firstUnreadMessageId).toBeNull();
+    expect(observed.unreadCount).toBe(0);
+  });
+
+  it('CHANNEL_HYDRATED with server unread → consumer sees seeded tracking', () => {
+    const store = createUnreadStore();
+    mount(store);
+    expect(observed.mode).toBe('clean');
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch-pre',
+        unreadCount: 3,
+        firstUnreadMessageId: 20,
+        firstUnreadCreatedAt: 1500,
+        unreadMessageIds: [20, 21, 22],
+        lastReadAt: 1000,
+      });
+    });
+    expect(observed.mode).toBe('tracking');
+    expect(observed.firstUnreadMessageId).toBe(20);
+    expect(observed.firstUnreadCreatedAt).toBe(1500);
+    expect(observed.unreadCount).toBe(3);
+  });
+
+  it('CHANNEL_HYDRATED with zero unread → consumer stays clean (lastReadAt records)', () => {
+    const store = createUnreadStore();
+    mount(store);
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch-clean',
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        firstUnreadCreatedAt: null,
+        unreadMessageIds: [],
+        lastReadAt: 2000,
+      });
+    });
+    expect(observed.mode).toBe('clean');
+    expect(observed.firstUnreadMessageId).toBeNull();
+    expect(observed.unreadCount).toBe(0);
+    expect(store.getState().lastReadAt).toBe(2000);
+  });
+
+  it('hydrate + receive away from bottom → count grows, anchor stays on first seed', () => {
+    const store = createUnreadStore();
+    mount(store);
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch1',
+        unreadCount: 2,
+        firstUnreadMessageId: 10,
+        firstUnreadCreatedAt: 1000,
+        unreadMessageIds: [10, 11],
+        lastReadAt: 999,
+      });
+    });
+    expect(observed.firstUnreadMessageId).toBe(10);
+    expect(observed.unreadCount).toBe(2);
+
+    act(() => {
+      dispatchToUnreadStore(
+        store,
+        {
+          type: 'MESSAGES_RECEIVED',
+          messages: [{ messageId: 12, createdAt: 1100 }, { messageId: 13, createdAt: 1200 }],
+          fromCurrentUser: false,
+        },
+        { isAtBottom: false },
+      );
+    });
+    expect(observed.firstUnreadMessageId).toBe(10); // anchor unchanged
+    expect(observed.unreadCount).toBe(4);
+  });
+
+  it('hydrate + mark-as-unread → user pin overrides, mode=marked-unread', () => {
+    const store = createUnreadStore();
+    mount(store);
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch1',
+        unreadCount: 1,
+        firstUnreadMessageId: 50,
+        firstUnreadCreatedAt: 5000,
+        unreadMessageIds: [50],
+        lastReadAt: 4900,
+      });
+    });
+    expect(observed.firstUnreadMessageId).toBe(50);
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'MARK_AS_UNREAD_SET',
+        messageId: 99,
+        createdAt: 9900,
+      });
+    });
+    expect(observed.mode).toBe('marked-unread');
+    expect(observed.firstUnreadMessageId).toBe(99);
+  });
+
+  it('hydrate then channel switch → fresh seed survives the previous state', () => {
+    const store = createUnreadStore();
+    mount(store);
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch-a',
+        unreadCount: 2,
+        firstUnreadMessageId: 10,
+        firstUnreadCreatedAt: 1000,
+        unreadMessageIds: [10, 11],
+        lastReadAt: 999,
+      });
+    });
+    expect(observed.firstUnreadMessageId).toBe(10);
+
+    act(() => {
+      dispatchToUnreadStore(store, { type: 'CHANNEL_CHANGED', channelUrl: 'ch-b' });
+    });
+    expect(observed.mode).toBe('clean');
+    expect(observed.firstUnreadMessageId).toBeNull();
+
+    act(() => {
+      dispatchToUnreadStore(store, {
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: 'ch-b',
+        unreadCount: 5,
+        firstUnreadMessageId: 200,
+        firstUnreadCreatedAt: 20000,
+        unreadMessageIds: [200, 201, 202, 203, 204],
+        lastReadAt: 19999,
+      });
+    });
+    expect(observed.firstUnreadMessageId).toBe(200);
+    expect(observed.unreadCount).toBe(5);
+  });
+});

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -22,6 +22,8 @@ import { MessageProvider } from '../../../Message/context/MessageProvider';
 import { getComponentKeyFromMessage, isContextMenuClosed } from '../../context/utils';
 import { InfiniteList } from './InfiniteList';
 import { useGroupChannel } from '../../context/hooks/useGroupChannel';
+import { useUnreadSelector } from '../../context/hooks/useUnreadSelector';
+import { selectFirstUnreadMessageId } from '../../internal/unread/selectors';
 import useSendbird from '../../../../lib/Sendbird/context/hooks/useSendbird';
 import { useLocalization } from '../../../../lib/LocalizationContext';
 
@@ -115,30 +117,50 @@ export const MessageList = (props: GroupChannelMessageListProps) => {
   const separatorMessageRef = useRef<CoreMessageType | undefined>(undefined);
   const isUnreadMessageExistInChannel = useRef<boolean>(false);
 
-  // Find the first unread message
-  const firstUnreadMessage = useMemo(() => {
-    if (!enableMarkAsUnread || !isInitializedRef.current || messages.length === 0 || readState === 'read' || !currentChannel?.myLastRead) {
-      return undefined;
-    }
+  // Phase 5.2.b.c — first-unread anchor cut-read.
+  // Source of truth is now the UnreadReducer, seeded at mount via
+  // CHANNEL_HYDRATED (Provider) and updated by USER_LEFT_BOTTOM /
+  // MESSAGES_RECEIVED / MARK_AS_UNREAD_SET / READ_CONFIRMED. The
+  // selector returns the messageId; we look up the full message object
+  // from the current messages array for downstream consumers that need
+  // it (separatorMessageRef pins the object across renders).
+  //
+  // The legacy MAU-mode gates (enableMarkAsUnread, isInitializedRef,
+  // messages.length, readState) are preserved: when MAU is off, or the
+  // channel isn't initialized yet, or readState is 'read', the consumer
+  // should not see a separator. We apply these gates here, before
+  // returning the message object derived from the selector.
+  const firstUnreadMessageIdFromReducer = useUnreadSelector(selectFirstUnreadMessageId);
 
+  // readState='unread' side effect previously embedded in the useMemo —
+  // promote to an effect so the render is pure.
+  useEffect(() => {
     if (readState === 'unread') {
       separatorMessageRef.current = undefined;
       isUnreadMessageExistInChannel.current = true;
     }
+  }, [readState]);
 
+  const firstUnreadMessage = useMemo<CoreMessageType | undefined>(() => {
+    if (!enableMarkAsUnread || !isInitializedRef.current || messages.length === 0 || readState === 'read' || !currentChannel?.myLastRead) {
+      return undefined;
+    }
+    if (firstUnreadMessageIdFromReducer !== null) {
+      const matched = messages.find((m) => m.messageId === firstUnreadMessageIdFromReducer);
+      if (matched && !isAdminMessage(matched as any)) {
+        return matched as CoreMessageType;
+      }
+    }
+    // Fallback for pagination cases where the reducer has no seed yet
+    // (or the seed message isn't in the loaded window). Preserves the
+    // legacy myLastRead+1 derivation as a safety net during the
+    // hydrate-timing gap (Plan §R-2).
     const myLastRead = currentChannel.myLastRead;
     const willFindMessageCreatedAt = myLastRead + 1;
-
-    // 조건 1: 정확히 myLastRead + 1인 메시지 찾기
     const exactMatchMessage = messages.find((message) => message.createdAt === willFindMessageCreatedAt);
-
-    if (exactMatchMessage) {
-      return exactMatchMessage as CoreMessageType;
-    }
-
-    // 조건 2: myLastRead + 1보다 큰 첫 번째 메시지 찾기 (Admin 메시지 제외)
+    if (exactMatchMessage) return exactMatchMessage as CoreMessageType;
     return messages.find((message) => message.createdAt > willFindMessageCreatedAt && !isAdminMessage(message as any)) as CoreMessageType | undefined;
-  }, [messages, currentChannel?.myLastRead, readState]);
+  }, [firstUnreadMessageIdFromReducer, messages, currentChannel?.myLastRead, readState, enableMarkAsUnread]);
 
   useEffect(() => {
     if (currentChannel?.url && loading) {

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -199,15 +199,17 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     }
   }, [logger]);
 
-  // Phase 5.1.a — Unread reducer store. Dual-write strategy (spec §AC-4):
-  // dispatch fires alongside the legacy `setNewMessageIds` /
-  // `setFirstUnreadMessageId` calls. Phase 5.1.b/c switch consumer reads
-  // over to this store via `useUnreadSelector`; the legacy state slice is
-  // retained until Phase 5.2 has a verification window.
+  // Unread reducer store. Reads consume this via `useUnreadSelector`.
+  // - 5.1.a wired dispatch sites alongside the legacy `setNewMessageIds`
+  //   call (which remains for its autoscroll signal — distinct concern).
+  // - 5.1.b exposed the read API via `GroupChannelUnreadContext`.
+  // - 5.2.b.b added the CHANNEL_HYDRATED seed at mount (below).
+  // - 5.2.b.c migrated MessageList.firstUnreadMessage to read from the
+  //   selector.
   //
-  // MESSAGES_DELETED is intentionally NOT dispatched — `@sendbird/uikit-tools@0.1.0`
-  // does not expose `onMessagesDeleted` (Plan §1). Re-evaluate when the
-  // uikit-tools bump (separate follow-up) ships that callback.
+  // MESSAGES_DELETED is intentionally NOT dispatched —
+  // `@sendbird/uikit-tools@0.1.0` does not expose `onMessagesDeleted`.
+  // Re-evaluate when the uikit-tools bump ships that callback.
   const unreadStoreRef = useRef(createUnreadStore());
 
   // Tracks the last channelUrl observed by the unread store so repeated

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -219,12 +219,23 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   // double-fire and any future subscriber re-render.
   const unreadChannelUrlRef = useRef<string | null>(null);
 
+  // 5.2.b G3 review I-1 — `useGroupChannelMessages` calls
+  // `updateInitialized(false)` then `(true)` inside `resetWithStartingPoint`
+  // (verified against the published source). Without this guard, jumping
+  // to an older message would re-fire the hydrate effect against the new
+  // message window and clobber any tracking state accumulated since the
+  // original mount. Hydrate once per channel; subsequent re-initializations
+  // are noops.
+  const hydratedChannelUrlRef = useRef<string | null>(null);
+
   // Thunk-guarded dispatch — see runtimeDispatch (W1). A bug in the
   // reducer or in a caller-supplied factory MUST NOT prevent the legacy
   // callback from continuing.
   const dispatchChannelChanged = useCallback((channelUrl: string) => {
     if (unreadChannelUrlRef.current === channelUrl) return;
     unreadChannelUrlRef.current = channelUrl;
+    // Reset the hydrate dedup ref so the new channel can be seeded once.
+    hydratedChannelUrlRef.current = null;
     return dispatchToUnreadStore(
       unreadStoreRef.current,
       { type: 'CHANNEL_CHANGED', channelUrl },
@@ -453,6 +464,13 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   useEffect(() => {
     if (!messageDataSource.initialized || !state.currentChannel) return;
     const channel = state.currentChannel;
+    // I-1 guard: hydrate at most once per channel mount. resetWithStartingPoint
+    // (jump-to-message) inside useGroupChannelMessages flips `initialized`
+    // false→true again with a different message window; without this guard
+    // the second pass would clobber tracking state.
+    if (hydratedChannelUrlRef.current === channel.url) return;
+    hydratedChannelUrlRef.current = channel.url;
+
     const myLastRead = channel.myLastRead ?? 0;
     const serverUnreadCount = channel.unreadMessageCount ?? 0;
     if (serverUnreadCount === 0) {
@@ -467,18 +485,18 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
       }));
       return;
     }
-    const unreadMessages = messageDataSource.messages.filter(
-      (m: { createdAt: number; sender?: { userId?: string } }) =>
-        m.createdAt > myLastRead && m.sender?.userId !== userId,
+    const peerUnread = messageDataSource.messages.filter(
+      (m) => m.createdAt > myLastRead
+        && (m as { sender?: { userId?: string } }).sender?.userId !== userId,
     );
-    const first = unreadMessages[0];
+    const first = peerUnread[0];
     unreadDispatch(() => ({
       type: 'CHANNEL_HYDRATED',
       channelUrl: channel.url,
       unreadCount: serverUnreadCount,
-      firstUnreadMessageId: first ? (first as { messageId: number }).messageId : null,
-      firstUnreadCreatedAt: first ? (first as { createdAt: number }).createdAt : null,
-      unreadMessageIds: unreadMessages.map((m) => (m as { messageId: number }).messageId),
+      firstUnreadMessageId: first ? first.messageId : null,
+      firstUnreadCreatedAt: first ? first.createdAt : null,
+      unreadMessageIds: peerUnread.map((m) => m.messageId),
       lastReadAt: myLastRead,
     }));
   }, [messageDataSource.initialized, state.currentChannel?.url, userId, unreadDispatch]);

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -431,6 +431,56 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     }
   }, [isScrollBottomReached, unreadDispatch]);
 
+  // Phase 5.2.b — Hydrate UnreadReducer from SDK state once the message
+  // collection is initialized. The session-local reducer needs this
+  // one-shot seed to know about pre-existing server-side unread (e.g.
+  // user enters a channel where unreadMessageCount > 0). Without this,
+  // consumer cut-read of firstUnreadMessage would regress (see
+  // .agentic/p0-phase-5-2a/audit.md §4.1).
+  //
+  // Effect dependencies: re-runs on channel switch and when the message
+  // collection finishes its initial fetch. CHANNEL_CHANGED (5.1.a) fires
+  // earlier on switch, so the reducer is already at clean state when
+  // this hydrate runs — ordering is correct.
+  //
+  // Pagination caveat (R-1): if messageDataSource.messages does not
+  // include the anchor (myLastRead + 1) because older messages aren't
+  // loaded, firstUnreadMessageId falls back to null. The badge still
+  // shows server count, but no separator anchor renders until more
+  // history loads. Accepted limitation for v1.
+  useEffect(() => {
+    if (!messageDataSource.initialized || !state.currentChannel) return;
+    const channel = state.currentChannel;
+    const myLastRead = channel.myLastRead ?? 0;
+    const serverUnreadCount = channel.unreadMessageCount ?? 0;
+    if (serverUnreadCount === 0) {
+      unreadDispatch(() => ({
+        type: 'CHANNEL_HYDRATED',
+        channelUrl: channel.url,
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        firstUnreadCreatedAt: null,
+        unreadMessageIds: [],
+        lastReadAt: myLastRead,
+      }));
+      return;
+    }
+    const unreadMessages = messageDataSource.messages.filter(
+      (m: { createdAt: number; sender?: { userId?: string } }) =>
+        m.createdAt > myLastRead && m.sender?.userId !== userId,
+    );
+    const first = unreadMessages[0];
+    unreadDispatch(() => ({
+      type: 'CHANNEL_HYDRATED',
+      channelUrl: channel.url,
+      unreadCount: serverUnreadCount,
+      firstUnreadMessageId: first ? (first as { messageId: number }).messageId : null,
+      firstUnreadCreatedAt: first ? (first as { createdAt: number }).createdAt : null,
+      unreadMessageIds: unreadMessages.map((m) => (m as { messageId: number }).messageId),
+      lastReadAt: myLastRead,
+    }));
+  }, [messageDataSource.initialized, state.currentChannel?.url, userId, unreadDispatch]);
+
   // Channel initialization
   useAsyncEffect(async () => {
     if (sdkStore.initialized && channelUrl) {

--- a/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
+++ b/src/modules/GroupChannel/context/hooks/useGroupChannel.ts
@@ -27,7 +27,6 @@ export interface GroupChannelActions extends MessageActions {
   markAsReadAll: (channel: GroupChannel) => void;
   markAsUnread: (message: SendableMessageType, source?: 'manual' | 'internal') => void;
   setReadStateChanged: (state: string) => void;
-  setFirstUnreadMessageId: (messageId: number | string | null) => void;
 
   // Message actions
   sendUserMessage: (params: UserMessageCreateParams) => Promise<UserMessage>;
@@ -220,9 +219,11 @@ export const useGroupChannel = () => {
     store.setState(state => ({ ...state, readState }));
   }, []);
 
-  const setFirstUnreadMessageId = useCallback((messageId: number | null) => {
-    store.setState(state => ({ ...state, firstUnreadMessageId: messageId }));
-  }, []);
+  // Phase 5.2.b.d — setFirstUnreadMessageId removed (dead code).
+  // The action was declared but never called anywhere in the source
+  // tree; `state.firstUnreadMessageId` was never part of initial state.
+  // The UnreadReducer's `selectFirstUnreadMessageId` is now the
+  // authoritative source via 5.1.b/5.2.b.c.
 
   const setNewMessageIds = useCallback((newMessageIds: number[]) => {
     store.setState(state => ({ ...state, newMessageIds }));
@@ -235,7 +236,6 @@ export const useGroupChannel = () => {
       markAsReadAll,
       markAsUnread: state.markAsUnread,
       setReadStateChanged,
-      setFirstUnreadMessageId,
       setNewMessageIds,
       setQuoteMessage,
       scrollToBottom,
@@ -251,7 +251,6 @@ export const useGroupChannel = () => {
     markAsReadAll,
     state.markAsUnread,
     setReadStateChanged,
-    setFirstUnreadMessageId,
     setQuoteMessage,
     scrollToBottom,
     scrollToMessage,

--- a/src/modules/GroupChannel/internal/unread/__tests__/reducer.transitions.spec.ts
+++ b/src/modules/GroupChannel/internal/unread/__tests__/reducer.transitions.spec.ts
@@ -247,9 +247,93 @@ describe('Phase 4 — unreadReducer transitions (RV-4.1 et al)', () => {
     expect(r.unreadCount).toBe(0);
   });
 
+  /* ─── CHANNEL_HYDRATED (5.2.b.a) ─────────────────────────────── */
+  it('CHANNEL_HYDRATED from clean with zero unread → clean state, lastReadAt recorded', () => {
+    const r = unreadReducer(createInitialUnreadState(), {
+      type: 'CHANNEL_HYDRATED',
+      channelUrl: 'ch1',
+      unreadCount: 0,
+      firstUnreadMessageId: null,
+      firstUnreadCreatedAt: null,
+      unreadMessageIds: [],
+      lastReadAt: 5000,
+    });
+    expect(r.mode).toBe('clean');
+    expect(r.firstUnreadMessageId).toBeNull();
+    expect(r.unreadCount).toBe(0);
+    expect(r.unreadMessageIds.size).toBe(0);
+    expect(r.lastReadAt).toBe(5000);
+    expect(r.separatorVisible).toBe(false);
+    expect(r.badgeVisible).toBe(false);
+  });
+
+  it('CHANNEL_HYDRATED from clean with N unread → tracking with seeded anchor + set', () => {
+    const r = unreadReducer(createInitialUnreadState(), {
+      type: 'CHANNEL_HYDRATED',
+      channelUrl: 'ch1',
+      unreadCount: 3,
+      firstUnreadMessageId: 42,
+      firstUnreadCreatedAt: 4200,
+      unreadMessageIds: [42, 43, 44],
+      lastReadAt: 4100,
+    });
+    expect(r.mode).toBe('tracking');
+    expect(r.firstUnreadMessageId).toBe(42);
+    expect(r.firstUnreadCreatedAt).toBe(4200);
+    expect(r.unreadCount).toBe(3);
+    expect(r.unreadMessageIds.size).toBe(3);
+    expect(r.unreadMessageIds.has(42)).toBe(true);
+    expect(r.unreadMessageIds.has(44)).toBe(true);
+    expect(r.separatorVisible).toBe(true);
+    expect(r.badgeVisible).toBe(true);
+    expect(r.lastReadAt).toBe(4100);
+  });
+
+  it('CHANNEL_HYDRATED into marked-unread mode does NOT clobber the user pin', () => {
+    const marked = unreadReducer(createInitialUnreadState(), {
+      type: 'MARK_AS_UNREAD_SET',
+      messageId: 99,
+      createdAt: 9900,
+    });
+    expect(marked.mode).toBe('marked-unread');
+    expect(marked.firstUnreadMessageId).toBe(99);
+
+    const r = unreadReducer(marked, {
+      type: 'CHANNEL_HYDRATED',
+      channelUrl: 'ch1',
+      unreadCount: 2,
+      firstUnreadMessageId: 50,
+      firstUnreadCreatedAt: 5000,
+      unreadMessageIds: [50, 51],
+      lastReadAt: 4500,
+    });
+    expect(r.mode).toBe('marked-unread');
+    expect(r.firstUnreadMessageId).toBe(99); // user pin wins
+    expect(r.lastReadAt).toBe(4500); // but lastReadAt does refresh
+  });
+
+  it('USER_REACHED_BOTTOM after CHANNEL_HYDRATED-tracking clears unread normally', () => {
+    let s = unreadReducer(createInitialUnreadState(), {
+      type: 'CHANNEL_HYDRATED',
+      channelUrl: 'ch1',
+      unreadCount: 2,
+      firstUnreadMessageId: 10,
+      firstUnreadCreatedAt: 1000,
+      unreadMessageIds: [10, 11],
+      lastReadAt: 999,
+    });
+    expect(s.mode).toBe('tracking');
+
+    s = unreadReducer(s, { type: 'USER_REACHED_BOTTOM', at: 2000 });
+    expect(s.mode).toBe('clean');
+    expect(s.unreadCount).toBe(0);
+    expect(s.shouldMarkAsRead).toBe(true);
+    expect(s.firstUnreadMessageId).toBeNull();
+  });
+
   /* ─── Exhaustiveness ──────────────────────────────────────────── */
-  it('ALL_UNREAD_EVENT_TYPES enumerates the 7 documented variants', () => {
-    expect(ALL_UNREAD_EVENT_TYPES.length).toBe(7);
+  it('ALL_UNREAD_EVENT_TYPES enumerates the 8 documented variants', () => {
+    expect(ALL_UNREAD_EVENT_TYPES.length).toBe(8);
     for (const t of ALL_UNREAD_EVENT_TYPES) {
       expect(t).toMatch(/^[A-Z_]+$/);
     }

--- a/src/modules/GroupChannel/internal/unread/reducer.ts
+++ b/src/modules/GroupChannel/internal/unread/reducer.ts
@@ -45,12 +45,24 @@ export type UnreadEvent =
   | { type: 'MESSAGES_DELETED'; messageIds: ReadonlyArray<number> }
   | { type: 'MARK_AS_UNREAD_SET'; messageId: number; createdAt: number }
   | { type: 'READ_CONFIRMED'; channelUrl: string; at: number }
-  | { type: 'CHANNEL_CHANGED'; channelUrl: string };
+  | { type: 'CHANNEL_CHANGED'; channelUrl: string }
+  | {
+      // Phase 5.2.b — one-shot seed at channel mount from SDK state.
+      // See .agentic/p0-phase-5-2b/spec.md §AC-1 + decision.md §4.1.
+      type: 'CHANNEL_HYDRATED';
+      channelUrl: string;
+      unreadCount: number;
+      firstUnreadMessageId: number | null;
+      firstUnreadCreatedAt: number | null;
+      unreadMessageIds: ReadonlyArray<number>;
+      lastReadAt: number;
+    };
 
 export type UnreadEventType = UnreadEvent['type'];
 
 export const ALL_UNREAD_EVENT_TYPES: ReadonlyArray<UnreadEventType> = [
   'CHANNEL_CHANGED',
+  'CHANNEL_HYDRATED',
   'MARK_AS_UNREAD_SET',
   'MESSAGES_DELETED',
   'MESSAGES_RECEIVED',
@@ -227,6 +239,51 @@ export function unreadReducer(
     case 'CHANNEL_CHANGED': {
       // Re-initialize for the new channel.
       return createInitialUnreadState();
+    }
+
+    case 'CHANNEL_HYDRATED': {
+      // Phase 5.2.b — bootstrap from SDK state at channel mount.
+      // Marked-unread mode is the user's explicit pin and takes
+      // precedence over any server-derived seed; do not clobber.
+      if (state.mode === 'marked-unread') {
+        return { ...state, lastReadAt: event.lastReadAt };
+      }
+      if (event.unreadCount === 0) {
+        // Server says no unread — transition to clean. Preserve any
+        // shouldMarkAsRead intent already raised (rare; usually false).
+        if (state.mode === 'clean' && state.unreadCount === 0 && state.lastReadAt === event.lastReadAt) {
+          return state;
+        }
+        return {
+          ...state,
+          mode: 'clean',
+          firstUnreadMessageId: null,
+          firstUnreadCreatedAt: null,
+          unreadMessageIds: UNREAD_STATE_SENTINELS.EMPTY_NUMBER_SET,
+          unreadCount: 0,
+          separatorVisible: false,
+          badgeVisible: false,
+          lastReadAt: event.lastReadAt,
+        };
+      }
+      // Server has unread — enter tracking with the supplied seed.
+      const idSet = event.unreadMessageIds.length > 0
+        ? new Set(event.unreadMessageIds)
+        : (event.firstUnreadMessageId !== null
+            ? new Set([event.firstUnreadMessageId])
+            : UNREAD_STATE_SENTINELS.EMPTY_NUMBER_SET as Set<number>);
+      return {
+        ...state,
+        mode: 'tracking',
+        firstUnreadMessageId: event.firstUnreadMessageId,
+        firstUnreadCreatedAt: event.firstUnreadCreatedAt,
+        unreadMessageIds: idSet,
+        unreadCount: event.unreadCount,
+        separatorVisible: event.firstUnreadMessageId !== null,
+        badgeVisible: event.unreadCount > 0,
+        shouldMarkAsRead: false,
+        lastReadAt: event.lastReadAt,
+      };
     }
 
     default: {


### PR DESCRIPTION
## Summary

Phase 5.2.b of the P0 runtime-coupling refactor (stacked on #1430). Implements **Model C — Hybrid** from the 5.2.a investigate cycle: the session-local UnreadReducer is seeded at channel mount with a one-shot `CHANNEL_HYDRATED` event, enabling the MessageList consumer to migrate from `currentChannel.myLastRead + 1`-based derivation to a reducer-backed selector. Also lands the dead-code cleanup of `setFirstUnreadMessageId` that the 5.2.a audit uncovered.

- **Investigate predecessor**: `.agentic/p0-phase-5-2a/{audit.md, decision.md}` — semantic audit + Model C rationale
- **Spec / Plan / Review**: `.agentic/p0-phase-5-2b/{spec.md, plan.md, review/code-review.md}`

## Phase-by-phase (5 commits)

| Phase | Commit | What |
|---|---|---|
| 5.2.b.a | `77e22e0b` | `CHANNEL_HYDRATED` event added to `UnreadEvent` union + reducer handler (clean / tracking branches + marked-unread no-clobber). 4 new transition tests. |
| 5.2.b.b | `2bc84e19` | GroupChannelProvider dispatches `CHANNEL_HYDRATED` in a new effect on `messageDataSource.initialized + state.currentChannel?.url`. Filters peer messages, derives anchor + ids. |
| 5.2.b.c | `c746e788` | MessageList.firstUnreadMessage reads from `useUnreadSelector(selectFirstUnreadMessageId)` then a `messages.find` lookup. Legacy `myLastRead+1` retained as fallback for the hydrate-timing gap. 6 new probe-based integration tests. |
| 5.2.b.d | `61f86ad9` | Dead-code cleanup: remove `setFirstUnreadMessageId` action (never called per audit §1.3 obs 1) + update Phase 0 context-shape baseline. |
| G3 fix | `2adec404` | Review fixes I-1 (hydratedChannelUrlRef guard against resetWithStartingPoint re-fire) + I-2 (drop structural type casts). |

## Why Model C

The 5.2.a investigate cycle established that:

- Phase 4's reducer model (`refactor-design.ko.md §7`) is intentionally **session-local** — tracks "messages received since the user left bottom" + manual mark-as-unread overlay.
- The legacy `MessageList.firstUnreadMessage` derivation is **server-truth** — `currentChannel.myLastRead + 1` lookup.
- These models DIVERGE in one critical scenario: user enters a channel with pre-existing unread (`unreadMessageCount > 0`). Reducer session-local would show zero unread; legacy shows the server-tracked separator.

Model C bridges the gap with a one-shot `CHANNEL_HYDRATED` seed at mount. Reducer transitions remain session-local; consumer reads now have a stable source.

## Parallel-only invariant (W1 inheritance)

`CHANNEL_HYDRATED` flows through the same `dispatchToUnreadStore` helper from PR #1430. The W1 try/catch + `onError` guard remains. The new Provider effect uses the existing thunk-guarded `unreadDispatch`.

## BC invariants (all PASS — `./scripts/bc-check.sh`)

- BC-1 `package.json` public fields unchanged
- BC-2 `dist/types/index.d.ts` export set unchanged
- BC-3 Context-shape baseline updated for the intentional `setFirstUnreadMessageId` removal (internal API only)
- BC-4 dts does NOT re-export from `internal/`
- BC-5 No external source imports from `internal/`
- BC-6 `scrollPubSub` topic + payload set unchanged

## Test plan

- [x] `./scripts/bc-check.sh` — BC-1 ~ BC-6 PASS
- [x] `yarn jest` — 197/199 PASS (2 pre-existing skipped, 0 fail), 1135 tests + 10 skipped — +10 new specs over #1430 baseline
- [x] 5× deterministic re-run of reducer + integration + Phase 0 characterization (7 suites / 63 tests) — stable
- [x] `yarn build` clean
- [x] G3 code review (deep, js-agent) — Ship verdict, both follow-up items applied

## Mid-cycle scope reduction (AC-5)

The original AC-5 plan was to mount the full `<GroupChannelProvider>` stack with a stubbed Sendbird/coreTs surface and drive 6 user scenarios through the real MessageList consumer. The first attempt OOM'd jest (likely an effect loop from incomplete mocks). Per Plan §5 risk mitigation, the test was reduced to a `<GroupChannelUnreadContext.Provider>` + probe consumer pattern that exercises the same dispatch → reducer → selector contract. A heavier app-shell test is a follow-up if uikit-tools API drift becomes a real concern. Documented in `.agentic/p0-phase-5-2b/spec.md` (test file header) and the 5.2.b.c commit body.

## Out of scope (intentional)

- `unreadSinceDate` non-MAU label migration (wall-clock semantic, separate decision)
- `MessageView.newMessageIds` autoscroll trigger migration (autoscroll, not unread)
- `Channel/*` module (different state shape)
- ScrollController real executor wiring (separate cycle)
- `MESSAGES_DELETED` dispatch (pending uikit-tools version bump for `onMessagesDeleted` callback)
- `currentChannel.unreadMessageCount` direct reads (server-truth display; reducer's `unreadCount` is a session counter, distinct concept)
- Phase 4's hand-rolled `parity.spec.ts` against the simplified legacy model — kept as a unit test of the reducer in isolation. The new integration spec covers the real consumer contract.

## Stacking note

Base = `refactor/p0-phase-5-1-unread-consumer` (PR #1430). Once #1430 merges, the base updates; this PR can then be rebased onto main directly. #1428 (Phase 4) underlies #1430 — typical merge order is #1428 → #1430 → #1431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)