### PR TITLE
[fix] Resolved TypingIndicator.tsx bug not cleaning up newHandlerId

### DIFF
--- a/src/modules/GroupChannel/components/TypingIndicator.tsx
+++ b/src/modules/GroupChannel/components/TypingIndicator.tsx
@@ -44,9 +44,10 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
   const [typingMembers, setTypingMembers] = useState<Member[]>([]);
 
   useEffect(() => {
+    let newHandlerId;
     if (sb?.groupChannel?.addGroupChannelHandler) {
       sb.groupChannel.removeGroupChannelHandler(handlerId);
-      const newHandlerId = uuidv4();
+      newHandlerId = uuidv4();
       const handler = new GroupChannelHandler({
         onTypingStatusUpdated: (groupChannel) => {
           // there is a possible warning in here - setState called after unmount
@@ -64,7 +65,7 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
     return () => {
       setTypingMembers([]);
       if (sb?.groupChannel?.removeGroupChannelHandler) {
-        sb.groupChannel.removeGroupChannelHandler(handlerId);
+        sb.groupChannel.removeGroupChannelHandler(newHandlerId ?? handlerId);
       }
     };
   }, [channelUrl]);


### PR DESCRIPTION
# Summary

`TypingIndicator.tsx` has a `useEffect` that does:
```
const newHandlerId = uuidv4();
sb.groupChannel.addGroupChannelHandler(newHandlerId, handler);
setHandlerId(newHandlerId);
```

Yet in that `useEffect`'s cleanup function, it targets removing `handlerId` instead of `newHandlerId`:
```
sb.groupChannel.removeGroupChannelHandler(handlerId);
```

This causes `TypingIndicator` to leak group channel handlers that stay subscribed and un-removed.

I came across this in a scenario where this compounded and caused many leaked handlers that then led to other issues.


# Fix
```
sb.groupChannel.removeGroupChannelHandler(newHandlerId ?? handlerId);
```

To defensively cover the scenario were `sb.groupChannel.addGroupChannelHandler` is not defined, and the code never instantiates a `newHandlerId`, it falls back to `?? handlerId`.

### Checklist

- [x] **All tests pass locally with my changes**
