### PR TITLE
[fix]: bump handlebars to 4.7.9 (SECURE-3011)

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "svgo@^2.7.0": "^2.8.1",
     "svgo@^3.0.2": "^3.3.3",
     "rollup@^4.20.0": "^4.59.0",
-    "@babel/plugin-transform-modules-systemjs": "^7.29.4"
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+    "handlebars@^4.4.3": "^4.7.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,9 +8183,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.4.3":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: ^1.2.5
     neo-async: ^2.6.2
@@ -8197,7 +8197,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 00e68bb5c183fd7b8b63322e6234b5ac8fbb960d712cb3f25587d559c2951d9642df83c04a1172c918c41bcfc81bfbd7a7718bbce93b893e0135fc99edea93ff
+  checksum: ac39070fc1c3c76a654e4b526383eaf1601976eaa474547b263915b4806977f083600e586ca923709baeed7c82a42640bcc9cc04c37a7efd3fb444f49b8347d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes [SECURE-3011](https://sendbird.atlassian.net/browse/SECURE-3011) — bump `handlebars` from 4.7.8 → 4.7.9 to address [CVE-2026-33941](https://nvd.nist.gov/vuln/detail/CVE-2026-33941) / [GHSA-xjpj-3mr7-gcpf](https://github.com/advisories/GHSA-xjpj-3mr7-gcpf).

- **Severity**: High
- **Vulnerability**: Handlebars CLI precompiler allows code injection / XSS via unescaped template filenames and CLI option values (`--namespace`, `--commonjs`, `--handlebarPath`).
- **Reachability**: Conditionally Reachable (per Semgrep SSC).

## Impact analysis

- `handlebars` is a **transitive devDependency** via `plop@^2.5.3` → `node-plop@0.26.3` → `handlebars@^4.4.3`.
- It is only used by the `generate-component` script (developer-only component scaffolding) — **not bundled into the published package**.
- No runtime / consumer impact. Bumped for supply-chain hygiene.

## Approach

- `node-plop` still pins `handlebars@^4.4.3`, so a direct `yarn up` wouldn't shift the resolution. Added a yarn `resolutions` entry to force `4.7.9`:

  ```json
  "handlebars@^4.4.3": "^4.7.9"
  ```

- `yarn.lock` now resolves `handlebars@npm:4.7.9`.

## Test plan

- [x] `yarn install` — resolution applied cleanly (`handlebars@npm:4.7.9` in `yarn.lock`)
- [x] `yarn build` — exit 0, dist generated (warnings are pre-existing, unrelated to this change)
- [x] `yarn test` — 941 passed / 10 skipped / 0 failed across 168 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURE-3011]: https://sendbird.atlassian.net/browse/SECURE-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ