### PR TITLE
[fix]: Restore public Thread action contracts changed by the Collection migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@sendbird/chat": "^4.22.10",
     "@sendbird/react-uikit-message-template-view": "^0.1.5",
-    "@sendbird/uikit-tools": "^0.1.5",
+    "@sendbird/uikit-tools": "^0.2.0",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
     "dompurify": "^3.4.13"

--- a/src/modules/Thread/components/ThreadUI/__test__/ThreadUI.integration.test.tsx
+++ b/src/modules/Thread/components/ThreadUI/__test__/ThreadUI.integration.test.tsx
@@ -114,9 +114,11 @@ const defaultMockState = {
 const defaultMockActions = {
   fetchPrevThreads: vi.fn((callback) => {
     callback();
+    return Promise.resolve();
   }),
   fetchNextThreads: vi.fn((callback) => {
     callback();
+    return Promise.resolve();
   }),
 };
 
@@ -232,6 +234,38 @@ describe('CreateChannelUI Integration Tests', () => {
     await waitFor(() => {
       expect(defaultMockActions.fetchPrevThreads).toBeCalledTimes(1);
     });
+  });
+
+  it('does not crash when fetchPrevThreads rejects during scroll to top', async () => {
+    let container;
+    const fetchPrevThreads = vi.fn(() => Promise.reject(new Error('fetch failed')));
+    const parentMessage = {
+      messageId: 1,
+      message: 'parent message',
+      isUserMessage: () => true,
+      isTextMessage: true,
+      createdAt: 0,
+      sender: {
+        userId: 'test-user-id',
+      },
+    };
+
+    await act(async () => {
+      const result = renderComponent(
+        { parentMessage, hasMorePrev: true },
+        { fetchPrevThreads },
+      );
+
+      container = result.container;
+    });
+
+    const scrollContainer = container.getElementsByClassName('sendbird-thread-ui--scroll')[0];
+    fireEvent.scroll(scrollContainer, { target: { scrollY: -1 } });
+
+    await waitFor(() => {
+      expect(fetchPrevThreads).toBeCalledTimes(1);
+    });
+    expect(screen.getByText('threaded message 1')).toBeInTheDocument();
   });
 
   it('fetchNextThreads is correctly called when scroll is bottom', async () => {

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -116,6 +116,8 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
             //
           }
         }
+      }).catch(() => {
+        // Fetch failures are non-fatal for the scroll handler; the list simply does not extend.
       });
     }
 
@@ -132,6 +134,8 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
             //
           }
         }
+      }).catch(() => {
+        // Fetch failures are non-fatal for the scroll handler; the list simply does not extend.
       });
     }
 

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -47,6 +47,11 @@ export interface ThreadProviderProps extends
 
 type ThreadMessageDataSource = ReturnType<typeof useGroupChannelThreadMessages>;
 
+export interface LocalFilePreview {
+  localUrl: string;
+  file: File;
+}
+
 export interface ThreadState extends ThreadProviderProps {
   currentChannel: GroupChannel;
   /** All thread replies (succeeded + pending + failed) in one list. Prefer this. */
@@ -67,6 +72,7 @@ export interface ThreadState extends ThreadProviderProps {
   currentUserId: string;
   typingMembers: Member[];
   nicknamesMap: Map<string, string>;
+  localFilePreviews: Map<string, LocalFilePreview>;
   loadPrevious?: ThreadMessageDataSource['loadPrevious'];
   loadNext?: ThreadMessageDataSource['loadNext'];
   resetWithStartingPoint?: ThreadMessageDataSource['resetWithStartingPoint'];
@@ -106,6 +112,7 @@ const initialState = () => ({
   currentUserId: '',
   typingMembers: [],
   nicknamesMap: null,
+  localFilePreviews: new Map(),
 } as ThreadState);
 
 export const ThreadContext = React.createContext<ReturnType<typeof createStore<ThreadState>> | null>(null);
@@ -161,6 +168,7 @@ export const ThreadManager: React.FC<React.PropsWithChildren<ThreadProviderProps
       currentChannel,
       parentMessage,
       parentMessageState,
+      localFilePreviews,
     },
   } = useThread();
   const { updateState } = useThreadStore();
@@ -267,6 +275,15 @@ export const ThreadManager: React.FC<React.PropsWithChildren<ThreadProviderProps
   const hasMorePrev = threadDataSource.hasPrevious();
   const hasMoreNext = threadDataSource.hasNext();
   const store = useContext(ThreadContext);
+
+  useEffect(() => {
+    return () => {
+      const previews = store?.getState().localFilePreviews;
+      previews?.forEach((preview) => URL.revokeObjectURL(preview.localUrl));
+      previews?.clear();
+    };
+  }, [store]);
+
   const messagesSyncKey = threadDataSource.messages
     .map((message) => {
       const uploadParams = (message as MultipleFilesMessage).messageParams as MultipleFilesMessageCreateParams | undefined;
@@ -278,11 +295,30 @@ export const ThreadManager: React.FC<React.PropsWithChildren<ThreadProviderProps
     .join('~');
 
   useEffect(() => {
-    if (!parentMessage) return;
+    if (!parentMessage) {
+      localFilePreviews.forEach((preview) => URL.revokeObjectURL(preview.localUrl));
+      localFilePreviews.clear();
+      return;
+    }
+
+    const scopedMessages = threadDataSource.messages;
+    scopedMessages.forEach((message) => {
+      const sendableMessage = message as SendableMessageType;
+      const preview = localFilePreviews.get(sendableMessage.reqId);
+      if (!preview) return;
+      if (sendableMessage.sendingStatus === SendingStatus.SUCCEEDED) {
+        URL.revokeObjectURL(preview.localUrl);
+        localFilePreviews.delete(sendableMessage.reqId);
+        return;
+      }
+
+      const localFileMessage = message as FileMessage & { localUrl?: string; file?: File };
+      localFileMessage.localUrl ??= preview.localUrl;
+      localFileMessage.file ??= preview.file;
+    });
     // core-ts scopes the collection to this thread's replies (belongsToThread on the event/fetch and
     // send/resend paths), so mirror them as-is. Split into the legacy public shape: allThreadMessages =
     // succeeded (server) messages, localThreadMessages = pending/failed; threadMessages = all of them.
-    const scopedMessages = threadDataSource.messages;
     const localThreadMessages = scopedMessages.filter((m) => {
       const sendingStatus = (m as SendableMessageType).sendingStatus;
       return sendingStatus === SendingStatus.PENDING || sendingStatus === SendingStatus.FAILED;

--- a/src/modules/Thread/context/__test__/ThreadProvider.spec.tsx
+++ b/src/modules/Thread/context/__test__/ThreadProvider.spec.tsx
@@ -116,14 +116,25 @@ describe('ThreadProvider', () => {
     currentUserId: 'test-user-id',
     typingMembers: [],
     nicknamesMap: expect.any(Map),
+    localFilePreviews: expect.any(Map),
   };
 
   const initialMockMessage = {
     messageId: 1,
   } as SendableMessageType;
+  let localPreviewCounter = 0;
 
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => `blob:thread-local-preview-${++localPreviewCounter}`),
+      configurable: true,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+    });
     // clearAllMocks only clears call history, not implementations, so restore the default
     // collection mock here — otherwise a test that overrides it (e.g. mockReturnValue) leaks
     // into later tests and makes the suite order-dependent.
@@ -131,6 +142,12 @@ describe('ThreadProvider', () => {
     const stateContextValue = { state: mockState };
     (useSendbird as Mock).mockReturnValue(stateContextValue);
     renderHook(() => useSendbird());
+  });
+
+  afterEach(() => {
+    mockDs.loadPrevious.mockReset();
+    mockDs.loadNext.mockReset();
+    mockDs.resetWithStartingPoint.mockReset();
   });
 
   it('provides the correct initial state', async () => {
@@ -228,9 +245,13 @@ describe('ThreadProvider', () => {
     });
   });
 
-  it('fetchPrevThreads delegates to the data source loadPrevious and fires the callback', async () => {
-    mockDs.loadPrevious.mockResolvedValue(undefined);
-    const callback = vi.fn();
+  it('returns promises from thread fetch actions when the data source functions are unavailable', async () => {
+    (useGroupChannelThreadMessages as Mock).mockReturnValue({
+      ...makeDefaultDs(),
+      loadPrevious: undefined,
+      loadNext: undefined,
+      resetWithStartingPoint: undefined,
+    });
     const wrapper = ({ children }) => (
       <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
     );
@@ -240,19 +261,23 @@ describe('ThreadProvider', () => {
       expect(result.current.state.currentChannel).not.toBe(undefined);
     });
 
-    await act(async () => {
-      result.current.actions.fetchPrevThreads(callback);
-    });
+    const returned = [
+      result.current.actions.initializeThreadFetcher(),
+      result.current.actions.fetchPrevThreads(),
+      result.current.actions.fetchNextThreads(),
+    ];
 
-    expect(mockDs.loadPrevious).toHaveBeenCalled();
-    await waitFor(() => {
-      expect(callback).toHaveBeenCalled();
+    returned.forEach((promise) => expect(promise).toBeInstanceOf(Promise));
+    await act(async () => {
+      await Promise.all(returned as unknown as Promise<void>[]);
     });
   });
 
-  it('fetchNextThreads delegates to the data source loadNext and fires the callback', async () => {
-    mockDs.loadNext.mockResolvedValue(undefined);
-    const callback = vi.fn();
+  it('fetchPrevThreads returns the exact fetched page before resolving', async () => {
+    const page = [{ messageId: 802 }] as unknown as SendableMessageType[];
+    mockDs.loadPrevious.mockImplementation(async (onFetched) => {
+      onFetched(page);
+    });
     const wrapper = ({ children }) => (
       <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
     );
@@ -262,14 +287,136 @@ describe('ThreadProvider', () => {
       expect(result.current.state.currentChannel).not.toBe(undefined);
     });
 
-    await act(async () => {
-      result.current.actions.fetchNextThreads(callback);
+    const order: string[] = [];
+    const callback = vi.fn(() => order.push('callback'));
+    const returned = result.current.actions.fetchPrevThreads(callback);
+    expect(returned).toBeInstanceOf(Promise);
+    await returned;
+    order.push('resolved');
+
+    expect(mockDs.loadPrevious).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(page);
+    expect(order).toEqual(['callback', 'resolved']);
+  });
+
+  it('fetchNextThreads returns the exact fetched empty page before resolving', async () => {
+    const page: SendableMessageType[] = [];
+    mockDs.loadNext.mockImplementation(async (onFetched) => {
+      onFetched(page);
+    });
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+
+    const { result } = renderHook(() => useThread(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel).not.toBe(undefined);
     });
 
+    const order: string[] = [];
+    const callback = vi.fn(() => order.push('callback'));
+    const returned = result.current.actions.fetchNextThreads(callback);
+    expect(returned).toBeInstanceOf(Promise);
+    await returned;
+    order.push('resolved');
+
     expect(mockDs.loadNext).toHaveBeenCalled();
-    await waitFor(() => {
-      expect(callback).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(page);
+    expect(order).toEqual(['callback', 'resolved']);
+  });
+
+  it('keeps concurrent fetched pages isolated by callback', async () => {
+    const previousPage = [{ messageId: 815 }] as unknown as SendableMessageType[];
+    const nextPage = [{ messageId: 816 }] as unknown as SendableMessageType[];
+    let resolvePrevious: () => void;
+    let resolveNext: () => void;
+    const previousLoad = new Promise<void>((resolve) => { resolvePrevious = resolve; });
+    const nextLoad = new Promise<void>((resolve) => { resolveNext = resolve; });
+    mockDs.loadPrevious.mockImplementation(async (onFetched) => {
+      await previousLoad;
+      onFetched(previousPage);
     });
+    mockDs.loadNext.mockImplementation(async (onFetched) => {
+      await nextLoad;
+      onFetched(nextPage);
+    });
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result } = renderHook(() => useThread(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel).not.toBe(undefined);
+    });
+
+    const previousCallback = vi.fn();
+    const nextCallback = vi.fn();
+    const previousFetch = result.current.actions.fetchPrevThreads(previousCallback);
+    const nextFetch = result.current.actions.fetchNextThreads(nextCallback);
+
+    resolvePrevious();
+    resolveNext();
+    await previousFetch;
+    await nextFetch;
+    expect(previousCallback).toHaveBeenCalledWith(previousPage);
+    expect(nextCallback).toHaveBeenCalledWith(nextPage);
+  });
+
+  it('skips the public callback when pagination resolves without a fetched page', async () => {
+    mockDs.loadPrevious.mockResolvedValue(undefined);
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result } = renderHook(() => useThread(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel).not.toBe(undefined);
+    });
+
+    const callback = vi.fn();
+    await expect(result.current.actions.fetchPrevThreads(callback)).resolves.toBeUndefined();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('initializeThreadFetcher returns the reset page before resolving', async () => {
+    const page = [{ messageId: 822 }] as unknown as SendableMessageType[];
+    mockDs.resetWithStartingPoint.mockImplementation(async (_startingPoint, onFetched) => {
+      onFetched(page);
+    });
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+
+    const { result } = renderHook(() => useThread(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel).not.toBe(undefined);
+    });
+
+    const order: string[] = [];
+    const callback = vi.fn(() => order.push('callback'));
+    const returned = result.current.actions.initializeThreadFetcher(callback);
+    expect(returned).toBeInstanceOf(Promise);
+    await returned;
+    order.push('resolved');
+
+    expect(mockDs.resetWithStartingPoint).toHaveBeenCalledWith(Number.MAX_SAFE_INTEGER, expect.any(Function));
+    expect(callback).toHaveBeenCalledWith(page);
+    expect(order).toEqual(['callback', 'resolved']);
+  });
+
+  it('resolves without a callback and logs a warning when reset fails', async () => {
+    const error = new Error('reset failed');
+    mockDs.resetWithStartingPoint.mockRejectedValue(error);
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result } = renderHook(() => useThread(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.state.currentChannel).not.toBe(undefined);
+    });
+
+    const callback = vi.fn();
+    await expect(result.current.actions.initializeThreadFetcher(callback)).resolves.toBeUndefined();
+    expect(callback).not.toHaveBeenCalled();
+    expect(mockState.config.logger.warning).toHaveBeenCalledWith('Thread resetWithStartingPoint failed', error);
   });
 
   it('initializeThreadFetcher resets a root thread (no anchor) at the latest edge (MAX_SAFE_INTEGER)', async () => {
@@ -296,7 +443,7 @@ describe('ThreadProvider', () => {
 
     // Must match the provider's initial open (MAX), not parentMessage.createdAt (which would hide the
     // latest replies behind hasMoreNext).
-    expect(mockDs.resetWithStartingPoint).toHaveBeenCalledWith(Number.MAX_SAFE_INTEGER);
+    expect(mockDs.resetWithStartingPoint).toHaveBeenCalledWith(Number.MAX_SAFE_INTEGER, expect.any(Function));
   });
 
   it('initializeThreadFetcher resets an anchored reply at the anchor message createdAt', async () => {
@@ -321,7 +468,7 @@ describe('ThreadProvider', () => {
       result.current.actions.initializeThreadFetcher();
     });
 
-    expect(mockDs.resetWithStartingPoint).toHaveBeenCalledWith(5000);
+    expect(mockDs.resetWithStartingPoint).toHaveBeenCalledWith(5000, expect.any(Function));
   });
 
   it('onParentMessageUpdated option syncs the updated parent message into state', async () => {
@@ -397,6 +544,234 @@ describe('ThreadProvider', () => {
     });
     expect(result.current.state.localThreadMessages).toEqual([pendingMessage, failedMessage]);
     expect(result.current.state.threadMessages).toEqual([succeededMessage, pendingMessage, failedMessage]);
+  });
+
+  it('preserves a local file preview when the collection replaces its pending message with a distinct failed message', async () => {
+    const parentMessageId = 550;
+    const requestId = 'failed-file-request';
+    const pendingMessage = {
+      messageId: 0,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.PENDING,
+    } as unknown as SendableMessageType;
+    const failedMessage = {
+      messageId: 0,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.FAILED,
+      serialize: () => ({ reqId: requestId, sendingStatus: SendingStatus.FAILED }),
+    } as unknown as SendableMessageType;
+    let dsMessages: SendableMessageType[] = [];
+    let rerenderProvider = () => {};
+    const sendFileMessage = vi.fn().mockImplementation((_params, onPending) => {
+      onPending(pendingMessage);
+      dsMessages = [failedMessage];
+      rerenderProvider();
+      return Promise.reject(new Error('upload failed'));
+    });
+    (useGroupChannelThreadMessages as Mock).mockImplementation(() => ({
+      ...makeDefaultDs(),
+      initialized: true,
+      messages: dsMessages,
+      sendFileMessage,
+    }));
+
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result, rerender } = renderHook(() => useThread(), { wrapper });
+    rerenderProvider = rerender;
+    const options = (useGroupChannelThreadMessages as Mock).mock.calls.at(-1)?.[3];
+    await act(async () => {
+      options.onParentMessageUpdated({ messageId: parentMessageId } as SendableMessageType);
+    });
+
+    const file = new File(['x'], 'failed.png', { type: 'image/png' });
+    await act(async () => {
+      await expect(result.current.actions.sendFileMessage(file)).rejects.toThrow('upload failed');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.localThreadMessages).toHaveLength(1);
+    });
+    const mirroredFailedMessage = result.current.state.localThreadMessages[0] as SendableMessageType & {
+      localUrl?: string;
+      file?: File;
+    };
+    expect(mirroredFailedMessage).toBe(failedMessage);
+    expect(mirroredFailedMessage.localUrl).toMatch(/^blob:thread-local-preview-\d+$/);
+    expect(mirroredFailedMessage.file).toBe(file);
+  });
+
+  it('keeps a failed message preview through a transient collection clear', async () => {
+    const parentMessageId = 575;
+    const requestId = 'transient-clear-file-request';
+    const pendingMessage = { messageId: 0, reqId: requestId, parentMessageId } as unknown as SendableMessageType;
+    const failedMessage = {
+      messageId: 0,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.FAILED,
+      serialize: () => ({ reqId: requestId, sendingStatus: SendingStatus.FAILED }),
+    } as unknown as SendableMessageType;
+    let dsMessages: SendableMessageType[] = [];
+    let rerenderProvider = () => {};
+    const sendFileMessage = vi.fn().mockImplementation((_params, onPending) => {
+      onPending(pendingMessage);
+      dsMessages = [failedMessage];
+      rerenderProvider();
+      return Promise.reject(new Error('upload failed'));
+    });
+    (useGroupChannelThreadMessages as Mock).mockImplementation(() => ({
+      ...makeDefaultDs(),
+      initialized: true,
+      messages: dsMessages,
+      sendFileMessage,
+    }));
+
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result, rerender } = renderHook(() => useThread(), { wrapper });
+    rerenderProvider = rerender;
+    const options = (useGroupChannelThreadMessages as Mock).mock.calls.at(-1)?.[3];
+    await act(async () => {
+      options.onParentMessageUpdated({ messageId: parentMessageId } as SendableMessageType);
+    });
+    await act(async () => {
+      await expect(result.current.actions.sendFileMessage(new File(['x'], 'transient.png'))).rejects.toThrow('upload failed');
+    });
+    await waitFor(() => expect(result.current.state.localThreadMessages).toHaveLength(1));
+    const previewUrl = result.current.state.localFilePreviews.get(requestId)?.localUrl;
+    expect(previewUrl).toBeDefined();
+
+    dsMessages = [];
+    rerender();
+    await waitFor(() => expect(result.current.state.threadMessages).toEqual([]));
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    expect(result.current.state.localFilePreviews.has(requestId)).toBe(true);
+
+    dsMessages = [failedMessage];
+    rerender();
+    await waitFor(() => {
+      expect(result.current.state.localThreadMessages).toEqual([failedMessage]);
+    });
+    const mirroredFailedMessage = result.current.state.localThreadMessages[0] as SendableMessageType & {
+      localUrl?: string;
+      file?: File;
+    };
+    expect(mirroredFailedMessage.localUrl).toBe(previewUrl);
+    expect(mirroredFailedMessage.file).toBeInstanceOf(File);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('revokes live file previews when the thread provider unmounts', async () => {
+    const parentMessageId = 576;
+    const requestId = 'unmount-file-request';
+    const pendingMessage = { messageId: 0, reqId: requestId, parentMessageId } as unknown as SendableMessageType;
+    const failedMessage = {
+      messageId: 0,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.FAILED,
+      serialize: () => ({ reqId: requestId, sendingStatus: SendingStatus.FAILED }),
+    } as unknown as SendableMessageType;
+    let dsMessages: SendableMessageType[] = [];
+    let rerenderProvider = () => {};
+    const sendFileMessage = vi.fn().mockImplementation((_params, onPending) => {
+      onPending(pendingMessage);
+      dsMessages = [failedMessage];
+      rerenderProvider();
+      return Promise.reject(new Error('upload failed'));
+    });
+    (useGroupChannelThreadMessages as Mock).mockImplementation(() => ({
+      ...makeDefaultDs(),
+      initialized: true,
+      messages: dsMessages,
+      sendFileMessage,
+    }));
+
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result, rerender, unmount } = renderHook(() => useThread(), { wrapper });
+    rerenderProvider = rerender;
+    const options = (useGroupChannelThreadMessages as Mock).mock.calls.at(-1)?.[3];
+    await act(async () => {
+      options.onParentMessageUpdated({ messageId: parentMessageId } as SendableMessageType);
+    });
+    await act(async () => {
+      await expect(result.current.actions.sendFileMessage(new File(['x'], 'unmount.png'))).rejects.toThrow('upload failed');
+    });
+    await waitFor(() => expect(result.current.state.localFilePreviews.has(requestId)).toBe(true));
+    const previewUrl = result.current.state.localFilePreviews.get(requestId)?.localUrl;
+    expect(previewUrl).toBeDefined();
+
+    unmount();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(previewUrl);
+  });
+
+  it('releases a failed file preview when a resend succeeds with the same request ID', async () => {
+    const parentMessageId = 577;
+    const requestId = 'resend-success-file-request';
+    const pendingMessage = { messageId: 0, reqId: requestId, parentMessageId } as unknown as SendableMessageType;
+    const failedMessage = {
+      messageId: 0,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.FAILED,
+      serialize: () => ({ reqId: requestId, sendingStatus: SendingStatus.FAILED }),
+    } as unknown as SendableMessageType;
+    const succeededMessage = {
+      messageId: 5770,
+      reqId: requestId,
+      parentMessageId,
+      sendingStatus: SendingStatus.SUCCEEDED,
+      serialize: () => ({ reqId: requestId, sendingStatus: SendingStatus.SUCCEEDED }),
+    } as unknown as SendableMessageType & { localUrl?: string; file?: File };
+    let dsMessages: SendableMessageType[] = [];
+    let rerenderProvider = () => {};
+    const sendFileMessage = vi.fn().mockImplementation((_params, onPending) => {
+      onPending(pendingMessage);
+      dsMessages = [failedMessage];
+      rerenderProvider();
+      return Promise.reject(new Error('upload failed'));
+    });
+    (useGroupChannelThreadMessages as Mock).mockImplementation(() => ({
+      ...makeDefaultDs(),
+      initialized: true,
+      messages: dsMessages,
+      sendFileMessage,
+    }));
+
+    const wrapper = ({ children }) => (
+      <ThreadProvider channelUrl="test-channel" message={initialMockMessage}>{children}</ThreadProvider>
+    );
+    const { result, rerender } = renderHook(() => useThread(), { wrapper });
+    rerenderProvider = rerender;
+    const options = (useGroupChannelThreadMessages as Mock).mock.calls.at(-1)?.[3];
+    await act(async () => {
+      options.onParentMessageUpdated({ messageId: parentMessageId } as SendableMessageType);
+    });
+    await act(async () => {
+      await expect(result.current.actions.sendFileMessage(new File(['x'], 'resend.png'))).rejects.toThrow('upload failed');
+    });
+    await waitFor(() => expect(result.current.state.localFilePreviews.has(requestId)).toBe(true));
+    const previewUrl = result.current.state.localFilePreviews.get(requestId)?.localUrl;
+    expect(previewUrl).toBeDefined();
+
+    dsMessages = [succeededMessage];
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.state.allThreadMessages).toEqual([succeededMessage]);
+    });
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(previewUrl);
+    expect(result.current.state.localFilePreviews.has(requestId)).toBe(false);
+    expect(succeededMessage.localUrl).toBeUndefined();
+    expect(succeededMessage.file).toBeUndefined();
   });
 
   it('reclassifies a reply from local to server when it transitions pending -> succeeded, without leaving a duplicate', async () => {

--- a/src/modules/Thread/context/__test__/useThreadMessageActions.spec.ts
+++ b/src/modules/Thread/context/__test__/useThreadMessageActions.spec.ts
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 import { User } from '@sendbird/chat';
+import { SendingStatus } from '@sendbird/chat/message';
 import type { FileMessage } from '@sendbird/chat/message';
 
 import { useThreadMessageActions } from '../hooks/useThreadMessageActions';
@@ -25,6 +26,7 @@ const makeState = (overrides: Partial<ThreadState> = {}): ThreadState => ({
   dsUpdateUserMessage: vi.fn().mockResolvedValue({ messageId: 4 }),
   dsResendMessage: vi.fn().mockImplementation(async (message) => message),
   dsDeleteMessage: vi.fn().mockResolvedValue(undefined),
+  localFilePreviews: new Map(),
   ...overrides,
 } as unknown as ThreadState);
 
@@ -35,9 +37,11 @@ const makeStatics = () => ({
 });
 
 describe('useThreadMessageActions', () => {
-  beforeAll(() => {
+  let localPreviewCounter = 0;
+
+  beforeEach(() => {
     Object.defineProperty(URL, 'createObjectURL', {
-      value: vi.fn(() => 'blob:thread-local-preview'),
+      value: vi.fn(() => `blob:thread-local-preview-${++localPreviewCounter}`),
       configurable: true,
     });
     Object.defineProperty(URL, 'revokeObjectURL', {
@@ -95,7 +99,7 @@ describe('useThreadMessageActions', () => {
   });
 
   it('sendFileMessage attaches a local preview (localUrl + file) to the pending message', async () => {
-    const pendingMessage = { messageId: 0 } as unknown as FileMessage;
+    const pendingMessage = { messageId: 0, reqId: 'file-message-request' } as unknown as FileMessage;
     const state = makeState({
       dsSendFileMessage: vi.fn().mockImplementation((_params, onPending) => {
         onPending?.(pendingMessage);
@@ -111,8 +115,37 @@ describe('useThreadMessageActions', () => {
     });
 
     const local = pendingMessage as FileMessage & { localUrl?: string; file?: File };
-    expect(local.localUrl).toBe('blob:thread-local-preview');
+    expect(local.localUrl).toMatch(/^blob:thread-local-preview-\d+$/);
     expect(local.file).toBe(file);
+    expect(state.localFilePreviews.has('file-message-request')).toBe(false);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(local.localUrl);
+  });
+
+  it('sendFileMessage rejects when the current channel is missing without invoking the hook or sending', async () => {
+    const onBeforeSendFileMessage = vi.fn();
+    const state = makeState({ currentChannel: undefined, onBeforeSendFileMessage });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+
+    await expect(result.current.sendFileMessage(file)).rejects.toThrow('current channel or data source is unavailable');
+
+    expect(onBeforeSendFileMessage).not.toHaveBeenCalled();
+    expect(state.dsSendFileMessage).not.toHaveBeenCalled();
+    expect(statics.logger.warning).toHaveBeenCalled();
+  });
+
+  it('sendFileMessage rejects when the data source is unavailable without invoking the hook or sending', async () => {
+    const onBeforeSendFileMessage = vi.fn();
+    const state = makeState({ dsSendFileMessage: undefined, onBeforeSendFileMessage });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+
+    await expect(result.current.sendFileMessage(file)).rejects.toThrow('current channel or data source is unavailable');
+
+    expect(onBeforeSendFileMessage).not.toHaveBeenCalled();
+    expect(statics.logger.warning).toHaveBeenCalled();
   });
 
   it('sendVoiceMessage builds voice metaArrays and publishes SEND_FILE_MESSAGE', async () => {
@@ -142,16 +175,56 @@ describe('useThreadMessageActions', () => {
       new File(['b'], 'b.png', { type: 'image/png' }),
     ];
 
+    let sentMessage;
     await act(async () => {
-      await result.current.sendMultipleFilesMessage(files);
+      sentMessage = await result.current.sendMultipleFilesMessage(files);
     });
 
     const [params] = (state.dsSendMultipleFilesMessage as Mock).mock.calls[0];
     expect(params.fileInfoList).toHaveLength(2);
     expect(params.fileInfoList[0]).toMatchObject({ fileName: 'a.png', mimeType: 'image/png' });
+    expect(sentMessage).toEqual({ messageId: 3 });
     await waitFor(() => {
       expect(statics.pubSub.publish).toHaveBeenCalledWith(topics.SEND_FILE_MESSAGE, expect.anything());
     });
+  });
+
+  it('sendMultipleFilesMessage rejects an empty file list without sending', async () => {
+    const state = makeState();
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+
+    await expect(result.current.sendMultipleFilesMessage([])).rejects.toThrow('at least two files');
+
+    expect(state.dsSendMultipleFilesMessage).not.toHaveBeenCalled();
+    expect(statics.logger.warning).toHaveBeenCalled();
+  });
+
+  it('sendMultipleFilesMessage rejects a single file without sending', async () => {
+    const state = makeState();
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const file = new File(['a'], 'a.png', { type: 'image/png' });
+
+    await expect(result.current.sendMultipleFilesMessage([file])).rejects.toThrow('at least two files');
+
+    expect(state.dsSendMultipleFilesMessage).not.toHaveBeenCalled();
+    expect(statics.logger.warning).toHaveBeenCalled();
+  });
+
+  it('sendMultipleFilesMessage rejects when the current channel is missing without sending', async () => {
+    const state = makeState({ currentChannel: undefined });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const files = [
+      new File(['a'], 'a.png', { type: 'image/png' }),
+      new File(['b'], 'b.png', { type: 'image/png' }),
+    ];
+
+    await expect(result.current.sendMultipleFilesMessage(files)).rejects.toThrow('current channel or data source is unavailable');
+
+    expect(state.dsSendMultipleFilesMessage).not.toHaveBeenCalled();
+    expect(statics.logger.warning).toHaveBeenCalled();
   });
 
   it('updateMessage builds update params and publishes UPDATE_USER_MESSAGE', async () => {
@@ -187,6 +260,61 @@ describe('useThreadMessageActions', () => {
     });
 
     expect(state.dsDeleteMessage).toHaveBeenCalledWith(message);
+  });
+
+  it('releases a local file preview after deleting its failed message', async () => {
+    const reqId = 'failed-file-request';
+    const localUrl = 'blob:thread-local-preview-deleted';
+    const state = makeState({
+      localFilePreviews: new Map([[reqId, { localUrl, file: new File(['file'], 'failed.txt') }]]),
+    });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const message = { messageId: 8, reqId } as unknown as SendableMessageType;
+
+    await act(async () => {
+      await result.current.deleteMessage(message);
+    });
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(localUrl);
+    expect(state.localFilePreviews.has(reqId)).toBe(false);
+  });
+
+  it('releases a local file preview when deleting its failed message fails', async () => {
+    const reqId = 'failed-file-request';
+    const localUrl = 'blob:thread-local-preview-delete-failed';
+    const error = new Error('delete failed');
+    const state = makeState({
+      dsDeleteMessage: vi.fn().mockRejectedValue(error),
+      localFilePreviews: new Map([[reqId, { localUrl, file: new File(['file'], 'failed.txt') }]]),
+    });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const message = { messageId: 8, reqId, sendingStatus: SendingStatus.FAILED } as unknown as SendableMessageType;
+
+    await expect(result.current.deleteMessage(message)).rejects.toBe(error);
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(localUrl);
+    expect(state.localFilePreviews.has(reqId)).toBe(false);
+  });
+
+  it('keeps a local file preview when deleting its failed message fails without a current channel', async () => {
+    const reqId = 'failed-file-request';
+    const localUrl = 'blob:thread-local-preview-delete-failed';
+    const error = new Error('delete failed');
+    const state = makeState({
+      currentChannel: undefined,
+      dsDeleteMessage: vi.fn().mockRejectedValue(error),
+      localFilePreviews: new Map([[reqId, { localUrl, file: new File(['file'], 'failed.txt') }]]),
+    });
+    const statics = makeStatics();
+    const { result } = renderHook(() => useThreadMessageActions(state, statics));
+    const message = { messageId: 8, reqId, sendingStatus: SendingStatus.FAILED } as unknown as SendableMessageType;
+
+    await expect(result.current.deleteMessage(message)).rejects.toBe(error);
+
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    expect(state.localFilePreviews.has(reqId)).toBe(true);
   });
 
   it('resendMessage delegates to the data source and publishes by message type', async () => {

--- a/src/modules/Thread/context/hooks/useThreadMessageActions.ts
+++ b/src/modules/Thread/context/hooks/useThreadMessageActions.ts
@@ -3,6 +3,7 @@ import { User } from '@sendbird/chat';
 import {
   FileMessage,
   FileMessageCreateParams,
+  SendingStatus,
   MessageMetaArray,
   MultipleFilesMessage,
   MultipleFilesMessageCreateParams,
@@ -25,7 +26,7 @@ import {
   VOICE_MESSAGE_FILE_NAME,
   VOICE_MESSAGE_MIME_TYPE,
 } from '../../../../utils/consts';
-import type { ThreadState } from '../ThreadProvider';
+import type { LocalFilePreview, ThreadState } from '../ThreadProvider';
 
 export type SendMessageParams = {
   message: string;
@@ -62,11 +63,16 @@ const scrollToLastAfterSend = () => {
   setTimeout(() => scrollIntoLast(), SCROLL_BOTTOM_DELAY_FOR_SEND);
 };
 
-const attachLocalFilePreview = (pendingMessage: FileMessage, file: File): string => {
+const attachLocalFilePreview = (
+  pendingMessage: FileMessage,
+  file: File,
+  localFilePreviews: Map<string, LocalFilePreview>,
+): string => {
   const localUrl = URL.createObjectURL(file);
   const localFileMessage = pendingMessage as FileMessage & { localUrl?: string; file?: File };
   localFileMessage.localUrl = localUrl;
   localFileMessage.file = file;
+  if (pendingMessage.reqId) localFilePreviews.set(pendingMessage.reqId, { localUrl, file });
   return localUrl;
 };
 
@@ -83,6 +89,7 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
     dsUpdateUserMessage,
     dsResendMessage,
     dsDeleteMessage,
+    localFilePreviews,
   } = state;
 
   const sendMessage = useCallback((props: SendMessageParams) => {
@@ -120,6 +127,15 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
   }, [dsSendUserMessage, onBeforeSendUserMessage, currentChannel, isMentionEnabled]);
 
   const sendFileMessage = useCallback((file: File, quoteMessage?: SendableMessageType): Promise<FileMessage> => {
+    if (!dsSendFileMessage || !currentChannel) {
+      const error = new Error('Thread | useThreadMessageActions: Sending file message cannot be sent because current channel or data source is unavailable.');
+      logger.warning('Thread | useThreadMessageActions: Sending file message failed, because current channel or data source is unavailable.', {
+        currentChannel,
+        dsSendFileMessage,
+        error,
+      });
+      return Promise.reject(error);
+    }
     const createParamsDefault = () => {
       const params = {} as FileMessageCreateParams;
       params.file = file;
@@ -130,15 +146,22 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
       return params;
     };
     const params = onBeforeSendFileMessage?.(file, quoteMessage) ?? createParamsDefault();
-    if (!dsSendFileMessage || !currentChannel) return Promise.resolve(null as unknown as FileMessage);
     logger.info('Thread | useThreadMessageActions: Sending file message start.', params);
     let localPreviewUrl: string | undefined;
+    let pendingReqId: string | undefined;
     return dsSendFileMessage(params, (pendingMessage) => {
-      localPreviewUrl = attachLocalFilePreview(pendingMessage, file);
+      pendingReqId = pendingMessage.reqId;
+      localPreviewUrl = attachLocalFilePreview(pendingMessage, file, localFilePreviews);
       scrollToLastAfterSend();
     })
       .then((sentMessage) => {
-        if (localPreviewUrl) URL.revokeObjectURL(localPreviewUrl);
+        const preview = pendingReqId && localFilePreviews.get(pendingReqId);
+        if (preview) {
+          URL.revokeObjectURL(preview.localUrl);
+          localFilePreviews.delete(pendingReqId);
+        } else if (localPreviewUrl) {
+          URL.revokeObjectURL(localPreviewUrl);
+        }
         pubSub.publish(topics.SEND_FILE_MESSAGE, {
           channel: currentChannel,
           message: sentMessage,
@@ -146,7 +169,7 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
         });
         return sentMessage;
       });
-  }, [dsSendFileMessage, onBeforeSendFileMessage, currentChannel]);
+  }, [dsSendFileMessage, onBeforeSendFileMessage, currentChannel, localFilePreviews]);
 
   const sendVoiceMessage = useCallback((file: File, duration: number, quoteMessage?: SendableMessageType) => {
     const params: FileMessageCreateParams = (onBeforeSendVoiceMessage && typeof onBeforeSendVoiceMessage === 'function')
@@ -167,12 +190,20 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
     if (!dsSendFileMessage || !currentChannel) return;
     logger.info('Thread | useThreadMessageActions: Sending voice message start.', params);
     let localPreviewUrl: string | undefined;
+    let pendingReqId: string | undefined;
     dsSendFileMessage(params, (pendingMessage) => {
-      localPreviewUrl = attachLocalFilePreview(pendingMessage, file);
+      pendingReqId = pendingMessage.reqId;
+      localPreviewUrl = attachLocalFilePreview(pendingMessage, file, localFilePreviews);
       scrollToLastAfterSend();
     })
       .then((sentMessage) => {
-        if (localPreviewUrl) URL.revokeObjectURL(localPreviewUrl);
+        const preview = pendingReqId && localFilePreviews.get(pendingReqId);
+        if (preview) {
+          URL.revokeObjectURL(preview.localUrl);
+          localFilePreviews.delete(pendingReqId);
+        } else if (localPreviewUrl) {
+          URL.revokeObjectURL(localPreviewUrl);
+        }
         pubSub.publish(topics.SEND_FILE_MESSAGE, {
           channel: currentChannel,
           message: sentMessage,
@@ -182,9 +213,23 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
       .catch((error) => {
         logger.info('Thread | useThreadMessageActions: Sending voice message failed.', error);
       });
-  }, [dsSendFileMessage, onBeforeSendVoiceMessage, currentChannel]);
+  }, [dsSendFileMessage, onBeforeSendVoiceMessage, currentChannel, localFilePreviews]);
 
   const sendMultipleFilesMessage = useCallback((files: Array<File>, quoteMessage?: SendableMessageType): Promise<MultipleFilesMessage> => {
+    if (files.length <= 1) {
+      const error = new Error('Thread | useThreadMessageActions: Sending multiple files message requires at least two files.');
+      logger.warning('Thread | useThreadMessageActions: Sending multiple files message failed, because there are no multiple files.', { files, error });
+      return Promise.reject(error);
+    }
+    if (!dsSendMultipleFilesMessage || !currentChannel) {
+      const error = new Error('Thread | useThreadMessageActions: Sending multiple files message cannot be sent because current channel or data source is unavailable.');
+      logger.warning('Thread | useThreadMessageActions: Sending multiple files message failed, because current channel or data source is unavailable.', {
+        currentChannel,
+        dsSendMultipleFilesMessage,
+        error,
+      });
+      return Promise.reject(error);
+    }
     const createParamsDefault = (): MultipleFilesMessageCreateParams => {
       const params: MultipleFilesMessageCreateParams = {
         fileInfoList: files.map((file: File): UploadableFileInfo => ({
@@ -201,7 +246,6 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
       return params;
     };
     const params = onBeforeSendMultipleFilesMessage?.(files, quoteMessage) ?? createParamsDefault();
-    if (!dsSendMultipleFilesMessage || !currentChannel) return Promise.resolve(null as unknown as MultipleFilesMessage);
     logger.info('Thread | useThreadMessageActions: Sending multiple files message start.', params);
     return dsSendMultipleFilesMessage(params, () => scrollToLastAfterSend())
       .then((sentMessage) => {
@@ -247,8 +291,25 @@ export function useThreadMessageActions(state: ThreadState, { logger, pubSub, is
   const deleteMessage = useCallback((message: SendableMessageType): Promise<void> => {
     if (!dsDeleteMessage) return Promise.resolve();
     logger.info('Thread | useThreadMessageActions: Deleting message.', message);
-    return dsDeleteMessage(message as UserMessage | FileMessage | MultipleFilesMessage);
-  }, [dsDeleteMessage]);
+    return dsDeleteMessage(message as UserMessage | FileMessage | MultipleFilesMessage)
+      .then(() => {
+        const preview = message.reqId && localFilePreviews.get(message.reqId);
+        if (preview) {
+          URL.revokeObjectURL(preview.localUrl);
+          localFilePreviews.delete(message.reqId);
+        }
+      })
+      .catch((error) => {
+        if (message.sendingStatus !== SendingStatus.SUCCEEDED && currentChannel) {
+          const preview = message.reqId && localFilePreviews.get(message.reqId);
+          if (preview) {
+            URL.revokeObjectURL(preview.localUrl);
+            localFilePreviews.delete(message.reqId);
+          }
+        }
+        throw error;
+      });
+  }, [dsDeleteMessage, localFilePreviews, currentChannel]);
 
   const resendMessage = useCallback((failedMessage: SendableMessageType) => {
     if (!(failedMessage as SendableMessageType)?.isResendable || !dsResendMessage || !currentChannel) {

--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -48,7 +48,12 @@ const useThread = () => {
       logger.warning('Thread resetWithStartingPoint failed', error);
       return;
     }
+    // onFetched fires only when the fetch succeeded (an empty page arrives as []), so `undefined`
+    // means the load failed or was guarded upstream — settle without the callback (pre-v3.18.3 behavior).
     if (page === undefined) return;
+    // Deliberate one-tick deferral, do not remove: onFetched fires before the collection state is
+    // mirrored into this store and before React commits the new replies, and ThreadUI's scroll
+    // restoration in this callback expects to run after that render.
     await new Promise<void>((resolve) => {
       setTimeout(resolve);
     });
@@ -64,7 +69,12 @@ const useThread = () => {
     await loadPrevious((messages) => {
       page = messages as CoreMessageType[];
     });
+    // onFetched fires only when the fetch succeeded (an empty page arrives as []), so `undefined`
+    // means the load failed or was guarded upstream — settle without the callback (pre-v3.18.3 behavior).
     if (page === undefined) return;
+    // Deliberate one-tick deferral, do not remove: onFetched fires before the collection state is
+    // mirrored into this store and before React commits the new replies, and ThreadUI's scroll
+    // restoration in this callback expects to run after that render.
     await new Promise<void>((resolve) => {
       setTimeout(resolve);
     });
@@ -80,7 +90,12 @@ const useThread = () => {
     await loadNext((messages) => {
       page = messages as CoreMessageType[];
     });
+    // onFetched fires only when the fetch succeeded (an empty page arrives as []), so `undefined`
+    // means the load failed or was guarded upstream — settle without the callback (pre-v3.18.3 behavior).
     if (page === undefined) return;
+    // Deliberate one-tick deferral, do not remove: onFetched fires before the collection state is
+    // mirrored into this store and before React commits the new replies, and ThreadUI's scroll
+    // restoration in this callback expects to run after that render.
     await new Promise<void>((resolve) => {
       setTimeout(resolve);
     });

--- a/src/modules/Thread/context/useThread.ts
+++ b/src/modules/Thread/context/useThread.ts
@@ -24,8 +24,14 @@ const useThread = () => {
 
   const toggleReaction = useToggleReactionCallback({ currentChannel }, { logger });
 
-  const initializeThreadFetcher = useCallback((callback?: (messages: CoreMessageType[]) => void) => {
-    const { resetWithStartingPoint, message: anchorMessage, parentMessage } = store.getState();
+  const initializeThreadFetcher = useCallback(async (
+    callback?: (messages: CoreMessageType[]) => void,
+  ): Promise<void> => {
+    const {
+      resetWithStartingPoint,
+      message: anchorMessage,
+      parentMessage,
+    } = store.getState();
     if (!resetWithStartingPoint) return;
     // Mirror ThreadProvider's initial startingPoint: anchor at the specific reply when entering from
     // one, otherwise open at the latest edge (MAX). parentMessage.createdAt would anchor at the oldest
@@ -33,25 +39,52 @@ const useThread = () => {
     const startingPoint = (anchorMessage && parentMessage && anchorMessage.messageId !== parentMessage.messageId)
       ? anchorMessage.createdAt
       : Number.MAX_SAFE_INTEGER;
-    resetWithStartingPoint(startingPoint).then(() => {
-      setTimeout(() => callback?.(store.getState().allThreadMessages));
+    let page: CoreMessageType[] | undefined;
+    try {
+      await resetWithStartingPoint(startingPoint, (messages) => {
+        page = messages as CoreMessageType[];
+      });
+    } catch (error) {
+      logger.warning('Thread resetWithStartingPoint failed', error);
+      return;
+    }
+    if (page === undefined) return;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve);
     });
-  }, [store]);
+    callback?.(page);
+  }, [store, logger]);
 
-  const fetchPrevThreads = useCallback((callback?: (messages: CoreMessageType[]) => void) => {
+  const fetchPrevThreads = useCallback(async (
+    callback?: (messages: CoreMessageType[]) => void,
+  ): Promise<void> => {
     const { loadPrevious } = store.getState();
     if (!loadPrevious) return;
-    loadPrevious().then(() => {
-      setTimeout(() => callback?.(store.getState().allThreadMessages));
+    let page: CoreMessageType[] | undefined;
+    await loadPrevious((messages) => {
+      page = messages as CoreMessageType[];
     });
+    if (page === undefined) return;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve);
+    });
+    callback?.(page);
   }, [store]);
 
-  const fetchNextThreads = useCallback((callback?: (messages: CoreMessageType[]) => void) => {
+  const fetchNextThreads = useCallback(async (
+    callback?: (messages: CoreMessageType[]) => void,
+  ): Promise<void> => {
     const { loadNext } = store.getState();
     if (!loadNext) return;
-    loadNext().then(() => {
-      setTimeout(() => callback?.(store.getState().allThreadMessages));
+    let page: CoreMessageType[] | undefined;
+    await loadNext((messages) => {
+      page = messages as CoreMessageType[];
     });
+    if (page === undefined) return;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve);
+    });
+    callback?.(page);
   }, [store]);
 
   const messageActions = useThreadMessageActions(state, { logger, pubSub, isMentionEnabled });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,7 +2945,7 @@ __metadata:
     "@rollup/plugin-typescript": ^11.1.5
     "@sendbird/chat": ^4.22.10
     "@sendbird/react-uikit-message-template-view": ^0.1.5
-    "@sendbird/uikit-tools": ^0.1.5
+    "@sendbird/uikit-tools": ^0.2.0
     "@storybook/addon-essentials": ^8.6.17
     "@storybook/manager-api": ^8.6.17
     "@storybook/react-vite": ^8.6.17
@@ -3010,13 +3010,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sendbird/uikit-tools@npm:^0.1.5":
-  version: 0.1.5
-  resolution: "@sendbird/uikit-tools@npm:0.1.5"
+"@sendbird/uikit-tools@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@sendbird/uikit-tools@npm:0.2.0"
   peerDependencies:
     "@sendbird/chat": ">=4.10.5 <5"
     react: ">=16.8.6"
-  checksum: 81ed6e5687707581f4b60cc3acb5341dae23dff086232fff76d91db2bda8a91bc6917c22beded7540f5991836caa0480524151989cf6ed1cb5cac2955d421313
+  checksum: 8306588ce384b670e5f9c668b79605c610ae0cfdbbfe08cf243312695b7c34d1c0efbe9e3ac2cc5516d64313cb49ec394fa9802551c4d9beaba8bf87e8c1c09b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The Collection migration (#1445, shipped in v3.18.3) silently changed the contract of public Thread context actions exposed via `useThread()` / `useThreadContext()`. This PR restores the pre-v3.18.3 contract, fixes two more byproducts of the same migration, and fixes one adjacent long-standing silent failure of the same class.

* `initializeThreadFetcher` / `fetchPrevThreads` / `fetchNextThreads` return a `Promise<void>` again (every path, guards included), so `await` / `.then()` no longer throws. A failed load resolves the promise without invoking the callback, matching the pre-migration behavior.
* Their callback receives exactly the newly fetched page again — delivered by the data source's new `onFetched` callback (uikit-tools 0.2.0), so the payload is bound to its own request: overlapping loads, thread switches, and realtime arrivals cannot contaminate it. A legitimately empty page invokes the callback with `[]`.
* The ThreadUI scroll handler defensively swallows fetch rejections.
* `sendMultipleFilesMessage` validates its inputs again (raised in a ticket comment as a third contract change from the same migration): it rejects — before `onBeforeSendMultipleFilesMessage` runs — on fewer than two files or a missing channel/data source, instead of resolving `null` cast to `MultipleFilesMessage`. Unlike the pre-migration code, a failed validation no longer still attempts the send.
* Failed file/voice messages keep their local blob preview again (another migration byproduct): previews are tracked in a per-provider `reqId` registry, re-attached by the mirror effect to the SDK's distinct failed-message instance, and released on trusted transitions only — send success, deletion (including a rejected deletion after the local message was removed), thread parent clear, and unmount. Previously the blob URL leaked on every failed send and on closing the thread.
* **Deliberate behavior change** (not a #1445 regression — this guard resolved `null` since before the migration): `sendFileMessage` now rejects with a descriptive error when the channel/data source is unavailable, instead of resolving `null` cast to `FileMessage`. Callers that null-checked the resolved value must catch the rejection instead. The only internal caller (ThreadMessageInput) already isolates each send task in try/catch.

An audit of the remaining public Thread actions (sendMessage, sendVoiceMessage, resendMessage, updateMessage, deleteMessage, toggleReaction) against the pre-migration base found no further caller-visible regressions. The upstream data-source fixes (settling on failure, fetched-page delivery) shipped in uikit-tools 0.2.0 (sendbird-uikit-core-ts#235) and are adopted by the dependency bump in this PR.

Note for reviewers: anyone who adapted custom code to the broken v3.18.3–v3.18.4 behavior (e.g. replacing instead of appending in the callback) will see the old semantics again — this PR is a restoration, which is why the changelog pins the affected versions.

Fixes [CLNP-8903](https://sendbird.atlassian.net/browse/CLNP-8903)

### Changelogs

* Fixed an issue introduced in v3.18.3 where `initializeThreadFetcher`, `fetchPrevThreads`, and `fetchNextThreads` from `useThreadContext()` returned `undefined` — so `await` / `.then()` on them threw — and passed the entire accumulated reply list to their callback instead of the newly fetched page.
* Fixed: failed file and voice messages in a thread keep their local file preview.
* Changed: `sendMultipleFilesMessage` from `useThreadContext()` rejects on fewer than two files or a missing channel, instead of resolving `null`.
* Changed: `sendFileMessage` from `useThreadContext()` rejects when no channel is available, instead of resolving `null`.

### Checklist

- [x] **All tests pass locally with my changes**
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **Public components / utils / props are appropriately exported**
- [ ] I have added necessary documentation (if appropriate)

[CLNP-8903]: https://sendbird.atlassian.net/browse/CLNP-8903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



