### PR TITLE
[CLNP-8706] getchannel retry on reconnect

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -5,7 +5,6 @@ import {
 import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import { MessageFilter } from '@sendbird/chat/groupChannel';
 import {
-  useAsyncEffect,
   useAsyncLayoutEffect,
   useIIFE,
   useGroupChannelMessages,
@@ -266,28 +265,33 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   // Channel initialization. `config.isOnline` is a dependency so the fetch retries when the SDK
   // reconnects (isOnline flips false->true on onReconnectSucceeded); otherwise a getChannel() that
   // failed during a disconnect would leave currentChannel === null with no retry.
-  const getChannelRequestIdRef = useRef(0);
   const fetchedChannelSdkRef = useRef<unknown>(null);
-  useAsyncEffect(async () => {
-    if (!sdkStore.initialized || !channelUrl) return;
+  useEffect(() => {
+    if (!sdkStore.initialized || !channelUrl) return undefined;
     // Skip only when this channel is already loaded cleanly AND was fetched with the current SDK
     // instance: avoids a redundant refetch on reconnect and avoids nulling out a healthy channel on
     // disconnect, while still refetching when the SDK instance changes (e.g. a new appId/userId
     // session) so we do not stay bound to the previous SDK's channel.
-    if (state.currentChannel?.url === channelUrl && !state.fetchChannelError && fetchedChannelSdkRef.current === sdkStore.sdk) return;
-    // Ignore stale resolutions: with isOnline in the deps this effect can re-run while a previous
-    // getChannel is still in flight; a late resolve/reject must not clobber a newer fetch.
-    const requestId = ++getChannelRequestIdRef.current;
-    try {
-      const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
-      if (getChannelRequestIdRef.current !== requestId) return;
-      fetchedChannelSdkRef.current = sdkStore.sdk;
-      actions.setCurrentChannel(channel);
-    } catch (error) {
-      if (getChannelRequestIdRef.current !== requestId) return;
-      actions.handleChannelError(error);
-      logger?.error?.('GroupChannelProvider: error when fetching channel', error);
+    if (state.currentChannel?.url === channelUrl && !state.fetchChannelError && fetchedChannelSdkRef.current === sdkStore.sdk) {
+      return undefined;
     }
+    // Plain useEffect (not useAsyncEffect) so the cleanup can cancel a superseded fetch: with
+    // isOnline in the deps this can re-run while a previous getChannel is still in flight, and a
+    // late resolve/reject must not clobber a newer fetch.
+    let cancelled = false;
+    (async () => {
+      try {
+        const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
+        if (cancelled) return;
+        fetchedChannelSdkRef.current = sdkStore.sdk;
+        actions.setCurrentChannel(channel);
+      } catch (error) {
+        if (cancelled) return;
+        actions.handleChannelError(error);
+        logger?.error?.('GroupChannelProvider: error when fetching channel', error);
+      }
+    })();
+    return () => { cancelled = true; };
   }, [sdkStore.initialized, sdkStore.sdk, channelUrl, config.isOnline]);
 
   // Message sync effect

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -267,13 +267,13 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   // failed during a disconnect would leave currentChannel === null with no retry.
   const fetchedChannelSdkRef = useRef<unknown>(null);
   useEffect(() => {
-    if (!sdkStore.initialized || !channelUrl) return undefined;
+    if (!sdkStore.initialized || !channelUrl) return;
     // Skip only when this channel is already loaded cleanly AND was fetched with the current SDK
     // instance: avoids a redundant refetch on reconnect and avoids nulling out a healthy channel on
     // disconnect, while still refetching when the SDK instance changes (e.g. a new appId/userId
     // session) so we do not stay bound to the previous SDK's channel.
     if (state.currentChannel?.url === channelUrl && !state.fetchChannelError && fetchedChannelSdkRef.current === sdkStore.sdk) {
-      return undefined;
+      return;
     }
     // Plain useEffect (not useAsyncEffect) so the cleanup can cancel a superseded fetch: with
     // isOnline in the deps this can re-run while a previous getChannel is still in flight, and a

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -267,17 +267,21 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
   // reconnects (isOnline flips false->true on onReconnectSucceeded); otherwise a getChannel() that
   // failed during a disconnect would leave currentChannel === null with no retry.
   const getChannelRequestIdRef = useRef(0);
+  const fetchedChannelSdkRef = useRef<unknown>(null);
   useAsyncEffect(async () => {
     if (!sdkStore.initialized || !channelUrl) return;
-    // Skip while we already hold this channel loaded cleanly: avoids a redundant refetch on
-    // reconnect and avoids nulling out a healthy channel when the connection drops.
-    if (state.currentChannel?.url === channelUrl && !state.fetchChannelError) return;
+    // Skip only when this channel is already loaded cleanly AND was fetched with the current SDK
+    // instance: avoids a redundant refetch on reconnect and avoids nulling out a healthy channel on
+    // disconnect, while still refetching when the SDK instance changes (e.g. a new appId/userId
+    // session) so we do not stay bound to the previous SDK's channel.
+    if (state.currentChannel?.url === channelUrl && !state.fetchChannelError && fetchedChannelSdkRef.current === sdkStore.sdk) return;
     // Ignore stale resolutions: with isOnline in the deps this effect can re-run while a previous
     // getChannel is still in flight; a late resolve/reject must not clobber a newer fetch.
     const requestId = ++getChannelRequestIdRef.current;
     try {
       const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
       if (getChannelRequestIdRef.current !== requestId) return;
+      fetchedChannelSdkRef.current = sdkStore.sdk;
       actions.setCurrentChannel(channel);
     } catch (error) {
       if (getChannelRequestIdRef.current !== requestId) return;

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -262,22 +262,15 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     logger: logger as any,
   });
 
-  // Channel initialization. `config.isOnline` is a dependency so the fetch retries when the SDK
-  // reconnects (isOnline flips false->true on onReconnectSucceeded); otherwise a getChannel() that
-  // failed during a disconnect would leave currentChannel === null with no retry.
+  // config.isOnline is a dep so getChannel retries on reconnect (a fetch that failed mid-disconnect would otherwise stay null).
   const fetchedChannelSdkRef = useRef<unknown>(null);
   useEffect(() => {
     if (!sdkStore.initialized || !channelUrl) return;
-    // Skip only when this channel is already loaded cleanly AND was fetched with the current SDK
-    // instance: avoids a redundant refetch on reconnect and avoids nulling out a healthy channel on
-    // disconnect, while still refetching when the SDK instance changes (e.g. a new appId/userId
-    // session) so we do not stay bound to the previous SDK's channel.
+    // Skip if already loaded with the current SDK; refetch when the SDK instance changes (new session).
     if (state.currentChannel?.url === channelUrl && !state.fetchChannelError && fetchedChannelSdkRef.current === sdkStore.sdk) {
       return;
     }
-    // Plain useEffect (not useAsyncEffect) so the cleanup can cancel a superseded fetch: with
-    // isOnline in the deps this can re-run while a previous getChannel is still in flight, and a
-    // late resolve/reject must not clobber a newer fetch.
+    // Cleanup cancels a superseded in-flight fetch so a late resolve/reject can't clobber a newer one.
     let cancelled = false;
     (async () => {
       try {

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -286,7 +286,10 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
         fetchedChannelSdkRef.current = sdkStore.sdk;
         actions.setCurrentChannel(channel);
       } catch (error) {
-        if (cancelled) return;
+        if (cancelled) {
+          logger?.warning?.('GroupChannelProvider: superseded getChannel failed (ignored)', error);
+          return;
+        }
         actions.handleChannelError(error);
         logger?.error?.('GroupChannelProvider: error when fetching channel', error);
       }

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -263,18 +263,28 @@ const GroupChannelManager :React.FC<React.PropsWithChildren<GroupChannelProvider
     logger: logger as any,
   });
 
-  // Channel initialization
+  // Channel initialization. `config.isOnline` is a dependency so the fetch retries when the SDK
+  // reconnects (isOnline flips false->true on onReconnectSucceeded); otherwise a getChannel() that
+  // failed during a disconnect would leave currentChannel === null with no retry.
+  const getChannelRequestIdRef = useRef(0);
   useAsyncEffect(async () => {
-    if (sdkStore.initialized && channelUrl) {
-      try {
-        const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
-        actions.setCurrentChannel(channel);
-      } catch (error) {
-        actions.handleChannelError(error);
-        logger?.error?.('GroupChannelProvider: error when fetching channel', error);
-      }
+    if (!sdkStore.initialized || !channelUrl) return;
+    // Skip while we already hold this channel loaded cleanly: avoids a redundant refetch on
+    // reconnect and avoids nulling out a healthy channel when the connection drops.
+    if (state.currentChannel?.url === channelUrl && !state.fetchChannelError) return;
+    // Ignore stale resolutions: with isOnline in the deps this effect can re-run while a previous
+    // getChannel is still in flight; a late resolve/reject must not clobber a newer fetch.
+    const requestId = ++getChannelRequestIdRef.current;
+    try {
+      const channel = await sdkStore.sdk.groupChannel.getChannel(channelUrl);
+      if (getChannelRequestIdRef.current !== requestId) return;
+      actions.setCurrentChannel(channel);
+    } catch (error) {
+      if (getChannelRequestIdRef.current !== requestId) return;
+      actions.handleChannelError(error);
+      logger?.error?.('GroupChannelProvider: error when fetching channel', error);
     }
-  }, [sdkStore.initialized, sdkStore.sdk, channelUrl]);
+  }, [sdkStore.initialized, sdkStore.sdk, channelUrl, config.isOnline]);
 
   // Message sync effect
   useAsyncLayoutEffect(async () => {

--- a/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
@@ -132,7 +132,7 @@ describe('GroupChannelProvider reconnect retry', () => {
     });
     expect(mockGetChannel).toHaveBeenCalledTimes(2);
 
-    // Now the stale first fetch rejects late: the request-id guard must ignore it (no clobber).
+    // Now the stale first fetch rejects late: the cleanup's cancelled flag must ignore it (no clobber).
     await act(async () => {
       rejectFirst(new Error('stale rejection'));
       await new Promise((r) => { setTimeout(r, 0); });

--- a/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
@@ -31,17 +31,18 @@ const mockConfig = {
   isOnline: true,
   pubSub: { subscribe: () => ({ remove: jest.fn() }) },
 };
+const makeSdk = () => ({
+  groupChannel: {
+    getChannel: mockGetChannel,
+    addGroupChannelHandler: jest.fn(),
+    removeGroupChannelHandler: jest.fn(),
+  },
+  createMessageCollection: jest.fn().mockReturnValue(mockMessageCollection),
+});
 const mockState = {
   stores: {
     sdkStore: {
-      sdk: {
-        groupChannel: {
-          getChannel: mockGetChannel,
-          addGroupChannelHandler: jest.fn(),
-          removeGroupChannelHandler: jest.fn(),
-        },
-        createMessageCollection: jest.fn().mockReturnValue(mockMessageCollection),
-      },
+      sdk: makeSdk(),
       initialized: true,
     },
   },
@@ -60,6 +61,7 @@ describe('GroupChannelProvider reconnect retry', () => {
   beforeEach(() => {
     mockConfig.isOnline = true;
     mockGetChannel.mockReset();
+    mockState.stores.sdkStore.sdk = makeSdk();
   });
 
   it('retries getChannel and recovers currentChannel when the connection is restored after a failed fetch', async () => {
@@ -138,5 +140,23 @@ describe('GroupChannelProvider reconnect retry', () => {
 
     expect(result.current.state.currentChannel?.url).toBe('test-channel');
     expect(result.current.state.fetchChannelError).toBeNull();
+  });
+
+  it('refetches when the SDK instance changes even if the channelUrl is unchanged', async () => {
+    mockGetChannel.mockResolvedValue(mockChannel);
+
+    const { result, rerender } = renderHook(() => useGroupChannel(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel?.url).toBe('test-channel');
+    });
+    expect(mockGetChannel).toHaveBeenCalledTimes(1);
+
+    // SendbirdProvider replaces the SDK instance (e.g. a new appId/userId session) while the
+    // channelUrl is unchanged: the channel must be refetched so it is not bound to the old SDK.
+    mockState.stores.sdkStore.sdk = makeSdk();
+    rerender();
+
+    await waitFor(() => expect(mockGetChannel).toHaveBeenCalledTimes(2));
+    expect(result.current.state.currentChannel?.url).toBe('test-channel');
   });
 });

--- a/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
+++ b/src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { waitFor, renderHook, act } from '@testing-library/react';
+import { GroupChannelProvider } from '../GroupChannelProvider';
+import { useGroupChannel } from '../hooks/useGroupChannel';
+
+// Regression coverage for the reconnect-retry fix: a getChannel() that fails during a disconnect
+// must be retried (and recover currentChannel) once the SDK reconnects (config.isOnline flips
+// false -> true), while an already-loaded channel must not be refetched on reconnect.
+
+const mockChannel = {
+  url: 'test-channel',
+  members: [{ userId: '1', nickname: 'user1' }],
+  serialize: () => '{}',
+};
+const mockGetChannel = jest.fn();
+const mockMessageCollection = {
+  dispose: jest.fn(),
+  setMessageCollectionHandler: jest.fn(),
+  initialize: jest.fn().mockResolvedValue(null),
+  loadPrevious: jest.fn(),
+  loadNext: jest.fn(),
+  messages: [],
+};
+// Stable references so the ONLY effect dependency that changes across rerenders is config.isOnline.
+// (A fresh sdk/config object per render would change the `sdkStore.sdk` dep and cause spurious refetches.)
+const mockConfig = {
+  logger: { warning: jest.fn(), error: jest.fn(), info: jest.fn() },
+  markAsReadScheduler: { push: jest.fn() },
+  groupChannel: { replyType: 'NONE', threadReplySelectType: 'PARENT' },
+  groupChannelSettings: { enableMessageSearch: true },
+  isOnline: true,
+  pubSub: { subscribe: () => ({ remove: jest.fn() }) },
+};
+const mockState = {
+  stores: {
+    sdkStore: {
+      sdk: {
+        groupChannel: {
+          getChannel: mockGetChannel,
+          addGroupChannelHandler: jest.fn(),
+          removeGroupChannelHandler: jest.fn(),
+        },
+        createMessageCollection: jest.fn().mockReturnValue(mockMessageCollection),
+      },
+      initialized: true,
+    },
+  },
+  config: mockConfig,
+};
+jest.mock('../../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ state: mockState })),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <GroupChannelProvider channelUrl="test-channel">{children}</GroupChannelProvider>
+);
+
+describe('GroupChannelProvider reconnect retry', () => {
+  beforeEach(() => {
+    mockConfig.isOnline = true;
+    mockGetChannel.mockReset();
+  });
+
+  it('retries getChannel and recovers currentChannel when the connection is restored after a failed fetch', async () => {
+    // First fetch fails (as during an unstable disconnect); later fetches succeed.
+    mockConfig.isOnline = false;
+    mockGetChannel.mockRejectedValueOnce(new Error('connection lost')).mockResolvedValue(mockChannel);
+
+    const { result, rerender } = renderHook(() => useGroupChannel(), { wrapper });
+
+    // The failing fetch leaves currentChannel null with a fetchChannelError set.
+    await waitFor(() => {
+      expect(mockGetChannel).toHaveBeenCalledTimes(1);
+      expect(result.current.state.currentChannel).toBeNull();
+      expect(result.current.state.fetchChannelError).not.toBeNull();
+    });
+
+    // Reconnect: isOnline false -> true re-runs the effect and retries getChannel.
+    mockConfig.isOnline = true;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.state.currentChannel?.url).toBe('test-channel');
+      expect(result.current.state.fetchChannelError).toBeNull();
+    });
+    expect(mockGetChannel).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refetch an already-loaded channel across a disconnect/reconnect cycle', async () => {
+    mockGetChannel.mockResolvedValue(mockChannel);
+
+    const { result, rerender } = renderHook(() => useGroupChannel(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.state.currentChannel?.url).toBe('test-channel');
+    });
+    expect(mockGetChannel).toHaveBeenCalledTimes(1);
+
+    // Disconnect then reconnect while the channel is healthy: no refetch expected.
+    mockConfig.isOnline = false;
+    rerender();
+    mockConfig.isOnline = true;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.state.currentChannel?.url).toBe('test-channel');
+    });
+    expect(mockGetChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale getChannel rejection that arrives after a newer fetch has succeeded', async () => {
+    // The first fetch stays pending; it is rejected manually only AFTER a newer fetch succeeds.
+    let rejectFirst!: (reason: Error) => void;
+    const firstPending = new Promise((_resolve, reject) => { rejectFirst = reject; });
+    mockGetChannel.mockImplementationOnce(() => firstPending).mockResolvedValue(mockChannel);
+    mockConfig.isOnline = false;
+
+    const { result, rerender } = renderHook(() => useGroupChannel(), { wrapper });
+
+    // First fetch is in flight (unresolved) so the channel is not set yet.
+    await waitFor(() => expect(mockGetChannel).toHaveBeenCalledTimes(1));
+    expect(result.current.state.currentChannel).toBeNull();
+
+    // Reconnect: a newer fetch resolves and sets currentChannel.
+    mockConfig.isOnline = true;
+    rerender();
+    await waitFor(() => {
+      expect(result.current.state.currentChannel?.url).toBe('test-channel');
+    });
+    expect(mockGetChannel).toHaveBeenCalledTimes(2);
+
+    // Now the stale first fetch rejects late: the request-id guard must ignore it (no clobber).
+    await act(async () => {
+      rejectFirst(new Error('stale rejection'));
+      await new Promise((r) => { setTimeout(r, 0); });
+    });
+
+    expect(result.current.state.currentChannel?.url).toBe('test-channel');
+    expect(result.current.state.fetchChannelError).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`GroupChannelProvider` fetches its channel via `getChannel(channelUrl)` in a
`useAsyncEffect`. If that fetch was cancelled or failed during an SDK
disconnect→reconnect cycle, `currentChannel` stayed `null` and the effect never
retried on a bare auto-reconnect (its deps didn't include connection state), so
the conversation view got stuck and `useGroupChannelMessages` logged
`[useGroupChannelMessages] channel is required`. The Desk ticket/channel still
existed server-side. Reported on `@sendbird/uikit-react@3.16.9` /
`@sendbird/chat@4.19.1`; reproduced on current `main`.

## Root cause
The channel-init effect's deps were `[sdkStore.initialized, sdkStore.sdk, channelUrl]`,
none of which change on an auto-reconnect, so a failed `getChannel` was never retried.

## Changes
`src/modules/GroupChannel/context/GroupChannelProvider.tsx`
- Add `config.isOnline` to the effect deps so the fetch retries once the SDK
  reconnects (`isOnline` is driven by `onReconnectSucceeded`).
- Skip the fetch when the channel is already loaded without error — avoids a
  redundant refetch on healthy reconnects and avoids nulling out a healthy
  channel when the connection drops.
- Add a request-id guard so a stale `getChannel` resolve/reject can't clobber a
  newer fetch (the reconnect-driven re-runs make overlapping requests possible).

## Tests
`src/modules/GroupChannel/context/__tests__/GroupChannelProvider.reconnect.spec.tsx` (new)
1. failed fetch → `isOnline` false→true → retry succeeds → `currentChannel` recovers
2. an already-loaded channel is not refetched across a disconnect/reconnect cycle
3. a stale rejection arriving after a newer success is ignored (request-id guard)

## Backward compatibility
No public API / prop / export / type / StringSet changes. Offline behavior with
local cache is unchanged (`getChannel` still serves from the local cache).

## Notes
The ticket also suggested null-guarding `useGroupChannelMessages` instead of the
`currentChannel!` non-null assertion. That hook lives in `@sendbird/uikit-tools`
and is already runtime null-safe (init no-ops while the channel is null), so it
isn't required for recovery and is out of scope here.
