### PR TITLE
[fix]: Stop deriving newInstance in SendbirdProvider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,32 @@ Stop and ask before changing:
 - anything destructive or hard to roll back
 
 <!-- Add repository-specific coding-agent instructions below this line. -->
+
+## SendbirdChat Instance Model
+
+`SendbirdProvider` is designed to be mounted **once per web application**, at the app root.
+It does not pass `newInstance` to `SendbirdChat.init()`, so it uses the cached singleton.
+
+An application that needs more than one instance — several providers, or more than one
+`appId` on a page — must opt in explicitly:
+
+```tsx
+<SendbirdProvider appId={appId} userId={userId} sdkInitParams={{ newInstance: true }} />
+```
+
+Consequences of that model, all expected rather than defects:
+
+- Mounting several providers on one `appId` without `newInstance` shares one instance and one
+  WebSocket. State that lives on the instance is therefore shared: the session handler, the
+  SDK extensions, and the connected user are whatever the most recent provider set. One
+  provider unmounting disconnects the shared socket, and the others do not reconnect.
+- Calling `init()` with a different `appId` replaces the singleton: the previous instance is
+  released, and anything still holding it — another provider, `SendbirdDesk`, application
+  code — will throw once it touches the released instance. A singleton cannot serve two
+  appIds; use `newInstance` for the one that should be separate.
+
+So before treating any of the above as a bug, check whether the scenario mounts more than one
+provider or uses more than one `appId` without `newInstance`. If it does, it is outside the
+model. Deriving `newInstance` inside UIKit is not an acceptable fix — it was the cause of
+CLNP-8809, where one provider mount per route navigation produced one SDK instance and one
+WebSocket each.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.21.0",
+    "@sendbird/chat": "^4.22.10",
     "@sendbird/react-uikit-message-template-view": "^0.1.5",
     "@sendbird/uikit-tools": "^0.1.5",
     "css-vars-ponyfill": "^2.3.2",

--- a/src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx
+++ b/src/lib/Sendbird/__tests__/SendbirdProvider.spec.tsx
@@ -56,24 +56,17 @@ describe('SendbirdProvider', () => {
     expect(mockActions.connect).toHaveBeenCalledWith(
       expect.objectContaining({
         appId: 'mockAppId',
-        isNewApp: true,
         userId: 'mockUserId',
       }),
     );
   });
 
-  it('should preserve the legacy isNewApp behavior across app and user changes', () => {
+  it('should never ask connect for a new SDK instance', () => {
     const { rerender } = render(
       <SendbirdContextProvider appId="mockAppId" userId="mockUserId">
         <div data-testid="child">Child Component</div>
       </SendbirdContextProvider>,
     );
-
-    expect(mockActions.connect).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      appId: 'mockAppId',
-      isNewApp: true,
-      userId: 'mockUserId',
-    }));
 
     rerender(
       <SendbirdContextProvider appId="mockAppId" userId="nextUserId">
@@ -81,21 +74,20 @@ describe('SendbirdProvider', () => {
       </SendbirdContextProvider>,
     );
 
-    expect(mockActions.connect).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      appId: 'mockAppId',
-      isNewApp: false,
-      userId: 'nextUserId',
-    }));
-
     rerender(
       <SendbirdContextProvider appId="nextAppId" userId="nextUserId">
         <div data-testid="child">Child Component</div>
       </SendbirdContextProvider>,
     );
 
+    expect(mockActions.connect).toHaveBeenCalledTimes(3);
+    // Whether a new SendbirdChat instance is needed is decided in connect() from the
+    // cached instance's appId, never inferred from the provider's own mount history.
+    mockActions.connect.mock.calls.forEach(([params]) => {
+      expect(params).not.toHaveProperty('isNewApp');
+    });
     expect(mockActions.connect).toHaveBeenNthCalledWith(3, expect.objectContaining({
       appId: 'nextAppId',
-      isNewApp: true,
       userId: 'nextUserId',
     }));
   });
@@ -112,7 +104,6 @@ describe('SendbirdProvider', () => {
     expect(mockActions.connect).toHaveBeenCalledTimes(2);
     expect(mockActions.connect).toHaveBeenNthCalledWith(1, expect.objectContaining({
       appId: 'mockAppId',
-      isNewApp: true,
       userId: 'mockUserId',
     }));
     expect(mockActions.connect).toHaveBeenNthCalledWith(2, expect.objectContaining({

--- a/src/lib/Sendbird/__tests__/initSDK.integration.spec.ts
+++ b/src/lib/Sendbird/__tests__/initSDK.integration.spec.ts
@@ -1,0 +1,52 @@
+import SendbirdChat from '@sendbird/chat';
+
+import { initSDK } from '../utils';
+
+/**
+ * Runs against the real @sendbird/chat, so it covers what unit tests with a mocked SDK
+ * cannot: that initSDK's parameters actually produce the intended instance lifecycle.
+ *
+ * `init()` is synchronous and does not connect, so no network is involved.
+ */
+const APP_A = 'AAAAAAAA-0000-0000-0000-00000000000A';
+const APP_B = 'BBBBBBBB-0000-0000-0000-00000000000B';
+
+// Reading appId goes through the vault, which is gone once the instance is released.
+const isReleased = (instance: { appId: string }) => {
+  try {
+    return typeof instance.appId !== 'string';
+  } catch {
+    return true;
+  }
+};
+
+describe('initSDK against the real SDK', () => {
+  it('reuses the cached instance while the appId stays the same', () => {
+    const first = initSDK({ appId: APP_A });
+
+    expect(first.appId).toBe(APP_A);
+    expect(SendbirdChat.instance).toBe(first);
+    // a remount, and then a second provider on the same appId
+    expect(initSDK({ appId: APP_A })).toBe(first);
+    expect(initSDK({ appId: APP_A })).toBe(first);
+  });
+
+  it('builds an instance bound to the new appId when the appId changes', () => {
+    const previous = initSDK({ appId: APP_A });
+    const next = initSDK({ appId: APP_B });
+
+    expect(next).not.toBe(previous);
+    expect(next.appId).toBe(APP_B);
+    expect(SendbirdChat.instance).toBe(next);
+    // the replaced instance is released, not merely dereferenced
+    expect(isReleased(previous)).toBe(true);
+  });
+
+  it('honors an explicit newInstance and leaves the cached instance alone', () => {
+    const cached = initSDK({ appId: APP_B });
+    const forced = initSDK({ appId: APP_B, sdkInitParams: { newInstance: true } });
+
+    expect(forced).not.toBe(cached);
+    expect(isReleased(cached)).toBe(false);
+  });
+});

--- a/src/lib/Sendbird/__tests__/providerHandoff.spec.tsx
+++ b/src/lib/Sendbird/__tests__/providerHandoff.spec.tsx
@@ -1,0 +1,108 @@
+import React, { act } from 'react';
+import { render } from '@testing-library/react';
+
+import SendbirdProvider from '../index';
+
+/**
+ * Reproduction probe for the provider handoff that happens on route navigation:
+ * the outgoing provider's unmount starts disconnectWebSocket(), React cannot await that
+ * cleanup, and the incoming provider connects. Now that both providers share one cached
+ * SendbirdChat instance, the question is whether connect() can start while the previous
+ * disconnect is still in flight on that same instance.
+ */
+const timeline: string[] = [];
+let settlePendingDisconnect: (() => void) | null = null;
+
+vi.mock('@sendbird/chat', () => {
+  const mockSdk = {
+    // one cached instance shared by every init(), as the SDK does for the same appId
+    init: vi.fn(() => mockSdk),
+    connect: vi.fn(async () => {
+      timeline.push('connect:start');
+      return { userId: 'test-user-id', nickname: '', profileUrl: '' };
+    }),
+    disconnectWebSocket: vi.fn(() => {
+      timeline.push('disconnect:start');
+      return new Promise<void>((resolve) => {
+        settlePendingDisconnect = () => {
+          timeline.push('disconnect:end');
+          resolve();
+        };
+      });
+    }),
+    updateCurrentUserInfo: vi.fn().mockResolvedValue(null),
+    addExtension: vi.fn().mockReturnThis(),
+    addSendbirdExtensions: vi.fn().mockReturnThis(),
+    message: { getMessageTemplatesByToken: vi.fn().mockResolvedValue({ hasMore: false, token: null, templates: [] }) },
+    appId: 'test-app-id',
+    appInfo: {
+      uploadSizeLimit: 1024,
+      multipleFilesMessageFileCountLimit: 10,
+      messageTemplateInfo: { token: null },
+      uikitConfigInfo: { lastUpdatedAt: 0 },
+    },
+  };
+
+  return {
+    __esModule: true,
+    default: mockSdk,
+    SendbirdProduct: { UIKIT_CHAT: 'UIKIT_CHAT' },
+    SendbirdPlatform: { JS: 'JS' },
+    DeviceOsPlatform: { WEB: 'WEB', MOBILE_WEB: 'MOBILE_WEB' },
+  };
+});
+
+describe('provider handoff on route navigation', () => {
+  beforeEach(() => {
+    timeline.length = 0;
+    settlePendingDisconnect = null;
+    global.MediaRecorder = {
+      isTypeSupported: vi.fn(() => true),
+    } as unknown as typeof MediaRecorder;
+  });
+
+  it('does not connect the shared instance while the previous disconnect is still pending', async () => {
+    const tree = (
+      <SendbirdProvider
+        appId="test-app-id"
+        userId="test-user-id"
+        eventHandlers={{
+          connection: {
+            onConnected: () => timeline.push('onConnected'),
+            onFailed: (e) => timeline.push(`onFailed:${e?.message ?? e}`),
+          },
+        }}
+      >
+        <div data-testid="child" />
+      </SendbirdProvider>
+    );
+
+    const first = render(tree);
+    // connect() awaits several times before it puts the instance into the store, and only
+    // an instance that reached the store can be disconnected on unmount
+    for (let i = 0; i < 10; i += 1) {
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 0); }); });
+    }
+    timeline.length = 0; // ignore the initial connect
+
+    // route navigation: the outgoing provider unmounts, the incoming one mounts before the
+    // pending disconnectWebSocket() has settled
+    await act(async () => {
+      first.unmount();
+      render(tree);
+      await Promise.resolve();
+    });
+
+    // the outgoing provider's teardown has started and is deliberately left unsettled
+    expect(timeline).toEqual(['disconnect:start']);
+
+    // the incoming provider must not touch the shared instance until that teardown lands
+    await act(async () => {
+      settlePendingDisconnect?.();
+      await new Promise((resolve) => { setTimeout(resolve, 0); });
+    });
+
+    expect(timeline.indexOf('connect:start')).toBeGreaterThan(timeline.indexOf('disconnect:end'));
+    expect(timeline).toContain('onConnected');
+  });
+});

--- a/src/lib/Sendbird/__tests__/useSendbird.spec.tsx
+++ b/src/lib/Sendbird/__tests__/useSendbird.spec.tsx
@@ -368,31 +368,36 @@ describe('useSendbird', () => {
         appId: 'mockAppId',
         customApiHost: undefined,
         customWebSocketHost: undefined,
-        isNewApp: false,
         sdkInitParams: {},
       });
 
       expect(mockSetupSDK).toHaveBeenCalled();
     });
 
-    it('should pass isNewApp through to initSDK during connect', async () => {
+    it('should report an SDK init failure through onFailed instead of rejecting', async () => {
       const { result } = renderHook(() => useSendbird(), { wrapper });
-      const mockInitSDK = vi.mocked(initSDK);
 
-      await act(async () => {
-        await result.current.actions.connect({
-          logger: mockLogger,
-          userId: 'mockUserId',
-          appId: 'mockAppId',
-          accessToken: 'mockAccessToken',
-          isNewApp: true,
-        });
+      const mockOnFailed = vi.fn();
+      const mockLogger = { error: vi.fn(), info: vi.fn() } as unknown as LoggerInterface;
+
+      // SendbirdChat.init() rejects an empty or malformed appId, which apps pass while
+      // their config is still loading. That must not escape connect() unhandled.
+      const initError = new Error('Invalid parameters.');
+      vi.mocked(initSDK).mockImplementationOnce(() => {
+        throw initError;
       });
 
-      expect(mockInitSDK).toHaveBeenCalledWith(expect.objectContaining({
-        appId: 'mockAppId',
-        isNewApp: true,
-      }));
+      await act(async () => {
+        await expect(result.current.actions.connect({
+          logger: mockLogger,
+          userId: 'mockUserId',
+          appId: '',
+          eventHandlers: { connection: { onFailed: mockOnFailed } },
+        })).resolves.toBeUndefined();
+      });
+
+      expect(mockOnFailed).toHaveBeenCalledWith(initError);
+      expect(mockStore.getState().stores.sdkStore.sdk).toStrictEqual({});
     });
 
     it('should handle connection failure and trigger onFailed event handler', async () => {

--- a/src/lib/Sendbird/__tests__/utils.spec.ts
+++ b/src/lib/Sendbird/__tests__/utils.spec.ts
@@ -117,16 +117,12 @@ describe('initSDK', () => {
     );
   });
 
-  it('uses isNewApp to set the newInstance init option', () => {
-    initSDK({
-      appId: 'testAppId',
-      isNewApp: true,
-    });
+  it('never sets newInstance on its own', () => {
+    initSDK({ appId: 'testAppId' });
 
     expect(SendbirdChat.init).toHaveBeenCalledWith(
-      expect.objectContaining({
-        appId: 'testAppId',
-        newInstance: true,
+      expect.not.objectContaining({
+        newInstance: expect.anything(),
       }),
     );
   });
@@ -134,7 +130,6 @@ describe('initSDK', () => {
   it('preserves an explicit sdkInitParams.newInstance override', () => {
     initSDK({
       appId: 'testAppId',
-      isNewApp: false,
       sdkInitParams: {
         newInstance: true,
       },

--- a/src/lib/Sendbird/context/SendbirdProvider.tsx
+++ b/src/lib/Sendbird/context/SendbirdProvider.tsx
@@ -100,17 +100,12 @@ const SendbirdContextManager = ({
     appInfoStore,
     actions,
   });
-  const previousAppIdRef = useRef('');
 
   // Reconnect when necessary
   useEffect(() => {
-    const isNewApp = previousAppIdRef.current !== appId;
-    previousAppIdRef.current = appId;
-
     actions.connect({
       appId,
       userId,
-      isNewApp,
       accessToken,
       isUserIdUsedForNickname,
       isMobile,

--- a/src/lib/Sendbird/context/hooks/useSendbird.tsx
+++ b/src/lib/Sendbird/context/hooks/useSendbird.tsx
@@ -178,7 +178,6 @@ export const useSendbird = () => {
       logger,
       userId,
       appId,
-      isNewApp = false,
       accessToken,
       nickname,
       profileUrl,
@@ -196,24 +195,26 @@ export const useSendbird = () => {
     // clean up previous ws connection
     await disconnect({ logger });
 
-    const sdk = initSDK({
-      appId,
-      isNewApp,
-      customApiHost,
-      customWebSocketHost,
-      sdkInitParams,
-    });
-
-    setupSDK(sdk, {
-      logger,
-      isMobile,
-      customExtensionParams,
-      sessionHandler: configureSession ? configureSession(sdk) : undefined,
-    });
-
     sdkActions.setSdkLoading(true);
 
+    // initSDK and setupSDK stay inside the try: SendbirdChat.init() rejects an empty or
+    // malformed appId, which apps routinely pass while their config is still loading.
+    // Outside the try that would surface as an unhandled rejection instead of onFailed.
     try {
+      const sdk = initSDK({
+        appId,
+        customApiHost,
+        customWebSocketHost,
+        sdkInitParams,
+      });
+
+      setupSDK(sdk, {
+        logger,
+        isMobile,
+        customExtensionParams,
+        sessionHandler: configureSession ? configureSession(sdk) : undefined,
+      });
+
       const user = await sdk.connect(userId, accessToken);
       userActions.initUser(user);
 

--- a/src/lib/Sendbird/context/hooks/useSendbird.tsx
+++ b/src/lib/Sendbird/context/hooks/useSendbird.tsx
@@ -8,6 +8,18 @@ import { MessageTemplatesInfo, SdkStore, SendbirdState, WaitingTemplateKeyData }
 import { initSDK, setupSDK, updateAppInfoStore, updateSdkStore, updateUserStore } from '../../utils';
 
 const NO_CONTEXT_ERROR = 'No sendbird state value available. Make sure you are rendering `<SendbirdProvider>` at the top of your app.';
+
+/**
+ * Teardown in flight for a SendbirdChat instance, keyed by that instance.
+ *
+ * On route navigation the outgoing provider's unmount starts `disconnectWebSocket()`. React
+ * cannot await an unmount cleanup, and the incoming provider reuses the same cached instance
+ * while holding a different store, so neither provider can see that a teardown is running.
+ * Left unserialized, `connect()` races it, and a teardown landing mid-connect cancels the
+ * connection. This lives outside the stores because it belongs to the instance, not to any
+ * one provider.
+ */
+const pendingTeardowns = new WeakMap<object, Promise<unknown>>();
 export const useSendbird = () => {
   const store = useContext(SendbirdContext);
   if (!store) throw new Error(NO_CONTEXT_ERROR);
@@ -160,7 +172,13 @@ export const useSendbird = () => {
     const sdk = state.stores.sdkStore.sdk;
 
     if (sdk?.disconnectWebSocket) {
-      await sdk.disconnectWebSocket();
+      const teardown = sdk.disconnectWebSocket();
+      pendingTeardowns.set(sdk, teardown);
+      try {
+        await teardown;
+      } finally {
+        if (pendingTeardowns.get(sdk) === teardown) pendingTeardowns.delete(sdk);
+      }
     }
 
     sdkActions.resetSdk();
@@ -207,6 +225,11 @@ export const useSendbird = () => {
         customWebSocketHost,
         sdkInitParams,
       });
+
+      // A provider unmounting elsewhere may still be tearing this instance down. Wait for
+      // that before touching it; a failed teardown must not stop us from connecting.
+      const teardown = pendingTeardowns.get(sdk);
+      if (teardown) await teardown.catch(() => undefined);
 
       setupSDK(sdk, {
         logger,

--- a/src/lib/Sendbird/types.ts
+++ b/src/lib/Sendbird/types.ts
@@ -191,6 +191,14 @@ export type UIKitOptions = PartialDeep<{
   openChannel: SBUConfig['openChannel']['channel'];
 }>;
 
+/**
+ * Mount this once per application, at the app root.
+ *
+ * The provider uses the cached `SendbirdChat` singleton, so mounting several of them on one
+ * `appId` shares a single instance and WebSocket, and using more than one `appId` on a page
+ * replaces the singleton. Pass `sdkInitParams={{ newInstance: true }}` on any provider that
+ * needs an instance of its own.
+ */
 export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.PropsWithChildren<unknown> {
   appId: string;
   userId: string;

--- a/src/lib/Sendbird/utils.ts
+++ b/src/lib/Sendbird/utils.ts
@@ -47,22 +47,23 @@ export const updateUserStore: UpdateUserStoreType = (state, payload) => {
 
 export function initSDK({
   appId,
-  isNewApp = false,
   customApiHost,
   customWebSocketHost,
   sdkInitParams = {},
 }: {
   appId: string;
-  isNewApp?: boolean;
   customApiHost?: string;
   customWebSocketHost?: string;
   sdkInitParams?: SendbirdChatInitParams;
 }) {
   const params = {
+    // `newInstance` is deliberately not derived here. It is the caller's decision, so it is
+    // only ever set when the app passes it through sdkInitParams; deriving it made every
+    // provider mount open its own SendbirdChat instance and WebSocket. When appId changes,
+    // SendbirdChat.init() releases the instance bound to the previous appId on its own.
     ...sdkInitParams,
     appId,
     modules: [new GroupChannelModule(), new OpenChannelModule()],
-    newInstance: typeof sdkInitParams.newInstance !== 'undefined' ? sdkInitParams.newInstance : isNewApp,
     localCacheEnabled: typeof sdkInitParams.localCacheEnabled !== 'undefined' ? sdkInitParams.localCacheEnabled : true,
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,18 +2891,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat@npm:^4.21.0":
-  version: 4.21.1
-  resolution: "@sendbird/chat@npm:4.21.1"
+"@sendbird/chat@npm:^4.22.10":
+  version: 4.22.10
+  resolution: "@sendbird/chat@npm:4.22.10"
   peerDependencies:
-    "@react-native-async-storage/async-storage": ^1.17.6
     react-native-mmkv: ">=2.0.0"
   peerDependenciesMeta:
-    "@react-native-async-storage/async-storage":
-      optional: true
     react-native-mmkv:
       optional: true
-  checksum: d5ff0e22376a1df9e5d7745c9ba4dccf43eec1afac24a24feb270ea2787f56b65621e42b4722ed1f6c99d68d1338061e8dbbe8a9a73c6442fe0bce2864bbb89c
+  checksum: 2d3a338f38f21d1c02efa45e55e27d0f3198454f90bd742835c653bb029ff91309102ac5213fc79b10a9b29d01440c0c4b2f2393f8b967d4193124aefa06c728
   languageName: node
   linkType: hard
 
@@ -2946,7 +2943,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.2.3
     "@rollup/plugin-replace": ^5.0.4
     "@rollup/plugin-typescript": ^11.1.5
-    "@sendbird/chat": ^4.21.0
+    "@sendbird/chat": ^4.22.10
     "@sendbird/react-uikit-message-template-view": ^0.1.5
     "@sendbird/uikit-tools": ^0.1.5
     "@storybook/addon-essentials": ^8.6.17


### PR DESCRIPTION
`SendbirdProvider` 가 마운트될 때마다 캐시된 인스턴스를 재사용하지 않고 새 `SendbirdChat` 인스턴스와 WebSocket 연결을 만들고 있었습니다.

`isNewApp` 이 마운트마다 초기화되는 컴포넌트 ref 에서 계산되어, "최초 마운트" 와 "appId 변경" 을 구분하지 못하고 **모든 마운트의 첫 effect 실행에서 `true`** 가 되었습니다. CLNP-8809 에 첨부된 고객 콘솔 로그에서 한 페이지 세션 동안 프로바이더 마운트 8회 → SDK 인스턴스 8개가 생성되었고, 사고 구간에는 2개가 동시에 살아 있었으며, 유실된 수신 메시지에 대해 **같은 페이지에서 MACK 이 2회** 전송된 것이 확인됩니다. 리마운트를 유발한 것은 티켓 전환이 아니라 라우트 이동이었습니다.

`newInstance` 는 호출자가 결정할 값이므로, 이제 앱이 `sdkInitParams` 로 전달한 경우에만 설정됩니다. `appId` 변경은 `SendbirdChat.init()` 이 이전 appId 에 묶인 인스턴스를 해제하는 방식으로 처리합니다 (sendbird/chat-js#1861, 4.22.10 배포). 애초에 UIKit 에서 이 플래그를 파생해도 appId 전환을 처리할 수 없었습니다 — 캐시된 인스턴스가 있으면 `init()` 이 전달된 파라미터를 전부 무시하기 때문입니다.

4.22.10 은 비어 있거나 잘못된 `appId` 를 거부하기도 합니다. 설정이 로딩되는 동안 빈 `appId` 를 넘기는 것은 흔한 사용 패턴이므로, `initSDK` 와 `setupSDK` 를 `connect()` 의 기존 `try` 안으로 옮겼습니다. 그래야 4.21.x 에서 `connect()` 실패를 통해 전달되던 것과 동일하게 `onFailed` 로 전달되고, unhandled rejection 으로 빠져나가지 않습니다.

#1419 (v3.18.0) 에서 발생한 회귀이며, `newInstance` 를 전달하지 않던 v3.15.14~v3.17.x 동작으로 되돌립니다.

Fixes [CLNP-8809](https://sendbird.atlassian.net/browse/CLNP-8809)

### Changelogs
- Fixed a bug where every `SendbirdProvider` mount created a new `SendbirdChat` instance and WebSocket connection instead of reusing the cached one

  `newInstance` is now set only when passed through `sdkInitParams`.
- Fixed a bug where a failure to initialize the Chat SDK, such as an empty `appId`, was not reported through the `onFailed` connection event handler

### Checklist
- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)


[CLNP-8809]: https://sendbird.atlassian.net/browse/CLNP-8809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ