### PR TITLE
[fix]: Stop refreshing the group channel collection on mount

### DIFF
--- a/src/modules/GroupChannelList/components/GroupChannelListUI/__tests__/GroupChannelListUI.emptyPlaceholder.integration.test.tsx
+++ b/src/modules/GroupChannelList/components/GroupChannelListUI/__tests__/GroupChannelListUI.emptyPlaceholder.integration.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import { act, render, screen } from '@testing-library/react';
+
+import { LocalizationContext } from '../../../../../lib/LocalizationContext';
+import { GroupChannelListProvider } from '../../../context/GroupChannelListProvider';
+import GroupChannelListUI from '../index';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const createDeferred = <T, >(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+};
+
+const createControlledCollection = () => {
+  const loadMoreDeferred = createDeferred<GroupChannel[]>();
+  const collection = {
+    channels: [] as GroupChannel[],
+    hasMore: true,
+    loadMore: vi.fn(() => loadMoreDeferred.promise),
+    dispose: vi.fn(),
+    setGroupChannelCollectionHandler: vi.fn(),
+    resolveLoadMore(channels: GroupChannel[]) {
+      collection.channels = channels;
+      loadMoreDeferred.resolve(channels);
+    },
+  };
+
+  return collection;
+};
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+};
+
+const mockState = {
+  stores: {
+    sdkStore: {
+      sdk: undefined as any,
+      initialized: true,
+      error: null,
+    },
+  },
+  config: {
+    logger,
+    isOnline: true,
+    disableMarkAsDelivered: true,
+    groupChannelList: {},
+  },
+};
+
+vi.mock('../../../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: mockState })),
+  useSendbird: vi.fn(() => ({ state: mockState })),
+}));
+
+const stringSet = {
+  PLACE_HOLDER__NO_CHANNEL: 'No channels',
+};
+
+describe('GroupChannelListUI empty placeholder integration', () => {
+  it('keeps the empty placeholder hidden until the initial collection has loaded', async () => {
+    const collectionA = createControlledCollection();
+    const collectionB = createControlledCollection();
+    const createGroupChannelCollection = vi.fn()
+      .mockReturnValueOnce(collectionA)
+      .mockReturnValueOnce(collectionB);
+
+    mockState.stores.sdkStore.sdk = {
+      currentUser: { userId: 'test-user-id' },
+      appInfo: { premiumFeatureList: [] },
+      connectionState: 'OPEN',
+      isCacheEnabled: false,
+      reconnect: vi.fn(),
+      addConnectionHandler: vi.fn(),
+      removeConnectionHandler: vi.fn(),
+      groupChannel: {
+        createGroupChannelCollection,
+        addGroupChannelHandler: vi.fn(),
+        removeGroupChannelHandler: vi.fn(),
+      },
+    } as any;
+
+    const channel = {
+      url: 'loaded-channel-url',
+      name: 'Loaded channel',
+      isGroupChannel: () => true,
+      serialize: () => ({ url: 'loaded-channel-url' }),
+    } as unknown as GroupChannel;
+
+    const { container } = render(
+      <LocalizationContext.Provider value={{ stringSet } as any}>
+        <GroupChannelListProvider
+          disableAutoSelect
+          onChannelSelect={vi.fn()}
+          onChannelCreated={vi.fn()}
+        >
+          <GroupChannelListUI
+            renderHeader={() => <div>Channels</div>}
+            renderChannelPreview={({ channel: renderedChannel }) => <div>{renderedChannel.name}</div>}
+          />
+        </GroupChannelListProvider>
+      </LocalizationContext.Provider>,
+    );
+
+    expect(screen.queryByText(stringSet.PLACE_HOLDER__NO_CHANNEL)).not.toBeInTheDocument();
+    expect(container.querySelector('.sendbird-loader')).toBeInTheDocument();
+
+    await act(async () => {
+      collectionA.resolveLoadMore([channel]);
+      await collectionA.loadMore.mock.results[0].value;
+    });
+
+    expect(screen.queryByText(stringSet.PLACE_HOLDER__NO_CHANNEL)).not.toBeInTheDocument();
+    expect(screen.getByText(channel.name)).toBeInTheDocument();
+  });
+});

--- a/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
+++ b/src/modules/GroupChannelList/context/GroupChannelListProvider.tsx
@@ -18,6 +18,7 @@ import { deleteNullish, noop } from '../../../utils/utils';
 import useSendbird from '../../../lib/Sendbird/context/hooks/useSendbird';
 import useGroupChannelList from './useGroupChannelList';
 import useDeepCompareEffect from '../../../hooks/useDeepCompareEffect';
+import useDidMountEffect from '../../../utils/useDidMountEffect';
 
 type OnCreateChannelClickParams = { users: Array<string>; onClose: () => void; channelType: CHANNEL_TYPE };
 type ChannelListDataSource = ReturnType<typeof useGroupChannelListDataSource>;
@@ -144,14 +145,18 @@ export const GroupChannelListManager: React.FC<GroupChannelListProviderProps> = 
     }
   }, [disableAutoSelect, stores.sdkStore.initialized, initialized, selectedChannelUrl]);
 
-  // Recreates the GroupChannelCollection when `channelListQueryParams` change
-  useEffect(() => {
+  const serializedChannelListQueryParams = Object.keys(channelListQueryParams ?? {}).sort()
+    .map((key: string) => `${key}=${encodeURIComponent(JSON.stringify(channelListQueryParams[key]))}`)
+    .join('&');
+
+  // Recreates the GroupChannelCollection when `channelListQueryParams` change.
+  // NOTE: This must not run on mount. useGroupChannelList already creates the initial
+  // collection with these params, so refreshing here would only discard it mid-flight.
+  // The superseded collection then resolves and commits the new, still-empty collection's
+  // channels, briefly rendering the empty-list placeholder. (CLNP-8827)
+  useDidMountEffect(() => {
     refresh?.();
-  }, [
-    Object.keys(channelListQueryParams ?? {}).sort()
-      .map((key: string) => `${key}=${encodeURIComponent(JSON.stringify(channelListQueryParams[key]))}`)
-      .join('&'),
-  ]);
+  }, [serializedChannelListQueryParams]);
 
   const { typingChannelUrls } = state;
 

--- a/src/modules/GroupChannelList/context/__tests__/GroupChannelListProvider.queryParams.spec.tsx
+++ b/src/modules/GroupChannelList/context/__tests__/GroupChannelListProvider.queryParams.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { GroupChannelListProvider } from '../GroupChannelListProvider';
+import type { ChannelListQueryParamsType } from '../GroupChannelListProvider';
+
+const { refreshMock } = vi.hoisted(() => ({ refreshMock: vi.fn() }));
+
+const mockState = {
+  stores: {
+    sdkStore: {
+      sdk: {
+        currentUser: {
+          userId: 'test-user-id',
+        },
+      },
+      initialized: true,
+    },
+  },
+  config: {
+    logger: console,
+    groupChannelList: {
+    },
+  },
+};
+vi.mock('../../../../lib/Sendbird/context/hooks/useSendbird', async () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: mockState })),
+  useSendbird: vi.fn(() => ({ state: mockState })),
+}));
+
+vi.mock('@sendbird/uikit-tools', async () => ({
+  ...await vi.importActual('@sendbird/uikit-tools'),
+  useGroupChannelList: vi.fn(() => ({
+    refreshing: false,
+    initialized: true,
+    groupChannels: [],
+    refresh: refreshMock,
+    loadMore: vi.fn(),
+  })),
+}));
+
+/**
+ * Regression tests for CLNP-8827.
+ *
+ * `useGroupChannelList` already creates the initial GroupChannelCollection using
+ * `channelListQueryParams`, so refreshing on mount only discarded that collection
+ * mid-flight. The superseded collection then resolved and committed the new,
+ * still-empty collection's channels, briefly rendering the empty-list placeholder.
+ *
+ * The refresh must therefore fire only when `channelListQueryParams` actually change.
+ */
+describe('GroupChannelListProvider - channelListQueryParams', () => {
+  const Subject = ({ channelListQueryParams }: { channelListQueryParams?: ChannelListQueryParamsType }) => (
+    <GroupChannelListProvider
+      onChannelSelect={vi.fn()}
+      onChannelCreated={vi.fn()}
+      channelListQueryParams={channelListQueryParams}
+    />
+  );
+
+  // Let every pending effect settle so a late refresh cannot slip past the assertion.
+  const flushEffects = () => act(async () => {});
+
+  beforeEach(() => {
+    refreshMock.mockClear();
+  });
+
+  it('does not refresh on mount', async () => {
+    render(<Subject channelListQueryParams={{ includeEmpty: true } as ChannelListQueryParamsType} />);
+    await flushEffects();
+
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh on mount without channelListQueryParams', async () => {
+    render(<Subject />);
+    await flushEffects();
+
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh on mount under StrictMode', async () => {
+    // StrictMode double-invokes effects (setup -> cleanup -> setup) on the same
+    // instance. A ref-based mount guard would let the second setup through and
+    // reintroduce the duplicate initialization in development builds.
+    render(
+      <React.StrictMode>
+        <Subject channelListQueryParams={{ includeEmpty: true } as ChannelListQueryParamsType} />
+      </React.StrictMode>,
+    );
+    await flushEffects();
+
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when channelListQueryParams change', async () => {
+    const { rerender } = render(
+      <Subject channelListQueryParams={{ includeEmpty: true } as ChannelListQueryParamsType} />,
+    );
+    await flushEffects();
+    expect(refreshMock).not.toHaveBeenCalled();
+
+    rerender(<Subject channelListQueryParams={{ includeEmpty: false } as ChannelListQueryParamsType} />);
+    await flushEffects();
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh when channelListQueryParams keep the same value', async () => {
+    const { rerender } = render(
+      <Subject channelListQueryParams={{ includeEmpty: true } as ChannelListQueryParamsType} />,
+    );
+    await flushEffects();
+
+    // A new object with identical contents - the serialized dependency must not change.
+    rerender(<Subject channelListQueryParams={{ includeEmpty: true } as ChannelListQueryParamsType} />);
+    await flushEffects();
+
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Stop refreshing the group channel collection on mount.

`useGroupChannelList` already creates the initial collection from `channelListQueryParams`, but the effect watching those params used a serialized string as its dependency, so it also ran on the first render and called `refresh()`. That discarded the collection whose first page was still in flight and started over.

While the replacement request was in flight the list was briefly reported as loaded and empty, so the empty-list placeholder rendered for about one round trip before the channels appeared. Apps running with the local cache enabled did not see it, because the replacement collection was already populated from the local database.

- Use the existing `useDidMountEffect` so the refresh runs only when `channelListQueryParams` actually change. A `useRef` guard would not do: React StrictMode double-invokes effects on the same instance, so the second setup would pass the guard and reintroduce the duplicate initialization in development.
- Drop one redundant collection and one redundant channel list request per mount. This happened on every mount regardless of the cache setting.

### Behavior changes

- The overlap used to report the list as loaded while it was still empty, so the auto-select effect called `onChannelSelect(null)` on mount. It now selects the first channel.
- `GroupChannelListUIView` is untouched. The empty-list placeholder still renders when the list is genuinely empty after loading.

### Tests

- `GroupChannelListProvider.queryParams.spec.tsx` — no refresh on mount, including under StrictMode; refresh on a real params change; no refresh when the params keep the same value.
- `GroupChannelListUI.emptyPlaceholder.integration.test.tsx` — renders the provider and the list UI against a fake SDK whose first page stays in flight, and asserts the loading placeholder shows while the empty-list placeholder never does. Reverting this change makes it fail on the rendered placeholder element.

All added tests were confirmed to fail without the source change.

### Follow-up

This removes the refresh that no consumer asked for. Overlapping refreshes are a separate matter and are tracked on their own: a `channelListQueryParams` change or an explicit `refresh()` that lands while a load is still in flight can still momentarily empty the list, and so can a `refresh()` overlapping a scroll-triggered `loadMore()`. None of those are introduced or widened here.

Fixes [CLNP-8827](https://sendbird.atlassian.net/browse/CLNP-8827)

### Changelogs

- Fix the group channel list briefly rendering the empty-list placeholder before channels load when the local cache is disabled

### Checklist

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] Public components / utils / props are appropriately exported
- [ ] I have added necessary documentation (if appropriate)


[CLNP-8827]: https://sendbird.atlassian.net/browse/CLNP-8827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ