### PR TITLE
fix(security): auto audit fix

### DIFF
--- a/samples/router/package-lock.json
+++ b/samples/router/package-lock.json
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3067,12 +3067,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3082,13 +3082,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4161,9 +4161,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q=="
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q=="
     },
     "@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -5540,20 +5540,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
       "requires": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.4"
       }
     },
     "react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
       "requires": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
       }
     },
     "resolve-from": {


### PR DESCRIPTION
# Security Audit Report

**Repository**: `sendbird/sendbird-uikit-react`
**Targets**: `samples/groupchannel` (npm), `samples/openchannel` (npm), `samples/router` (npm), `samples/typescript_sample` (npm), `.` (yarn-berry)
**Date**: 2026-08-31

## Summary

| | Critical | High | Moderate | Low | Total |
|---|---|---|---|---|---|
| Before | 1 | 28 | 21 | 12 | 62 |
| **Fixed** | 0 | 0 | 0 | 0 | **0** |
| Remaining | 1 | 28 | 21 | 12 | 62 |

## Remaining Vulnerabilities (requires manual review)

| Package | Target | Severity | Detail |
|---|---|---|---|
| react-router | samples/router | moderate | [React Router: Open redirect via backslash in <Link> and useNavigate (CVE-2025-68470 bypass)](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) |
| react-router-dom | samples/router | moderate | - |
| @jest/core | samples/typescript_sample | low | - |
| @svgr/plugin-svgo | samples/typescript_sample | high | - |
| @svgr/webpack | samples/typescript_sample | high | - |
| @tootallnate/once | samples/typescript_sample | low | [@tootallnate/once vulnerable to Incorrect Control Flow Scoping](https://github.com/advisories/GHSA-vpq2-c234-7xj6) |
| bfj | samples/typescript_sample | high | - |
| css-minimizer-webpack-plugin | samples/typescript_sample | moderate | - |
| css-select | samples/typescript_sample | high | - |
| http-proxy-agent | samples/typescript_sample | low | - |
| jest | samples/typescript_sample | low | - |
| jest-cli | samples/typescript_sample | low | - |
| jest-config | samples/typescript_sample | low | - |
| jest-environment-jsdom | samples/typescript_sample | low | - |
| jest-runner | samples/typescript_sample | low | - |
| jsdom | samples/typescript_sample | low | - |
| jsonpath | samples/typescript_sample | high | - |
| nth-check | samples/typescript_sample | high | [Inefficient Regular Expression Complexity in nth-check](https://github.com/advisories/GHSA-rp65-9cf3-cjxr) |
| postcss | samples/typescript_sample | high | [PostCSS line return parsing error](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |
| react-scripts | samples/typescript_sample | high | - |
| resolve-url-loader | samples/typescript_sample | moderate | - |
| rollup-plugin-terser | samples/typescript_sample | high | - |
| serialize-javascript | samples/typescript_sample | high | [Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) |
| sockjs | samples/typescript_sample | moderate | - |
| svgo | samples/typescript_sample | high | [SVGO removeScripts plugin leaves some executable scripts intact](https://github.com/advisories/GHSA-2p49-hgcm-8545) |
| underscore | samples/typescript_sample | high | [Underscore has unlimited recursion in _.flatten and _.isEqual, potential for DoS attack](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw) |
| uuid | samples/typescript_sample | moderate | [uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided](https://github.com/advisories/GHSA-w5hq-g745-h8pq) |
| webpack-dev-server | samples/typescript_sample | moderate | [webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser](https://github.com/advisories/GHSA-9jgg-88mc-972h) |
| workbox-build | samples/typescript_sample | high | - |
| workbox-webpack-plugin | samples/typescript_sample | high | - |
| braces | . | high | [Uncontrolled resource consumption in braces](https://github.com/advisories/GHSA-grv7-fg5c-xmjg) |
| micromatch | . | moderate | [Regular Expression Denial of Service (ReDoS) in micromatch](https://github.com/advisories/GHSA-952p-6rrq-rcjv) |
| @eslint/plugin-kit | . | low | [Regular Expression Denial of Service (ReDoS) in @eslint/plugin-kit](https://github.com/advisories/GHSA-7q7g-4xm8-89cq) |
| @eslint/plugin-kit | . | low | [@eslint/plugin-kit is vulnerable to Regular Expression Denial of Service attacks through ConfigCommentParser](https://github.com/advisories/GHSA-xffm-g5w8-qvg7) |
| tmp | . | low | [tmp allows arbitrary temporary file / directory write via symbolic link `dir` parameter](https://github.com/advisories/GHSA-52f5-9888-hmc6) |
| postcss | . | moderate | [PostCSS line return parsing error](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |
| @remix-run/router | . | high | [React Router vulnerable to XSS via Open Redirects](https://github.com/advisories/GHSA-2w69-qvjg-hvjx) |
| react-router | . | moderate | [React Router has unexpected external redirect via untrusted paths](https://github.com/advisories/GHSA-9jcx-v3wj-wh4m) |
| tar | . | high | [node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Traversal](https://github.com/advisories/GHSA-34x7-hfp2-rc4v) |
| tar | . | high | [node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Insufficient Path Sanitization](https://github.com/advisories/GHSA-8qq5-rm4j-mr97) |
| tar | . | high | [Arbitrary File Read/Write via Hardlink Target Escape Through Symlink Chain in node-tar Extraction](https://github.com/advisories/GHSA-83g3-92jg-28cx) |
| tar | . | high | [tar has Hardlink Path Traversal via Drive-Relative Linkpath](https://github.com/advisories/GHSA-qffp-2rhf-9h96) |
| tar | . | high | [node-tar Symlink Path Traversal via Drive-Relative Linkpath](https://github.com/advisories/GHSA-9ppj-qmqm-q256) |
| tar | . | high | [Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on macOS APFS](https://github.com/advisories/GHSA-r6q2-hw4h-h46w) |
| postcss | . | moderate | [PostCSS has XSS via Unescaped </style> in its CSS Stringify Output](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) |
| ip-address | . | moderate | [ip-address has XSS in Address6 HTML-emitting methods](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) |
| uuid | . | moderate | [uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided](https://github.com/advisories/GHSA-w5hq-g745-h8pq) |
| tmp | . | high | [tmp has Path Traversal via unsanitized prefix/postfix that enables directory escape](https://github.com/advisories/GHSA-ph9p-34f9-6g65) |
| tar | . | moderate | [node-tar applies PAX size override to intermediary GNU long-name/long-link headers, causing tar parser interpretation differential (file smuggling)](https://github.com/advisories/GHSA-vmf3-w455-68vh) |
| tar | . | moderate | [node-tar: Process crash via PAX numeric path type confusion](https://github.com/advisories/GHSA-w8wr-v893-vjvp) |
| tar | . | critical | [node-tar: Decompression/parse DoS via unlimited input](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) |
| tar | . | high | [node-tar: Negative tar entry size causes infinite loop in archive replace](https://github.com/advisories/GHSA-8x88-c5mf-7j5w) |
| tar | . | moderate | [node-tar: Uncaught Exception DoS via NUL byte in PAX path/linkpath records](https://github.com/advisories/GHSA-gvwx-54wh-qm9j) |
| postcss | . | high | [PostCSS: Arbitrary file read and information disclosure via attacker-controlled sourceMappingURL in CSS comments](https://github.com/advisories/GHSA-6g55-p6wh-862q) |
| react-router | . | moderate | [React Router: Open redirect via backslash in <Link> and useNavigate (CVE-2025-68470 bypass)](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) |
| react-router | . | moderate | [React Router: Arbitrary Constructor Injection via deserializeErrors() in React Router SSR Hydration](https://github.com/advisories/GHSA-337j-9hxr-rhxg) |
| postcss | . | moderate | [PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) |
| ip-address | . | high | [ip-address: Address4 decodes leading-zero octets as decimal while resolvers decode them as octal, allowing SSRF and trust-boundary bypass](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) |
| @remix-run/router | . | moderate | [React Router's same-origin redirect with path starting // causes open redirect via protocol-relative URL reinterpretation](https://github.com/advisories/GHSA-2j2x-hqr9-3h42) |
| react-router | . | moderate | [React Router's same-origin redirect with path starting // causes open redirect via protocol-relative URL reinterpretation](https://github.com/advisories/GHSA-2j2x-hqr9-3h42) |
| postcss | . | high | [PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure](https://github.com/advisories/GHSA-r28c-9q8g-f849) |
| tar | . | high | [node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection](https://github.com/advisories/GHSA-r292-9mhp-454m) |

## Changed files

`samples/router/package-lock.json`

## Review checklist

- [ ] Verify no breaking changes in updated dependencies
- [ ] Confirm CI passes
