### PR TITLE
[CLNP-8774] fix: prevent TypingIndicator from leaking group channel handlers on unmount

### DIFF
--- a/src/modules/GroupChannel/components/TypingIndicator.tsx
+++ b/src/modules/GroupChannel/components/TypingIndicator.tsx
@@ -44,9 +44,10 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
   const [typingMembers, setTypingMembers] = useState<Member[]>([]);
 
   useEffect(() => {
+    let newHandlerId: string | undefined;
     if (sb?.groupChannel?.addGroupChannelHandler) {
       sb.groupChannel.removeGroupChannelHandler(handlerId);
-      const newHandlerId = uuidv4();
+      newHandlerId = uuidv4();
       const handler = new GroupChannelHandler({
         onTypingStatusUpdated: (groupChannel) => {
           // there is a possible warning in here - setState called after unmount
@@ -64,7 +65,7 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
     return () => {
       setTypingMembers([]);
       if (sb?.groupChannel?.removeGroupChannelHandler) {
-        sb.groupChannel.removeGroupChannelHandler(handlerId);
+        sb.groupChannel.removeGroupChannelHandler(newHandlerId ?? handlerId);
       }
     };
   }, [channelUrl]);

--- a/src/modules/GroupChannel/components/TypingIndicator.tsx
+++ b/src/modules/GroupChannel/components/TypingIndicator.tsx
@@ -40,14 +40,12 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
   const { state } = useSendbird();
   const sb = state?.stores?.sdkStore?.sdk;
   const logger = state?.config?.logger;
-  const [handlerId, setHandlerId] = useState(uuidv4());
   const [typingMembers, setTypingMembers] = useState<Member[]>([]);
 
   useEffect(() => {
-    let newHandlerId: string | undefined;
+    let handlerId: string | undefined;
     if (sb?.groupChannel?.addGroupChannelHandler) {
-      sb.groupChannel.removeGroupChannelHandler(handlerId);
-      newHandlerId = uuidv4();
+      handlerId = uuidv4();
       const handler = new GroupChannelHandler({
         onTypingStatusUpdated: (groupChannel) => {
           // there is a possible warning in here - setState called after unmount
@@ -58,14 +56,13 @@ export const TypingIndicator = ({ channelUrl }: TypingIndicatorProps) => {
           }
         },
       });
-      sb.groupChannel.addGroupChannelHandler(newHandlerId, handler);
-      setHandlerId(newHandlerId);
+      sb.groupChannel.addGroupChannelHandler(handlerId, handler);
     }
 
     return () => {
       setTypingMembers([]);
-      if (sb?.groupChannel?.removeGroupChannelHandler) {
-        sb.groupChannel.removeGroupChannelHandler(newHandlerId ?? handlerId);
+      if (handlerId && sb?.groupChannel?.removeGroupChannelHandler) {
+        sb.groupChannel.removeGroupChannelHandler(handlerId);
       }
     };
   }, [channelUrl]);

--- a/src/modules/GroupChannel/components/__test__/TypingIndicator.spec.tsx
+++ b/src/modules/GroupChannel/components/__test__/TypingIndicator.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { TypingIndicator } from '../TypingIndicator';
+
+const { mockAddGroupChannelHandler, mockRemoveGroupChannelHandler, mockState } = vi.hoisted(() => {
+  const mockAddGroupChannelHandler = vi.fn();
+  const mockRemoveGroupChannelHandler = vi.fn();
+  const mockState = {
+    stores: {
+      sdkStore: {
+        sdk: {
+          groupChannel: {
+            addGroupChannelHandler: mockAddGroupChannelHandler,
+            removeGroupChannelHandler: mockRemoveGroupChannelHandler,
+          },
+        },
+        initialized: true,
+      },
+    },
+    config: {
+      logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn() },
+    },
+  };
+  return { mockAddGroupChannelHandler, mockRemoveGroupChannelHandler, mockState };
+});
+
+vi.mock('../../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: mockState })),
+}));
+
+describe('GroupChannel/TypingIndicator group channel handler lifecycle (CLNP-8774)', () => {
+  beforeEach(() => {
+    mockAddGroupChannelHandler.mockClear();
+    mockRemoveGroupChannelHandler.mockClear();
+  });
+
+  it('removes the exact handler id it registered when unmounted, so the handler does not leak', () => {
+    const { unmount } = render(<TypingIndicator channelUrl="channel-a" />);
+
+    expect(mockAddGroupChannelHandler).toHaveBeenCalledTimes(1);
+    const registeredId = mockAddGroupChannelHandler.mock.calls[0][0];
+    expect(registeredId).toBeTruthy();
+
+    unmount();
+
+    expect(mockRemoveGroupChannelHandler).toHaveBeenCalledWith(registeredId);
+  });
+
+  it('removes every registered handler across a channel switch followed by unmount (no leak)', () => {
+    const { rerender, unmount } = render(<TypingIndicator channelUrl="channel-a" />);
+    rerender(<TypingIndicator channelUrl="channel-b" />);
+
+    expect(mockAddGroupChannelHandler).toHaveBeenCalledTimes(2);
+    const firstId = mockAddGroupChannelHandler.mock.calls[0][0];
+    const secondId = mockAddGroupChannelHandler.mock.calls[1][0];
+    expect(firstId).not.toBe(secondId);
+
+    unmount();
+
+    expect(mockRemoveGroupChannelHandler).toHaveBeenCalledWith(firstId);
+    expect(mockRemoveGroupChannelHandler).toHaveBeenCalledWith(secondId);
+  });
+});


### PR DESCRIPTION
## What & why
`TypingIndicator`'s `useEffect` cleanup removed the stale `handlerId` state
instead of the `newHandlerId` that was actually registered via
`addGroupChannelHandler`. The live `GroupChannelHandler` was therefore never
removed on unmount and leaked, accumulating across mount/unmount cycles (e.g.
repeated channel navigation). Originally reported in #1444.

## Changes
- Hoist `newHandlerId` into the effect scope so the cleanup removes the exact
  id it registered, falling back to `handlerId` when no handler was added.
- Add a regression test covering unmount and channel-switch cleanup (fails on
  the previous code, passes with the fix).
- `Channel/components/TypingIndicator` re-exports this component, so both
  module entry points are covered by the one change.
