### PR TITLE
[fix]: Show the delivery status of messages that never reached the server

### DIFF
--- a/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
+++ b/src/modules/Thread/components/ThreadList/ThreadListItemContent.tsx
@@ -11,8 +11,11 @@ import { MessageEmojiMenu } from '../../../../ui/MessageItemReactionMenu';
 import Label, { LabelTypography, LabelColors } from '../../../../ui/Label';
 import {
   getClassName,
+  isFailedMessage,
   isMultipleFilesMessage,
   isOGMessage,
+  isPendingMessage,
+  isSendableMessage,
   isThumbnailMessage,
   SendableMessageType,
 } from '../../../../utils';
@@ -122,6 +125,11 @@ export default function ThreadListItemContent(props: ThreadListItemContentProps)
   const isByMe = (userId === (message as SendableMessageType)?.sender?.userId)
     || ((message as SendableMessageType)?.sendingStatus === 'pending')
     || ((message as SendableMessageType)?.sendingStatus === 'failed');
+  // A message that has not settled must always show its status. chainTop/chainBottom are
+  // public props, so a custom list can chain one and silently remove the only indication
+  // that the message never went out.
+  const isUnsettled = isSendableMessage(message)
+    && (isPendingMessage(message) || isFailedMessage(message));
   const useReplying = !!((replyType === 'QUOTE_REPLY' || replyType === 'THREAD')
     && message?.parentMessageId && message?.parentMessage
     && !disableQuoteMessage
@@ -210,7 +218,7 @@ export default function ThreadListItemContent(props: ThreadListItemContentProps)
         }
         <div className={getClassName(['sendbird-thread-list-item-content__middle__body-container'])} >
           {/* message status component */}
-          {(isByMe && !chainBottom) && (
+          {(isByMe && (!chainBottom || isUnsettled)) && (
             <div className={getClassName(['sendbird-thread-list-item-content__middle__body-container__created-at', 'left', supposedHoverClassName])}>
               <div className="sendbird-thread-list-item-content__middle__body-container__created-at__component-container">
                 <MessageStatus

--- a/src/modules/Thread/components/ThreadList/__tests__/ThreadListItemContent.spec.tsx
+++ b/src/modules/Thread/components/ThreadList/__tests__/ThreadListItemContent.spec.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ThreadListItemContent from '../ThreadListItemContent';
+import { useLocalization } from '../../../../../lib/LocalizationContext';
+import { useMediaQueryContext } from '../../../../../lib/MediaQueryContext';
+import useSendbird from '../../../../../lib/Sendbird/context/hooks/useSendbird';
+import useThread from '../../../context/useThread';
+
+vi.mock('date-fns/format', () => ({ default: () => 'mock-date' }));
+
+vi.mock('../../../../../lib/LocalizationContext', async () => {
+  const reactModule = await vi.importActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    LocalizationContext: reactModule.createContext({
+      stringSet: { DATE_FORMAT__MESSAGE_CREATED_AT: 'p' },
+    }),
+    useLocalization: vi.fn(),
+  };
+});
+vi.mock('../../../../../lib/MediaQueryContext', () => ({
+  __esModule: true,
+  useMediaQueryContext: vi.fn(),
+}));
+vi.mock('../../../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(),
+  useSendbird: vi.fn(),
+}));
+vi.mock('../../../context/useThread', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+vi.mock('../../../../Channel/context/hooks/useThreadMessageKindKeySelector', () => ({
+  __esModule: true,
+  useThreadMessageKindKeySelector: () => 'thread-message-kind-key',
+}));
+vi.mock('../../../../Channel/context/hooks/useFileInfoListWithUploaded', () => ({
+  __esModule: true,
+  useFileInfoListWithUploaded: () => [],
+}));
+
+const createMockChannel = () => ({
+  isGroupChannel: () => true,
+  isEphemeral: false,
+  getUnreadMemberCount: () => 1,
+  getUndeliveredMemberCount: () => 1,
+}) as any;
+
+const createMockMessage = (sendingStatus: string) => ({
+  messageId: 2020,
+  messageType: 'user',
+  message: 'a thread reply',
+  createdAt: 1579767478896,
+  reactions: [],
+  sendingStatus,
+  parentMessageId: 0,
+  parentMessage: null,
+  threadInfo: { replyCount: 0 },
+  sender: { profileUrl: '', userId: 'user-id-001', nickname: 'Mathew' },
+  isAdminMessage: () => false,
+  isUserMessage: () => true,
+  isFileMessage: () => false,
+  isResendable: () => false,
+}) as any;
+
+const STATUS_SELECTOR = '.sendbird-message-status';
+
+describe('modules/Thread/ThreadListItemContent', () => {
+  beforeEach(() => {
+    (useMediaQueryContext as any).mockReturnValue({ isMobile: false });
+    (useLocalization as any).mockReturnValue({
+      dateLocale: {},
+      stringSet: { DATE_FORMAT__MESSAGE_CREATED_AT: 'p' },
+    });
+    (useSendbird as any).mockReturnValue({
+      state: {
+        config: {
+          logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn() },
+          groupChannel: { enableOgtag: true },
+        },
+        eventHandlers: {},
+      },
+    });
+    (useThread as any).mockReturnValue({
+      state: { onBeforeDownloadFileMessage: null, filterEmojiCategoryIds: undefined },
+      actions: { deleteMessage: vi.fn() },
+    });
+  });
+
+  // CLNP-8803 / C1
+  //
+  // Same defect as MessageContent: the status block was gated purely on chainBottom, so a
+  // chained pending or failed reply lost its only delivery indicator.
+  describe('undelivered status survives grouping', () => {
+    const renderWithChain = (sendingStatus: string, chainBottom: boolean) => render(
+      <ThreadListItemContent
+        userId="user-id-001"
+        channel={createMockChannel()}
+        message={createMockMessage(sendingStatus)}
+        chainBottom={chainBottom}
+      />,
+    );
+
+    it('renders the status of a pending reply even when chained', () => {
+      const { container } = renderWithChain('pending', true);
+      expect(container.querySelector(STATUS_SELECTOR)).toBeTruthy();
+    });
+
+    it('renders the status of a failed reply even when chained', () => {
+      const { container } = renderWithChain('failed', true);
+      expect(container.querySelector(STATUS_SELECTOR)).toBeTruthy();
+    });
+
+    it('still hides the status of a chained succeeded reply', () => {
+      const { container } = renderWithChain('succeeded', true);
+      expect(container.querySelector(STATUS_SELECTOR)).toBe(null);
+    });
+
+    it('still shows the status of an unchained succeeded reply', () => {
+      const { container } = renderWithChain('succeeded', false);
+      expect(container.querySelector(STATUS_SELECTOR)).toBeTruthy();
+    });
+  });
+
+  // A reply from someone else can never be pending or failed, so every incoming branch must
+  // keep following chainBottom exactly as before.
+  describe('incoming replies keep their chain behaviour', () => {
+    const renderIncoming = (chainBottom: boolean) => render(
+      <ThreadListItemContent
+        userId="another-user"
+        channel={createMockChannel()}
+        message={createMockMessage('succeeded')}
+        chainBottom={chainBottom}
+      />,
+    );
+
+    it('hides the sender avatar when chained', () => {
+      const { container } = renderIncoming(true);
+      expect(
+        container.querySelector('.sendbird-thread-list-item-content__left__avatar'),
+      ).toBe(null);
+    });
+
+    it('shows the sender avatar when not chained', () => {
+      const { container } = renderIncoming(false);
+      expect(
+        container.querySelector('.sendbird-thread-list-item-content__left__avatar'),
+      ).toBeTruthy();
+    });
+
+    it('never renders the outgoing status block for an incoming reply', () => {
+      expect(renderIncoming(false).container.querySelector(STATUS_SELECTOR)).toBe(null);
+      expect(renderIncoming(true).container.querySelector(STATUS_SELECTOR)).toBe(null);
+    });
+  });
+});

--- a/src/ui/MessageContent/__tests__/MessageContent.spec.js
+++ b/src/ui/MessageContent/__tests__/MessageContent.spec.js
@@ -357,4 +357,57 @@ describe('ui/MessageContent', () => {
       container.querySelector('.sendbird-text-message-item-body')
     ).toBeTruthy();
   });
+
+  // CLNP-8803 / C1
+  //
+  // chainTop/chainBottom are public props, so an app with a custom MessageList computes
+  // them itself and bypasses compareMessagesForGrouping's guard. This component trusted
+  // the incoming value and dropped the status block entirely, which is how an undelivered
+  // message ended up with no timestamp, no spinner and no error icon at all.
+  describe('undelivered status survives grouping', () => {
+    const renderWithChain = (sendingStatus, chainBottom) => render(
+      <MessageContent
+        userId="user-id-001"
+        message={createMockMessage((m) => ({ ...m, sendingStatus }))}
+        channel={createMockChannel()}
+        chainBottom={chainBottom}
+      />
+    );
+
+    it('renders the status of a pending message even when chained', () => {
+      const { container } = renderWithChain('pending', true);
+      expect(container.querySelector('.sendbird-message-status')).toBeTruthy();
+    });
+
+    it('renders the status of a failed message even when chained', () => {
+      const { container } = renderWithChain('failed', true);
+      expect(container.querySelector('.sendbird-message-status')).toBeTruthy();
+    });
+
+    it('still hides the status of a chained succeeded message', () => {
+      const { container } = renderWithChain('succeeded', true);
+      expect(container.querySelector('.sendbird-message-status')).toBe(null);
+    });
+
+    it('still shows the status of an unchained succeeded message', () => {
+      const { container } = renderWithChain('succeeded', false);
+      expect(container.querySelector('.sendbird-message-status')).toBeTruthy();
+    });
+
+    it('leaves the incoming-message chain behaviour alone', () => {
+      // A message from someone else can never be pending or failed, so the chained
+      // created-at block must keep following chainBottom exactly as before.
+      const { container } = render(
+        <MessageContent
+          userId="another-user"
+          message={createMockMessage()}
+          channel={createMockChannel()}
+          chainBottom
+        />
+      );
+      expect(
+        container.querySelector('.sendbird-message-content__middle__body-container__created-at')
+      ).toBe(null);
+    });
+  });
 });

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -16,9 +16,10 @@ import {
   CoreMessageType,
   getClassName,
   isAdminMessage,
+  isFailedMessage,
   isFormMessage,
   isMultipleFilesMessage,
-  isOGMessage, isSendableMessage,
+  isOGMessage, isPendingMessage, isSendableMessage,
   isTemplateMessage,
   isThumbnailMessage,
   isValidTemplateMessageType,
@@ -167,6 +168,11 @@ export function MessageContent(props: MessageContentProps): ReactElement {
     || ((message as SendableMessageType)?.sendingStatus === 'pending')
     || ((message as SendableMessageType)?.sendingStatus === 'failed');
   const isByMeClassName = isByMe ? 'outgoing' : 'incoming';
+  // A message that has not settled must always show its status. chainTop/chainBottom are
+  // public props, so a custom MessageList can chain one and silently remove the only
+  // indication that the message never went out.
+  const isUnsettled = isSendableMessage(message)
+    && (isPendingMessage(message) || isFailedMessage(message));
   const chainTopClassName = chainTop ? 'chain-top' : '';
   const isReactionEnabledInChannel = isReactionEnabled && !channel?.isEphemeral;
   const isReactionEnabledClassName = isReactionEnabledInChannel ? 'use-reactions' : '';
@@ -383,7 +389,7 @@ export function MessageContent(props: MessageContentProps): ReactElement {
           )}
         >
           {/* message status component when sent by me */}
-          {(isByMe && !chainBottom) && (
+          {(isByMe && (!chainBottom || isUnsettled)) && (
             <div
               className={classnames(
                 'sendbird-message-content__middle__body-container__created-at',

--- a/src/ui/MessageStatus/__tests__/MessageStatus.spec.js
+++ b/src/ui/MessageStatus/__tests__/MessageStatus.spec.js
@@ -50,3 +50,89 @@ describe('ui/MessageStatus', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 });
+
+// CLNP-8803 / C3
+//
+// `NONE` means "no status to show", but the component fell back to the ERROR icon for it
+// and attached the `sendbird-message-status--sent` hook class, because that class was
+// gated on `status !== FAILED` rather than on the status actually being sent. An app that
+// hides `--sent` to drop the read receipts therefore also hid the bogus error icon,
+// leaving an undelivered message completely blank.
+describe('ui/MessageStatus - unmapped status must not borrow another status signal', () => {
+  // `canceled` resolves to NONE; the SDK has no 'none' sending status of its own.
+  const unmappedMsg = { ...dummyMessage, sendingStatus: 'canceled' };
+
+  it('renders no status icon at all', () => {
+    const { queryByTestId } = render(<MessageStatus message={unmappedMsg} />);
+    expect(queryByTestId('sendbird-message-status-icon')).toBeNull();
+  });
+
+  it('does not leak the literal string "icon" as the icon type', () => {
+    // Icon's switch falls through to the string 'icon' for an undefined type, so simply
+    // dropping the ERROR fallback without gating the render would print that text.
+    const { container } = render(<MessageStatus message={unmappedMsg} />);
+    expect(container.textContent).not.toContain('icon');
+  });
+
+  it('does not attach the sent hook class', () => {
+    const { container } = render(<MessageStatus message={unmappedMsg} />);
+    expect(container.querySelector('.sendbird-message-status--sent')).toBeNull();
+  });
+
+  it('does not render a sent timestamp', () => {
+    const { queryByTestId } = render(<MessageStatus message={unmappedMsg} />);
+    expect(queryByTestId('sendbird-message-status-text')).toBeNull();
+  });
+
+  it('keeps the status container so layout hooks survive', () => {
+    const { container } = render(<MessageStatus message={unmappedMsg} />);
+    expect(container.getElementsByClassName('sendbird-message-status').length).toBe(1);
+  });
+});
+
+describe('ui/MessageStatus - settled statuses are unchanged', () => {
+  const groupChannel = (counts) => ({ isGroupChannel: () => true, ...counts });
+
+  it('keeps the icon and the sent hook class for SENT', () => {
+    const { queryByTestId } = render(<MessageStatus message={dummyMessage} />);
+    const icon = queryByTestId('sendbird-message-status-icon');
+    expect(icon.className).toContain('sendbird-icon-done');
+    expect(icon.className).toContain('sendbird-message-status--sent');
+  });
+
+  it('keeps the icon and the sent hook class for DELIVERED', () => {
+    const channel = groupChannel({
+      getUnreadMemberCount: () => 1,
+      getUndeliveredMemberCount: () => 0,
+    });
+    const { queryByTestId } = render(<MessageStatus message={dummyMessage} channel={channel} />);
+    const icon = queryByTestId('sendbird-message-status-icon');
+    expect(icon.className).toContain('sendbird-icon-done-all');
+    expect(icon.className).toContain('sendbird-message-status--sent');
+  });
+
+  it('keeps the icon and the sent hook class for READ', () => {
+    const channel = groupChannel({ getUnreadMemberCount: () => 0 });
+    const { queryByTestId } = render(<MessageStatus message={dummyMessage} channel={channel} />);
+    const icon = queryByTestId('sendbird-message-status-icon');
+    expect(icon.className).toContain('sendbird-icon-done-all');
+    expect(icon.className).toContain('sendbird-message-status--sent');
+  });
+
+  it('keeps the error icon and withholds the sent hook class for FAILED', () => {
+    const { queryByTestId } = render(
+      <MessageStatus message={{ ...dummyMessage, sendingStatus: 'failed' }} />,
+    );
+    const icon = queryByTestId('sendbird-message-status-icon');
+    expect(icon.className).toContain('sendbird-icon-error');
+    expect(icon.className).not.toContain('sendbird-message-status--sent');
+  });
+
+  it('keeps the spinner for PENDING', () => {
+    const { queryByTestId } = render(
+      <MessageStatus message={{ ...dummyMessage, sendingStatus: 'pending' }} />,
+    );
+    const icon = queryByTestId('sendbird-message-status-icon');
+    expect(icon.className).toContain('sendbird-loader');
+  });
+});

--- a/src/ui/MessageStatus/index.tsx
+++ b/src/ui/MessageStatus/index.tsx
@@ -75,16 +75,19 @@ export default function MessageStatus({
             height="16px"
           />
         </Loader>
-      ) : (
+      ) : iconType[status] ? (
+        // Only render once the status maps to an icon. `Icon` falls through to the
+        // literal string 'icon' for an undefined type, and falling back to ERROR here
+        // reported an unmapped status as a send failure.
         <Icon
-          className={classnames('sendbird-message-status__icon', hideMessageStatusIcon && 'hide-icon', status !== OutgoingMessageStates.FAILED && 'sendbird-message-status--sent')}
+          className={classnames('sendbird-message-status__icon', hideMessageStatusIcon && 'hide-icon', isSentStatus(status) && 'sendbird-message-status--sent')}
           testID="sendbird-message-status-icon"
-          type={iconType[status] || IconTypes.ERROR}
+          type={iconType[status]}
           fillColor={iconColor[status]}
           width="16px"
           height="16px"
         />
-      )}
+      ) : null}
       {isSentStatus(status) && (
         <Label
           className="sendbird-message-status__text"

--- a/src/utils/__tests__/compareMessagesForGrouping.spec.ts
+++ b/src/utils/__tests__/compareMessagesForGrouping.spec.ts
@@ -1,87 +1,118 @@
-import { compareMessagesForGrouping, isSameGroup } from '../../utils/messages';
+import { compareMessagesForGrouping } from '../../utils/messages';
 
-vi.mock('../../utils/messages', async () => ({
-  ...await vi.importActual('../../utils/messages'),
-  isSameGroup: vi.fn(),
-}));
+// NOTE: this suite previously mocked `isSameGroup` and called the comparator with five
+// arguments while the real signature takes six (stringSet is the fourth). The mock never
+// intercepted the internal call and the misplaced arguments pushed every case down the
+// non-group early return, so the assertions passed for the wrong reason. Both problems are
+// fixed here: the comparator runs unmocked against real message shapes.
+
+const stringSet = { DATE_FORMAT__MESSAGE_CREATED_AT: 'p' } as any;
+
+const messageWith = (sendingStatus: string, overrides: Record<string, unknown> = {}) => ({
+  messageId: 1,
+  messageType: 'user',
+  sendingStatus,
+  sender: { userId: 'tester' },
+  createdAt: 1579767478896,
+  ...overrides,
+} as any);
+
+/** A group channel where nobody has caught up, so no message resolves to READ/DELIVERED. */
+const groupChannel = {
+  channelType: 'group',
+  isGroupChannel: () => true,
+  getUnreadMemberCount: () => 1,
+  getUndeliveredMemberCount: () => 1,
+} as any;
+
+const compare = (
+  sendingStatus: string,
+  channel: unknown,
+  replyType?: string,
+  overrides?: Record<string, unknown>,
+) => compareMessagesForGrouping(
+  messageWith(sendingStatus, overrides),
+  messageWith(sendingStatus, overrides),
+  messageWith(sendingStatus, overrides),
+  stringSet,
+  channel as any,
+  replyType as any,
+);
 
 describe('compareMessagesForGrouping', () => {
-  it('should return false for both chainTop and chainBottom when replyType is THREAD and currentMessage has threadInfo', () => {
-    const prevMessage = {};
-    const currMessage = {
-      threadInfo: {},
-    };
-    const nextMessage = {};
-    const currentChannel = {};
-    const replyType = 'THREAD';
-    // @ts-ignore
-    const result = compareMessagesForGrouping(prevMessage, currMessage, nextMessage, currentChannel, replyType);
-    expect(result).toEqual([false, false]);
+  it('returns [false, false] when replyType is THREAD and the message has threadInfo', () => {
+    expect(compare('succeeded', groupChannel, 'THREAD', { threadInfo: {} })).toEqual([false, false]);
   });
 
-  // NOTE: Using vi.mock to mock methods of a specific module is not functioning as expected.
-  //  Nevertheless, even aside from that, since this test is not intended to validate something, it will be skipped.
-  it.skip('should return [true, true] when on same group', () => {
-    // @ts-ignore
-    isSameGroup.mockImplementation(() => true);
-    const prevMessage = {
-      sendingStatus: 'succeeded',
-      messageType: 'user',
-      sender: { userId: 'tester1' },
-      createdAt: 0,
-    };
-    const currMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const nextMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const currentChannel = {
+  it('returns [true, true] for consecutive succeeded messages in the same group', () => {
+    expect(compare('succeeded', groupChannel)).toEqual([true, true]);
+  });
+
+  it('returns [false, false] when the message is pending', () => {
+    expect(compare('pending', groupChannel)).toEqual([false, false]);
+  });
+
+  it('returns [false, false] when the message is failed', () => {
+    expect(compare('failed', groupChannel)).toEqual([false, false]);
+  });
+
+  it('returns a two-element tuple, as the exported contract promises', () => {
+    const result = compare('succeeded', groupChannel);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// CLNP-8803
+//
+// getOutgoingMessageState now maps canceled and scheduled to NONE before consulting read
+// receipts. isSameGroup compares isReadMessage() on both sides, and receipt counts are
+// per-message (they key off createdAt), so two same-minute canceled messages could
+// previously differ by receipt and stay ungrouped. Collapsing both to NONE would have
+// started chaining them. Grouping is decided by delivery, not by receipt bookkeeping, so
+// the guard covers every state that never reached the server.
+describe('compareMessagesForGrouping - undelivered messages are never chained', () => {
+  it('does not group canceled messages', () => {
+    expect(compare('canceled', groupChannel)).toEqual([false, false]);
+  });
+
+  it('does not group scheduled messages', () => {
+    expect(compare('scheduled', groupChannel)).toEqual([false, false]);
+  });
+
+  it('does not group a canceled pair whose read receipts disagree', () => {
+    // Before the guard covered `canceled`, one side resolved to READ and the other to NONE,
+    // which happened to keep them apart. That accident must not be what protects us.
+    const mixedReceiptChannel = {
+      channelType: 'group',
       isGroupChannel: () => true,
-      getUnreadMemberCount: () => 1,
+      getUnreadMemberCount: (m: any) => (m.messageId === 1 ? 0 : 1),
       getUndeliveredMemberCount: () => 1,
-    };
-    const replyType = 'QUOTE_REPLY';
-    // @ts-ignore
-    const result = compareMessagesForGrouping(prevMessage, currMessage, nextMessage, currentChannel, replyType);
-    expect(result).toEqual([true, true]);
+    } as any;
+    const first = messageWith('canceled', { messageId: 1 });
+    const second = messageWith('canceled', { messageId: 2 });
+
+    expect(
+      compareMessagesForGrouping(first, second, first, stringSet, mixedReceiptChannel, undefined),
+    ).toEqual([false, false]);
+  });
+});
+
+// The non-group early return is deliberately left untouched: OpenChannel calls the
+// comparator without a channel (OpenChannelMessageList passes four arguments) and renders
+// its pending/failed indicators independently of the chain flags, so guarding that path
+// would change avatars and headers in a view that has no status bug. MessageContent's own
+// unsettled-message check covers the null-channel group case instead.
+describe('compareMessagesForGrouping - the non-group path is unchanged', () => {
+  it('still groups pending messages when there is no channel', () => {
+    expect(compare('pending', null)).toEqual([true, true]);
   });
 
-  it('should return [false, false] when on same group but sendingStatus is pending', () => {
-    // @ts-ignore
-    isSameGroup.mockImplementation(() => true);
-    const prevMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const currMessage = {
-      sendingStatus: 'pending',
-    };
-    const nextMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const currentChannel = {};
-    const replyType = 'QUOTE_REPLY';
-    // @ts-ignore
-    const result = compareMessagesForGrouping(prevMessage, currMessage, nextMessage, currentChannel, replyType);
-    expect(result).toEqual([false, false]);
+  it('still groups failed messages in a non-group channel', () => {
+    expect(compare('failed', { channelType: 'open' })).toEqual([true, true]);
   });
 
-  it('should return [false, false] when on same group but sendingStatus is failed', () => {
-    // @ts-ignore
-    isSameGroup.mockImplementation(() => true);
-    const prevMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const currMessage = {
-      sendingStatus: 'failed',
-    };
-    const nextMessage = {
-      sendingStatus: 'succeeded',
-    };
-    const currentChannel = {};
-    const replyType = 'QUOTE_REPLY';
-    // @ts-ignore
-    const result = compareMessagesForGrouping(prevMessage, currMessage, nextMessage, currentChannel, replyType);
-    expect(result).toEqual([false, false]);
+  it('still groups succeeded messages when there is no channel', () => {
+    expect(compare('succeeded', null)).toEqual([true, true]);
   });
 });

--- a/src/utils/exports/__tests__/getOutgoingMessageState.spec.ts
+++ b/src/utils/exports/__tests__/getOutgoingMessageState.spec.ts
@@ -1,0 +1,142 @@
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { UserMessage } from '@sendbird/chat/message';
+import { getOutgoingMessageState, OutgoingMessageStates } from '../getOutgoingMessageState';
+
+/**
+ * CLNP-8803 / C4
+ *
+ * `getUnreadMemberCount` and `getUndeliveredMemberCount` are outgoing read receipts:
+ * they count the joined members whose cached receipt timestamp is older than the
+ * message's `createdAt`. The SDK short-circuits them to `0` for super, broadcast and
+ * exclusive channels, and they are naturally `0` when nobody else has joined.
+ *
+ * Running those checks before confirming the message actually reached the server made
+ * an unsent message report as READ. These tests pin the receipt checks behind a
+ * `succeeded` guard while keeping every succeeded path unchanged.
+ */
+
+/** A channel whose receipt counters always report 0, as super/broadcast channels do. */
+const zeroReceiptChannel = {
+  isGroupChannel: () => true,
+  getUnreadMemberCount: () => 0,
+  getUndeliveredMemberCount: () => 0,
+} as unknown as GroupChannel;
+
+/** An ordinary group channel where the recipient has not caught up with the message. */
+const pendingReceiptChannel = {
+  isGroupChannel: () => true,
+  getUnreadMemberCount: () => 1,
+  getUndeliveredMemberCount: () => 1,
+} as unknown as GroupChannel;
+
+describe('getOutgoingMessageState - undelivered messages must not borrow read receipts', () => {
+  it('does not report a canceled message as READ when the receipt counters are 0', () => {
+    expect(
+      getOutgoingMessageState(
+        zeroReceiptChannel,
+        { sendingStatus: 'canceled' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.NONE);
+  });
+
+  it('does not report a scheduled message as READ or DELIVERED when the receipt counters are 0', () => {
+    expect(
+      getOutgoingMessageState(
+        zeroReceiptChannel,
+        { sendingStatus: 'scheduled' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.NONE);
+  });
+
+  it('does not report a canceled message as DELIVERED when only the delivery counter is 0', () => {
+    expect(
+      getOutgoingMessageState(
+        {
+          isGroupChannel: () => true,
+          getUnreadMemberCount: () => 1,
+          getUndeliveredMemberCount: () => 0,
+        } as unknown as GroupChannel,
+        { sendingStatus: 'canceled' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.NONE);
+  });
+
+  it('keeps canceled out of the FAILED bucket', () => {
+    // `canceled` covers both an aborted request and a user-cancelled upload; the SDK
+    // collapses the two into one error code, so UIKit must not promote it to a failure.
+    expect(
+      getOutgoingMessageState(
+        pendingReceiptChannel,
+        { sendingStatus: 'canceled' } as UserMessage,
+      ),
+    ).not.toBe(OutgoingMessageStates.FAILED);
+  });
+});
+
+describe('getOutgoingMessageState - unchanged behaviour', () => {
+  it('still resolves an ordinary group channel undelivered message to NONE', () => {
+    // The dominant real-world case: receipts are non-zero, so this was already NONE.
+    expect(
+      getOutgoingMessageState(
+        pendingReceiptChannel,
+        { sendingStatus: 'canceled' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.NONE);
+  });
+
+  it('still resolves a succeeded message to READ when the unread counter is 0', () => {
+    expect(
+      getOutgoingMessageState(
+        zeroReceiptChannel,
+        { sendingStatus: 'succeeded' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.READ);
+  });
+
+  it('still resolves a succeeded message to DELIVERED when only the delivery counter is 0', () => {
+    expect(
+      getOutgoingMessageState(
+        {
+          isGroupChannel: () => true,
+          getUnreadMemberCount: () => 1,
+          getUndeliveredMemberCount: () => 0,
+        } as unknown as GroupChannel,
+        { sendingStatus: 'succeeded' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.DELIVERED);
+  });
+
+  it('still resolves a succeeded message to SENT when neither counter is 0', () => {
+    expect(
+      getOutgoingMessageState(
+        pendingReceiptChannel,
+        { sendingStatus: 'succeeded' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.SENT);
+  });
+
+  it('still resolves a succeeded open channel message to SENT', () => {
+    expect(
+      getOutgoingMessageState(
+        { isGroupChannel: () => false } as unknown as GroupChannel,
+        { sendingStatus: 'succeeded' } as UserMessage,
+      ),
+    ).toBe(OutgoingMessageStates.SENT);
+  });
+
+  it('still resolves pending and failed before any receipt check', () => {
+    expect(
+      getOutgoingMessageState(zeroReceiptChannel, { sendingStatus: 'pending' } as UserMessage),
+    ).toBe(OutgoingMessageStates.PENDING);
+    expect(
+      getOutgoingMessageState(zeroReceiptChannel, { sendingStatus: 'failed' } as UserMessage),
+    ).toBe(OutgoingMessageStates.FAILED);
+  });
+
+  it('still resolves a missing message to NONE', () => {
+    expect(getOutgoingMessageState(zeroReceiptChannel, null)).toBe(OutgoingMessageStates.NONE);
+    expect(
+      getOutgoingMessageState(zeroReceiptChannel, {} as UserMessage),
+    ).toBe(OutgoingMessageStates.NONE);
+  });
+});

--- a/src/utils/exports/getOutgoingMessageState.ts
+++ b/src/utils/exports/getOutgoingMessageState.ts
@@ -24,6 +24,13 @@ export const getOutgoingMessageState = (
   if (message.sendingStatus === 'failed') {
     return OutgoingMessageStates.FAILED;
   }
+  // Read/delivery receipts only mean something once the message reached the server.
+  // The counters below report 0 for super, broadcast and exclusive channels, and for
+  // channels with no other joined member, so running them first made a message that
+  // never left the device report as READ.
+  if (message.sendingStatus !== 'succeeded') {
+    return OutgoingMessageStates.NONE;
+  }
   if (channel?.isGroupChannel?.()) {
     /* GroupChannel only */
     if ((channel as GroupChannel).getUnreadMemberCount?.(message) === 0) {
@@ -32,8 +39,5 @@ export const getOutgoingMessageState = (
       return OutgoingMessageStates.DELIVERED;
     }
   }
-  if (message.sendingStatus === 'succeeded') {
-    return OutgoingMessageStates.SENT;
-  }
-  return OutgoingMessageStates.NONE;
+  return OutgoingMessageStates.SENT;
 };

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -30,7 +30,14 @@ export const compareMessagesForGrouping = (
     return [false, false];
   }
   const sendingStatus = (currMessage as UserMessage)?.sendingStatus || '';
-  const isAcceptable = sendingStatus !== 'pending' && sendingStatus !== 'failed';
+  // A message that has not been delivered to the recipients must not be chained. `canceled`
+  // and `scheduled` join `pending`/`failed` here because getOutgoingMessageState now maps
+  // them all to NONE: without this, two same-minute canceled messages that used to differ by
+  // read receipt would start chaining. Grouping follows delivery, not receipt bookkeeping.
+  const isAcceptable = sendingStatus !== 'pending'
+    && sendingStatus !== 'failed'
+    && sendingStatus !== 'canceled'
+    && sendingStatus !== 'scheduled';
   return [
     isSameGroup(prevMessage, currMessage, stringSet, currentChannel) && isAcceptable,
     isSameGroup(currMessage, nextMessage, stringSet, currentChannel) && isAcceptable,


### PR DESCRIPTION

Outgoing messages that never settled could render with no timestamp, no spinner and no error icon at all, so an agent had no way to tell that a message had not been sent. Four defects contributed, each of which is real on its own.

**Status was gated purely on grouping.** `MessageContent` and `ThreadListItemContent` dropped the entire status block whenever `chainBottom` was true. UIKit's own grouping never chains a `pending`/`failed` message, but `chainTop`/`chainBottom` are public props, so an application with a custom `MessageList` computes them itself and bypasses that guarantee. The components now honour the invariant themselves and always render the status of an unsettled message.

**An unmapped status borrowed another status' signal.** `MessageStatus` fell back to the `ERROR` icon for a status it had no icon for, and attached the `sendbird-message-status--sent` hook class on everything that was not `FAILED` — including `NONE`. An application that hides that class to drop the read receipts therefore also hid the bogus error icon, leaving the message completely blank. The icon is now rendered only when the status maps to one, and the hook class follows `isSentStatus`.

**Read receipts were consulted before delivery was confirmed.** `getOutgoingMessageState` ran the group-channel unread/undelivered checks ahead of the `succeeded` check. Those counters short-circuit to `0` for super, broadcast and exclusive channels and for channels with no other joined member, so a message that never left the device could be reported as `READ`, complete with a send timestamp. Delivery is now confirmed first.

**Undelivered messages are no longer chained.** `compareMessagesForGrouping` excluded `pending` and `failed` from grouping; `canceled` and `scheduled` now join them. Without this, collapsing those states to `NONE` above would have started chaining two same-minute canceled messages that previously stayed apart because their read receipts happened to differ.

Every `succeeded` path is unchanged, in both group and open channels. No public signature changes.

## Scope

This addresses the display of messages that were not delivered. It does not change delivery itself.

It covers the status rendering of ordinary outgoing messages in `MessageContent` and `ThreadListItemContent`. Server-originated template messages render through `MessageContentForTemplateMessage`, which has no status path; UIKit has no send path that attaches a template payload, so this is out of scope by design.

## Behaviour changes to be aware of

These are fixes rather than contract changes, but they are visible to integrators.

- Applications passing `chainBottom` from a custom `MessageList` will now see a spinner or an error icon appear on grouped unsettled messages. Layout may shift accordingly.
- `.sendbird-message-status--sent` no longer matches an unmapped (`NONE`) status.
- The `.sendbird-message-status__icon` node is no longer rendered for an unmapped status. The `sendbird-message-status` container remains, but stylesheets or selectors that assume the inner node always exists will be affected.
- In group channels, `canceled` and `scheduled` messages are no longer chained, so their sender header and spacing change.
- In super and broadcast channels, an undelivered message no longer shows a send timestamp.

OpenChannel behaviour is unchanged: `compareMessagesForGrouping`'s no-channel path is untouched.

## Verification

- Full suite: 169 files, 974 tests passing
- Type check, lint and build pass
- No snapshot changes — every existing render path is byte-identical
- Public type declarations compared against the build output; `getOutgoingMessageState`, `compareMessagesForGrouping`, `isSameGroup` and `OutgoingMessageStates` are unchanged
- Rendered a status matrix (6 states x light/dark x with and without an application hiding `--sent`) in Chrome and compared against the baseline build; the five settled states are pixel-identical

Fixes [CLNP-8803](https://sendbird.atlassian.net/browse/CLNP-8803)

### Changelogs

- Fixed a bug where an outgoing message that failed to send could render without any status indicator when a custom message list grouped it
- Fixed a bug where a message with no mapped status showed an error icon and carried the sent-status class
- Fixed a bug where an undelivered message could be reported as read in super and broadcast channels
- Fixed a bug where canceled and scheduled messages could be grouped with adjacent messages

## Checklist

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

---

Independent correctness review by Codex (two rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CLNP-8803]: https://sendbird.atlassian.net/browse/CLNP-8803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ