### PR TITLE
[CLNP-8841][feat]: customize the @mention profile popup and direct-message channel creation

### DIFF
--- a/src/lib/Sendbird/__tests__/SendbirdProvider.migration.spec.tsx
+++ b/src/lib/Sendbird/__tests__/SendbirdProvider.migration.spec.tsx
@@ -84,6 +84,7 @@ const mockProps: SendbirdProviderProps = {
   renderUserProfile: vi.fn(),
   onStartDirectMessage: vi.fn(),
   onUserProfileMessage: vi.fn(),
+  onBeforeCreateChannel: vi.fn(),
   eventHandlers: {},
   children: <div>Test Child</div>,
 };
@@ -233,6 +234,7 @@ describe('SendbirdProvider Props & Context Interface Validation', () => {
     expect(config.htmlTextDirection).toBe(mockProps.htmlTextDirection);
     expect(config.forceLeftToRightMessageLayout).toBe(mockProps.forceLeftToRightMessageLayout);
     expect(config.isMultipleFilesMessageEnabled).toBe(mockProps.isMultipleFilesMessageEnabled);
+    expect(config.onBeforeCreateChannel).toBe(mockProps.onBeforeCreateChannel);
 
     // Default values validation
     expect(config.uikitUploadSizeLimit).toBe(DEFAULT_UPLOAD_SIZE_LIMIT);

--- a/src/lib/Sendbird/__tests__/SendbirdProvider.migration.spec.tsx
+++ b/src/lib/Sendbird/__tests__/SendbirdProvider.migration.spec.tsx
@@ -84,7 +84,7 @@ const mockProps: SendbirdProviderProps = {
   renderUserProfile: vi.fn(),
   onStartDirectMessage: vi.fn(),
   onUserProfileMessage: vi.fn(),
-  onBeforeCreateChannel: vi.fn(),
+  onBeforeStartDirectMessage: vi.fn(),
   eventHandlers: {},
   children: <div>Test Child</div>,
 };
@@ -234,7 +234,7 @@ describe('SendbirdProvider Props & Context Interface Validation', () => {
     expect(config.htmlTextDirection).toBe(mockProps.htmlTextDirection);
     expect(config.forceLeftToRightMessageLayout).toBe(mockProps.forceLeftToRightMessageLayout);
     expect(config.isMultipleFilesMessageEnabled).toBe(mockProps.isMultipleFilesMessageEnabled);
-    expect(config.onBeforeCreateChannel).toBe(mockProps.onBeforeCreateChannel);
+    expect(config.onBeforeStartDirectMessage).toBe(mockProps.onBeforeStartDirectMessage);
 
     // Default values validation
     expect(config.uikitUploadSizeLimit).toBe(DEFAULT_UPLOAD_SIZE_LIMIT);

--- a/src/lib/Sendbird/context/SendbirdProvider.tsx
+++ b/src/lib/Sendbird/context/SendbirdProvider.tsx
@@ -67,8 +67,8 @@ const SendbirdContextManager = ({
   disableMarkAsDelivered = false,
   renderUserProfile,
   onUserProfileMessage: _onUserProfileMessage,
+  onBeforeStartDirectMessage,
   onStartDirectMessage: _onStartDirectMessage,
-  onBeforeCreateChannel,
   isUserIdUsedForNickname = true,
   sdkInitParams,
   customExtensionParams,
@@ -280,9 +280,9 @@ const SendbirdContextManager = ({
     config: {
       disableMarkAsDelivered,
       renderUserProfile,
+      onBeforeStartDirectMessage,
       onStartDirectMessage,
       onUserProfileMessage: onStartDirectMessage, // legacy of onStartDirectMessage
-      onBeforeCreateChannel,
       allowProfileEdit,
       isOnline,
       userId,
@@ -312,8 +312,8 @@ const SendbirdContextManager = ({
   }), [
     disableMarkAsDelivered,
     renderUserProfile,
+    onBeforeStartDirectMessage,
     onStartDirectMessage,
-    onBeforeCreateChannel,
     allowProfileEdit,
     isOnline,
     userId,
@@ -376,8 +376,8 @@ const InternalSendbirdProvider = (props: SendbirdProviderProps & { logger: Logge
   const defaultProps: TwoDepthPartial<SendbirdState> = deleteNullish({
     config: {
       renderUserProfile: props?.renderUserProfile,
+      onBeforeStartDirectMessage: props?.onBeforeStartDirectMessage,
       onStartDirectMessage: props?.onStartDirectMessage,
-      onBeforeCreateChannel: props?.onBeforeCreateChannel,
       allowProfileEdit: props?.allowProfileEdit,
       appId: props?.appId,
       userId: props?.userId,

--- a/src/lib/Sendbird/context/SendbirdProvider.tsx
+++ b/src/lib/Sendbird/context/SendbirdProvider.tsx
@@ -68,6 +68,7 @@ const SendbirdContextManager = ({
   renderUserProfile,
   onUserProfileMessage: _onUserProfileMessage,
   onStartDirectMessage: _onStartDirectMessage,
+  onBeforeCreateChannel,
   isUserIdUsedForNickname = true,
   sdkInitParams,
   customExtensionParams,
@@ -281,6 +282,7 @@ const SendbirdContextManager = ({
       renderUserProfile,
       onStartDirectMessage,
       onUserProfileMessage: onStartDirectMessage, // legacy of onStartDirectMessage
+      onBeforeCreateChannel,
       allowProfileEdit,
       isOnline,
       userId,
@@ -311,6 +313,7 @@ const SendbirdContextManager = ({
     disableMarkAsDelivered,
     renderUserProfile,
     onStartDirectMessage,
+    onBeforeCreateChannel,
     allowProfileEdit,
     isOnline,
     userId,
@@ -374,6 +377,7 @@ const InternalSendbirdProvider = (props: SendbirdProviderProps & { logger: Logge
     config: {
       renderUserProfile: props?.renderUserProfile,
       onStartDirectMessage: props?.onStartDirectMessage,
+      onBeforeCreateChannel: props?.onBeforeCreateChannel,
       allowProfileEdit: props?.allowProfileEdit,
       appId: props?.appId,
       userId: props?.userId,

--- a/src/lib/Sendbird/types.ts
+++ b/src/lib/Sendbird/types.ts
@@ -229,12 +229,12 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
   autoscrollMessageOverflowToTop?: boolean;
   // UserProfile
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  onBeforeStartDirectMessage?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams;
   onStartDirectMessage?: (channel: GroupChannel) => void;
   /**
    * @deprecated Please use `onStartDirectMessage` instead. It's renamed.
    */
   onUserProfileMessage?: (channel: GroupChannel) => void;
-  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
 
   // Customer provided callbacks
   eventHandlers?: SBUEventHandlers;
@@ -242,8 +242,8 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
 
 export interface SendbirdStateConfig {
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  onBeforeStartDirectMessage?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams;
   onStartDirectMessage?: (props: GroupChannel) => void;
-  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
   allowProfileEdit: boolean;
   isOnline: boolean;
   userId: string;

--- a/src/lib/Sendbird/types.ts
+++ b/src/lib/Sendbird/types.ts
@@ -234,6 +234,7 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
    * @deprecated Please use `onStartDirectMessage` instead. It's renamed.
    */
   onUserProfileMessage?: (channel: GroupChannel) => void;
+  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
 
   // Customer provided callbacks
   eventHandlers?: SBUEventHandlers;
@@ -242,6 +243,7 @@ export interface SendbirdProviderProps extends CommonUIKitConfigProps, React.Pro
 export interface SendbirdStateConfig {
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onStartDirectMessage?: (props: GroupChannel) => void;
+  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
   allowProfileEdit: boolean;
   isOnline: boolean;
   userId: string;

--- a/src/lib/UserProfileContext.tsx
+++ b/src/lib/UserProfileContext.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
-import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import type { User } from '@sendbird/chat';
+import type { GroupChannel, GroupChannelCreateParams } from '@sendbird/chat/groupChannel';
 import type { RenderUserProfileProps } from '../types';
 import useSendbird from './Sendbird/context/hooks/useSendbird';
 
@@ -8,6 +9,7 @@ interface UserProfileContextInterface {
   disableUserProfile: boolean;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   onStartDirectMessage?: (channel: GroupChannel) => void;
+  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
 
   /**
    * @deprecated This prop has been renamed to `onStartDirectMessage`.
@@ -25,7 +27,7 @@ export const UserProfileContext = React.createContext<UserProfileContextInterfac
 });
 
 export type UserProfileProviderProps = React.PropsWithChildren<
-  Partial<UserProfileContextInterface>
+  Omit<Partial<UserProfileContextInterface>, 'onBeforeCreateChannel'>
   & {
     /** This prop is optional. It is no longer necessary to provide it because the value can be accessed through SendbirdStateContext. */
     disableUserProfile?: boolean;
@@ -55,6 +57,7 @@ export const UserProfileProvider = ({
         disableUserProfile: _disableUserProfile ?? !config.common.enableUsingDefaultUserProfile,
         renderUserProfile: _renderUserProfile ?? config.renderUserProfile,
         onStartDirectMessage,
+        onBeforeCreateChannel: config.onBeforeCreateChannel,
         /** legacy of onStartDirectMessage */
         onUserProfileMessage: onStartDirectMessage,
       }}

--- a/src/lib/UserProfileContext.tsx
+++ b/src/lib/UserProfileContext.tsx
@@ -8,8 +8,8 @@ interface UserProfileContextInterface {
   isOpenChannel: boolean;
   disableUserProfile: boolean;
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
+  onBeforeStartDirectMessage?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams;
   onStartDirectMessage?: (channel: GroupChannel) => void;
-  onBeforeCreateChannel?: (channelParams: GroupChannelCreateParams, users: User[]) => GroupChannelCreateParams | Promise<GroupChannelCreateParams>;
 
   /**
    * @deprecated This prop has been renamed to `onStartDirectMessage`.
@@ -27,7 +27,7 @@ export const UserProfileContext = React.createContext<UserProfileContextInterfac
 });
 
 export type UserProfileProviderProps = React.PropsWithChildren<
-  Omit<Partial<UserProfileContextInterface>, 'onBeforeCreateChannel'>
+  Partial<UserProfileContextInterface>
   & {
     /** This prop is optional. It is no longer necessary to provide it because the value can be accessed through SendbirdStateContext. */
     disableUserProfile?: boolean;
@@ -43,6 +43,7 @@ export const UserProfileProvider = ({
   disableUserProfile: _disableUserProfile = false,
   renderUserProfile: _renderUserProfile,
   onUserProfileMessage: _onUserProfileMessage,
+  onBeforeStartDirectMessage: _onBeforeStartDirectMessage,
   onStartDirectMessage: _onStartDirectMessage,
   children,
 }: UserProfileProviderProps) => {
@@ -56,8 +57,8 @@ export const UserProfileProvider = ({
         isOpenChannel,
         disableUserProfile: _disableUserProfile ?? !config.common.enableUsingDefaultUserProfile,
         renderUserProfile: _renderUserProfile ?? config.renderUserProfile,
+        onBeforeStartDirectMessage: _onBeforeStartDirectMessage ?? config.onBeforeStartDirectMessage,
         onStartDirectMessage,
-        onBeforeCreateChannel: config.onBeforeCreateChannel,
         /** legacy of onStartDirectMessage */
         onUserProfileMessage: onStartDirectMessage,
       }}

--- a/src/lib/__tests__/UserProfileContext.spec.tsx
+++ b/src/lib/__tests__/UserProfileContext.spec.tsx
@@ -1,0 +1,52 @@
+import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { UserProfileProvider, UserProfileContext } from '../UserProfileContext';
+
+const { configOnBeforeCreateChannel } = vi.hoisted(() => ({ configOnBeforeCreateChannel: vi.fn() }));
+
+const mockConfig = {
+  common: { enableUsingDefaultUserProfile: true },
+  renderUserProfile: undefined,
+  onStartDirectMessage: undefined,
+  onBeforeCreateChannel: configOnBeforeCreateChannel,
+};
+
+vi.mock('../Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: { config: mockConfig } })),
+}));
+
+const Consumer = () => {
+  const ctx = useContext(UserProfileContext);
+  return (
+    <div data-testid="result">
+      {ctx.onBeforeCreateChannel === configOnBeforeCreateChannel ? 'from-config' : 'other'}
+    </div>
+  );
+};
+
+describe('UserProfileProvider - onBeforeCreateChannel wiring', () => {
+  it('exposes config.onBeforeCreateChannel through the context value', () => {
+    render(
+      <UserProfileProvider>
+        <Consumer />
+      </UserProfileProvider>,
+    );
+    expect(screen.getByTestId('result')).toHaveTextContent('from-config');
+  });
+
+  it('ignores a spread onBeforeCreateChannel prop and always reads from config (create-list flow must not leak in)', () => {
+    const listFlowCallback = vi.fn();
+    const spreadProps = { onBeforeCreateChannel: listFlowCallback } as any;
+
+    render(
+      <UserProfileProvider {...spreadProps}>
+        <Consumer />
+      </UserProfileProvider>,
+    );
+
+    expect(screen.getByTestId('result')).toHaveTextContent('from-config');
+  });
+});

--- a/src/lib/__tests__/UserProfileContext.spec.tsx
+++ b/src/lib/__tests__/UserProfileContext.spec.tsx
@@ -1,16 +1,16 @@
 import React, { useContext } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { UserProfileProvider, UserProfileContext } from '../UserProfileContext';
 
-const { configOnBeforeCreateChannel } = vi.hoisted(() => ({ configOnBeforeCreateChannel: vi.fn() }));
+const { configCallback } = vi.hoisted(() => ({ configCallback: vi.fn() }));
 
 const mockConfig = {
   common: { enableUsingDefaultUserProfile: true },
   renderUserProfile: undefined,
   onStartDirectMessage: undefined,
-  onBeforeCreateChannel: configOnBeforeCreateChannel,
+  onBeforeStartDirectMessage: configCallback,
 };
 
 vi.mock('../Sendbird/context/hooks/useSendbird', () => ({
@@ -18,35 +18,44 @@ vi.mock('../Sendbird/context/hooks/useSendbird', () => ({
   default: vi.fn(() => ({ state: { config: mockConfig } })),
 }));
 
+let captured: unknown;
 const Consumer = () => {
-  const ctx = useContext(UserProfileContext);
-  return (
-    <div data-testid="result">
-      {ctx.onBeforeCreateChannel === configOnBeforeCreateChannel ? 'from-config' : 'other'}
-    </div>
-  );
+  captured = useContext(UserProfileContext).onBeforeStartDirectMessage;
+  return null;
 };
 
-describe('UserProfileProvider - onBeforeCreateChannel wiring', () => {
-  it('exposes config.onBeforeCreateChannel through the context value', () => {
+describe('UserProfileProvider - onBeforeStartDirectMessage wiring', () => {
+  beforeEach(() => {
+    captured = undefined;
+  });
+
+  it('exposes config.onBeforeStartDirectMessage through the context value', () => {
     render(
       <UserProfileProvider>
         <Consumer />
       </UserProfileProvider>,
     );
-    expect(screen.getByTestId('result')).toHaveTextContent('from-config');
+    expect(captured).toBe(configCallback);
   });
 
-  it('ignores a spread onBeforeCreateChannel prop and always reads from config (create-list flow must not leak in)', () => {
+  it('lets a provider prop override the config value', () => {
+    const propCallback = vi.fn();
+    render(
+      <UserProfileProvider onBeforeStartDirectMessage={propCallback}>
+        <Consumer />
+      </UserProfileProvider>,
+    );
+    expect(captured).toBe(propCallback);
+  });
+
+  it('is unaffected by the unrelated create-list onBeforeCreateChannel prop', () => {
     const listFlowCallback = vi.fn();
     const spreadProps = { onBeforeCreateChannel: listFlowCallback } as any;
-
     render(
       <UserProfileProvider {...spreadProps}>
         <Consumer />
       </UserProfileProvider>,
     );
-
-    expect(screen.getByTestId('result')).toHaveTextContent('from-config');
+    expect(captured).toBe(configCallback);
   });
 });

--- a/src/modules/App/__tests__/App.spec.tsx
+++ b/src/modules/App/__tests__/App.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import App from '../index';
+
+const { sendbirdCapture } = vi.hoisted(() => ({
+  sendbirdCapture: { props: null as any },
+}));
+
+// Isolate App from the real provider/SDK: capture the props App passes down.
+vi.mock('../../../lib/Sendbird', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    sendbirdCapture.props = props;
+    return null;
+  },
+}));
+
+vi.mock('../AppLayout', () => ({
+  __esModule: true,
+  AppLayout: () => null,
+}));
+
+describe('App - direct-message hook forwarding', () => {
+  beforeEach(() => {
+    sendbirdCapture.props = null;
+  });
+
+  it('forwards onBeforeStartDirectMessage straight to SendbirdProvider', () => {
+    const onBeforeStartDirectMessage = vi.fn((params) => params);
+    render(<App appId="app-id" userId="user-id" onBeforeStartDirectMessage={onBeforeStartDirectMessage} />);
+
+    expect(sendbirdCapture.props.onBeforeStartDirectMessage).toBe(onBeforeStartDirectMessage);
+  });
+});

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -35,6 +35,7 @@ export interface AppProps {
   allowProfileEdit?: SendbirdProviderProps['allowProfileEdit'];
   disableMarkAsDelivered?: SendbirdProviderProps['disableMarkAsDelivered'];
   renderUserProfile?: SendbirdProviderProps['renderUserProfile'];
+  onBeforeCreateChannel?: SendbirdProviderProps['onBeforeCreateChannel'];
   imageCompression?: SendbirdProviderProps['imageCompression'];
   uikitOptions?: SendbirdProviderProps['uikitOptions'];
   isUserIdUsedForNickname?: SendbirdProviderProps['isUserIdUsedForNickname'];
@@ -93,6 +94,7 @@ export default function App(props: AppProps) {
     allowProfileEdit = false,
     disableMarkAsDelivered = false,
     renderUserProfile,
+    onBeforeCreateChannel,
     onProfileEditSuccess,
     imageCompression = {},
     disableAutoSelect = false,
@@ -138,6 +140,7 @@ export default function App(props: AppProps) {
       colorSet={colorSet}
       disableMarkAsDelivered={disableMarkAsDelivered}
       renderUserProfile={renderUserProfile}
+      onBeforeCreateChannel={onBeforeCreateChannel}
       imageCompression={imageCompression}
       isMultipleFilesMessageEnabled={isMultipleFilesMessageEnabled}
       autoscrollMessageOverflowToTop={autoscrollMessageOverflowToTop}

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -35,7 +35,7 @@ export interface AppProps {
   allowProfileEdit?: SendbirdProviderProps['allowProfileEdit'];
   disableMarkAsDelivered?: SendbirdProviderProps['disableMarkAsDelivered'];
   renderUserProfile?: SendbirdProviderProps['renderUserProfile'];
-  onBeforeCreateChannel?: SendbirdProviderProps['onBeforeCreateChannel'];
+  onBeforeStartDirectMessage?: SendbirdProviderProps['onBeforeStartDirectMessage'];
   imageCompression?: SendbirdProviderProps['imageCompression'];
   uikitOptions?: SendbirdProviderProps['uikitOptions'];
   isUserIdUsedForNickname?: SendbirdProviderProps['isUserIdUsedForNickname'];
@@ -94,7 +94,7 @@ export default function App(props: AppProps) {
     allowProfileEdit = false,
     disableMarkAsDelivered = false,
     renderUserProfile,
-    onBeforeCreateChannel,
+    onBeforeStartDirectMessage,
     onProfileEditSuccess,
     imageCompression = {},
     disableAutoSelect = false,
@@ -140,7 +140,7 @@ export default function App(props: AppProps) {
       colorSet={colorSet}
       disableMarkAsDelivered={disableMarkAsDelivered}
       renderUserProfile={renderUserProfile}
-      onBeforeCreateChannel={onBeforeCreateChannel}
+      onBeforeStartDirectMessage={onBeforeStartDirectMessage}
       imageCompression={imageCompression}
       isMultipleFilesMessageEnabled={isMultipleFilesMessageEnabled}
       autoscrollMessageOverflowToTop={autoscrollMessageOverflowToTop}

--- a/src/ui/MentionLabel/__tests__/MentionLabel.spec.tsx
+++ b/src/ui/MentionLabel/__tests__/MentionLabel.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import MentionLabel from '../index';
+import { LocalizationContext } from '../../../lib/LocalizationContext';
+import { UserProfileContext } from '../../../lib/UserProfileContext';
+
+// No `createApplicationUserListQuery` => clicking the mention opens the popup immediately.
+const mockState = {
+  config: { userId: 'me', logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn() } },
+  stores: { sdkStore: { sdk: {} } },
+};
+
+vi.mock('../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: mockState })),
+}));
+
+// Render dropdown/menu content inline instead of through a portal.
+vi.mock('react-dom', async () => ({
+  ...(await vi.importActual<typeof import('react-dom')>('react-dom')),
+  createPortal: (node: React.ReactNode) => node,
+}));
+
+const stringSet = {
+  USER_PROFILE__MESSAGE: 'Message',
+  USER_PROFILE__USER_ID: 'User ID',
+  NO_NAME: '(No name)',
+};
+
+const renderMention = (contextValue: Record<string, unknown> = {}) => render(
+  <LocalizationContext.Provider value={{ stringSet } as any}>
+    <UserProfileContext.Provider
+      value={{ isOpenChannel: false, disableUserProfile: false, ...contextValue } as any}
+    >
+      <MentionLabel
+        mentionTemplate="@"
+        mentionedUserId="other-user"
+        mentionedUserNickname="Other"
+        isByMe={false}
+      />
+    </UserProfileContext.Provider>
+  </LocalizationContext.Provider>,
+);
+
+describe('MentionLabel - renderUserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // MenuItems renders its dropdown into this portal root; without it, it renders nothing.
+    const portalRoot = document.createElement('div');
+    portalRoot.id = 'sendbird-dropdown-portal';
+    document.body.appendChild(portalRoot);
+  });
+
+  afterEach(() => {
+    document.getElementById('sendbird-dropdown-portal')?.remove();
+  });
+
+  it('renders renderUserProfile output when a custom renderer is provided', () => {
+    const renderUserProfile = vi.fn(() => <div data-testid="custom-profile">CUSTOM PROFILE</div>);
+
+    renderMention({ renderUserProfile });
+
+    // Open the popup by clicking the mention.
+    fireEvent.click(screen.getByText('@Other'));
+
+    expect(screen.getByTestId('custom-profile')).toBeInTheDocument();
+    expect(renderUserProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ currentUserId: 'me', close: expect.any(Function) }),
+    );
+  });
+
+  it('renders the default UserProfile popup when no custom renderer is provided (backward compatibility)', () => {
+    renderMention({});
+
+    fireEvent.click(screen.getByText('@Other'));
+
+    // The default popup (with its Message button) is shown, not a custom node.
+    expect(screen.queryByTestId('custom-profile')).not.toBeInTheDocument();
+    expect(screen.getByText('Message')).toBeInTheDocument();
+  });
+});

--- a/src/ui/MentionLabel/__tests__/MentionLabel.spec.tsx
+++ b/src/ui/MentionLabel/__tests__/MentionLabel.spec.tsx
@@ -6,10 +6,9 @@ import MentionLabel from '../index';
 import { LocalizationContext } from '../../../lib/LocalizationContext';
 import { UserProfileContext } from '../../../lib/UserProfileContext';
 
-// No `createApplicationUserListQuery` => clicking the mention opens the popup immediately.
 const mockState = {
   config: { userId: 'me', logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn() } },
-  stores: { sdkStore: { sdk: {} } },
+  stores: { sdkStore: { sdk: {} as any } },
 };
 
 vi.mock('../../../lib/Sendbird/context/hooks/useSendbird', () => ({
@@ -17,7 +16,6 @@ vi.mock('../../../lib/Sendbird/context/hooks/useSendbird', () => ({
   default: vi.fn(() => ({ state: mockState })),
 }));
 
-// Render dropdown/menu content inline instead of through a portal.
 vi.mock('react-dom', async () => ({
   ...(await vi.importActual<typeof import('react-dom')>('react-dom')),
   createPortal: (node: React.ReactNode) => node,
@@ -28,6 +26,10 @@ const stringSet = {
   USER_PROFILE__USER_ID: 'User ID',
   NO_NAME: '(No name)',
 };
+
+const sdkReturningUsers = (members: unknown[]) => ({
+  createApplicationUserListQuery: () => ({ next: () => Promise.resolve(members) }),
+});
 
 const renderMention = (contextValue: Record<string, unknown> = {}) => render(
   <LocalizationContext.Provider value={{ stringSet } as any}>
@@ -47,7 +49,7 @@ const renderMention = (contextValue: Record<string, unknown> = {}) => render(
 describe('MentionLabel - renderUserProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // MenuItems renders its dropdown into this portal root; without it, it renders nothing.
+    mockState.stores.sdkStore.sdk = {};
     const portalRoot = document.createElement('div');
     portalRoot.id = 'sendbird-dropdown-portal';
     document.body.appendChild(portalRoot);
@@ -57,26 +59,39 @@ describe('MentionLabel - renderUserProfile', () => {
     document.getElementById('sendbird-dropdown-portal')?.remove();
   });
 
-  it('renders renderUserProfile output when a custom renderer is provided', () => {
+  it('renders renderUserProfile with the fetched user when a custom renderer is provided', async () => {
+    mockState.stores.sdkStore.sdk = sdkReturningUsers([{ userId: 'other-user', nickname: 'Other' }]);
     const renderUserProfile = vi.fn(() => <div data-testid="custom-profile">CUSTOM PROFILE</div>);
 
     renderMention({ renderUserProfile });
-
-    // Open the popup by clicking the mention.
     fireEvent.click(screen.getByText('@Other'));
 
-    expect(screen.getByTestId('custom-profile')).toBeInTheDocument();
+    expect(await screen.findByTestId('custom-profile')).toBeInTheDocument();
     expect(renderUserProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ currentUserId: 'me', close: expect.any(Function) }),
+      expect.objectContaining({
+        user: expect.objectContaining({ userId: 'other-user' }),
+        currentUserId: 'me',
+        close: expect.any(Function),
+      }),
     );
+  });
+
+  it('falls back to the default popup when the mentioned user cannot be resolved', async () => {
+    mockState.stores.sdkStore.sdk = sdkReturningUsers([]);
+    const renderUserProfile = vi.fn(() => <div data-testid="custom-profile">CUSTOM PROFILE</div>);
+
+    renderMention({ renderUserProfile });
+    fireEvent.click(screen.getByText('@Other'));
+
+    expect(await screen.findByText('Message')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-profile')).not.toBeInTheDocument();
+    expect(renderUserProfile).not.toHaveBeenCalled();
   });
 
   it('renders the default UserProfile popup when no custom renderer is provided (backward compatibility)', () => {
     renderMention({});
-
     fireEvent.click(screen.getByText('@Other'));
 
-    // The default popup (with its Message button) is shown, not a custom node.
     expect(screen.queryByTestId('custom-profile')).not.toBeInTheDocument();
     expect(screen.getByText('Message')).toBeInTheDocument();
   });

--- a/src/ui/MentionLabel/index.tsx
+++ b/src/ui/MentionLabel/index.tsx
@@ -79,9 +79,9 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
         </a>
       )}
       menuItems={(closeDropdown: () => void): ReactElement => (
-        renderUserProfile ? (
+        renderUserProfile && user ? (
           renderUserProfile({
-            user: user as User,
+            user,
             close: closeDropdown,
             currentUserId: userId,
             avatarRef: mentionRef,

--- a/src/ui/MentionLabel/index.tsx
+++ b/src/ui/MentionLabel/index.tsx
@@ -13,6 +13,7 @@ import Label, { LabelTypography, LabelColors } from '../Label';
 import UserProfile from '../UserProfile';
 import { classnames } from '../../utils/utils';
 import useSendbird from '../../lib/Sendbird/context/hooks/useSendbird';
+import { useUserProfileContext } from '../../lib/UserProfileContext';
 
 interface MentionLabelProps {
   mentionTemplate: string;
@@ -32,6 +33,7 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
   const mentionRef = useRef<HTMLAnchorElement>();
 
   const { state } = useSendbird();
+  const { renderUserProfile } = useUserProfileContext();
   const userId = state?.config?.userId;
   const sdk = state?.stores?.sdkStore?.sdk;
   const amIBeingMentioned = userId === mentionedUserId;
@@ -77,22 +79,31 @@ export default function MentionLabel(props: MentionLabelProps): JSX.Element {
         </a>
       )}
       menuItems={(closeDropdown: () => void): ReactElement => (
-        <MenuItems
-          /**
-          * parentRef: For catching location(x, y) of MenuItems
-          * parentContainRef: For toggling more options(menus & reactions)
-          */
-          parentRef={mentionRef}
-          parentContainRef={mentionRef}
-          closeDropdown={closeDropdown}
-          style={{ paddingTop: '0px', paddingBottom: '0px' }}
-        >
-          <UserProfile
-            user={user}
-            onSuccess={closeDropdown}
-            currentUserId={userId}
-          />
-        </MenuItems>
+        renderUserProfile ? (
+          renderUserProfile({
+            user: user as User,
+            close: closeDropdown,
+            currentUserId: userId,
+            avatarRef: mentionRef,
+          })
+        ) : (
+          <MenuItems
+            /**
+            * parentRef: For catching location(x, y) of MenuItems
+            * parentContainRef: For toggling more options(menus & reactions)
+            */
+            parentRef={mentionRef}
+            parentContainRef={mentionRef}
+            closeDropdown={closeDropdown}
+            style={{ paddingTop: '0px', paddingBottom: '0px' }}
+          >
+            <UserProfile
+              user={user}
+              onSuccess={closeDropdown}
+              currentUserId={userId}
+            />
+          </MenuItems>
+        )
       )}
     />
   );

--- a/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
+++ b/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
@@ -137,6 +137,20 @@ describe('UserProfile - onBeforeStartDirectMessage', () => {
     expect(onStartDirectMessage).not.toHaveBeenCalled();
   });
 
+  it('logs channel-create failure on the default path too (no onBeforeStartDirectMessage)', async () => {
+    mockCreateChannel.mockRejectedValueOnce(new Error('network'));
+    const onStartDirectMessage = vi.fn();
+
+    renderUserProfile({ onStartDirectMessage });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalledWith(
+      'UserProfile: channel create failed', expect.any(Error),
+    ));
+    expect(onStartDirectMessage).not.toHaveBeenCalled();
+  });
+
   it('closes the popup immediately (synchronously) even when onBeforeStartDirectMessage is set', () => {
     const onBeforeStartDirectMessage = vi.fn((params: GroupChannelCreateParams) => params);
     const onSuccess = vi.fn();

--- a/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
+++ b/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import type { GroupChannel, GroupChannelCreateParams } from '@sendbird/chat/groupChannel';
+
+import UserProfile from '../index';
+import { LocalizationContext } from '../../../lib/LocalizationContext';
+import { UserProfileContext } from '../../../lib/UserProfileContext';
+
+const { mockCreateChannel } = vi.hoisted(() => ({ mockCreateChannel: vi.fn() }));
+
+const mockState = {
+  config: {
+    userId: 'me',
+    logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  },
+};
+
+vi.mock('../../../lib/Sendbird/context/hooks/useSendbird', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ state: mockState })),
+}));
+
+vi.mock('../../../lib/selectors', () => ({
+  getCreateGroupChannel: () => mockCreateChannel,
+}));
+
+const stringSet = {
+  USER_PROFILE__MESSAGE: 'Message',
+  USER_PROFILE__USER_ID: 'User ID',
+  NO_NAME: '(No name)',
+};
+
+const renderUserProfile = (contextValue: Record<string, unknown>) => render(
+  <LocalizationContext.Provider value={{ stringSet } as any}>
+    <UserProfileContext.Provider
+      value={{
+        isOpenChannel: false,
+        disableUserProfile: false,
+        ...contextValue,
+      } as any}
+    >
+      <UserProfile
+        user={{ userId: 'other-user', nickname: 'Other' } as any}
+        currentUserId="me"
+        onSuccess={vi.fn()}
+      />
+    </UserProfileContext.Provider>
+  </LocalizationContext.Provider>,
+);
+
+describe('UserProfile - onBeforeCreateChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateChannel.mockResolvedValue({ url: 'created-channel' } as GroupChannel);
+  });
+
+  it('applies onBeforeCreateChannel to modify params before the channel is created', async () => {
+    const onBeforeCreateChannel = vi.fn((params: GroupChannelCreateParams) => ({
+      ...params,
+      isDistinct: true,
+      data: 'custom-metadata',
+    }));
+    const onStartDirectMessage = vi.fn();
+
+    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    await waitFor(() => expect(mockCreateChannel).toHaveBeenCalledTimes(1));
+
+    // The callback receives the default params and the target user(s).
+    expect(onBeforeCreateChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDistinct: false,
+        invitedUserIds: ['other-user'],
+        operatorUserIds: ['me'],
+      }),
+      [expect.objectContaining({ userId: 'other-user' })],
+    );
+    // createChannel must receive the PROCESSED params, not the defaults.
+    expect(mockCreateChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ isDistinct: true, data: 'custom-metadata', invitedUserIds: ['other-user'] }),
+    );
+    // The after-hook still fires with the created channel.
+    await waitFor(() => expect(onStartDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'created-channel' }),
+    ));
+  });
+
+  it('supports an async onBeforeCreateChannel', async () => {
+    const onBeforeCreateChannel = vi.fn(async (params: GroupChannelCreateParams) => ({ ...params, isDistinct: true }));
+
+    renderUserProfile({ onBeforeCreateChannel });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    await waitFor(() => expect(mockCreateChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ isDistinct: true }),
+    ));
+  });
+
+  it('falls back to default params (isDistinct:false) when onBeforeCreateChannel is not provided (backward compatibility)', async () => {
+    const onStartDirectMessage = vi.fn();
+
+    renderUserProfile({ onStartDirectMessage });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    expect(mockCreateChannel).toHaveBeenCalledTimes(1);
+    expect(mockCreateChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDistinct: false,
+        invitedUserIds: ['other-user'],
+        operatorUserIds: ['me'],
+      }),
+    );
+
+    await waitFor(() => expect(onStartDirectMessage).toHaveBeenCalled());
+  });
+});

--- a/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
+++ b/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
@@ -31,7 +31,7 @@ const stringSet = {
   NO_NAME: '(No name)',
 };
 
-const renderUserProfile = (contextValue: Record<string, unknown>) => render(
+const renderUserProfile = (contextValue: Record<string, unknown>, onSuccess: () => void = vi.fn()) => render(
   <LocalizationContext.Provider value={{ stringSet } as any}>
     <UserProfileContext.Provider
       value={{
@@ -43,7 +43,7 @@ const renderUserProfile = (contextValue: Record<string, unknown>) => render(
       <UserProfile
         user={{ userId: 'other-user', nickname: 'Other' } as any}
         currentUserId="me"
-        onSuccess={vi.fn()}
+        onSuccess={onSuccess}
       />
     </UserProfileContext.Provider>
   </LocalizationContext.Provider>,
@@ -143,5 +143,16 @@ describe('UserProfile - onBeforeCreateChannel', () => {
     await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalled());
     expect(mockCreateChannel).not.toHaveBeenCalled();
     expect(onStartDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it('closes the popup immediately (synchronously) even when onBeforeCreateChannel is set', () => {
+    const onBeforeCreateChannel = vi.fn((params: GroupChannelCreateParams) => params);
+    const onSuccess = vi.fn();
+
+    renderUserProfile({ onBeforeCreateChannel }, onSuccess);
+
+    fireEvent.click(screen.getByText('Message'));
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
+++ b/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
@@ -118,4 +118,30 @@ describe('UserProfile - onBeforeCreateChannel', () => {
 
     await waitFor(() => expect(onStartDirectMessage).toHaveBeenCalled());
   });
+
+  it('logs and creates no channel when a synchronous onBeforeCreateChannel throws', async () => {
+    const onBeforeCreateChannel = vi.fn(() => { throw new Error('boom'); });
+    const onStartDirectMessage = vi.fn();
+
+    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalled());
+    expect(mockCreateChannel).not.toHaveBeenCalled();
+    expect(onStartDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs and creates no channel when an async onBeforeCreateChannel rejects', async () => {
+    const onBeforeCreateChannel = vi.fn(async () => { throw new Error('boom'); });
+    const onStartDirectMessage = vi.fn();
+
+    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+
+    fireEvent.click(screen.getByText('Message'));
+
+    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalled());
+    expect(mockCreateChannel).not.toHaveBeenCalled();
+    expect(onStartDirectMessage).not.toHaveBeenCalled();
+  });
 });

--- a/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
+++ b/src/ui/UserProfile/__tests__/UserProfile.spec.tsx
@@ -49,28 +49,28 @@ const renderUserProfile = (contextValue: Record<string, unknown>, onSuccess: () 
   </LocalizationContext.Provider>,
 );
 
-describe('UserProfile - onBeforeCreateChannel', () => {
+describe('UserProfile - onBeforeStartDirectMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateChannel.mockResolvedValue({ url: 'created-channel' } as GroupChannel);
   });
 
-  it('applies onBeforeCreateChannel to modify params before the channel is created', async () => {
-    const onBeforeCreateChannel = vi.fn((params: GroupChannelCreateParams) => ({
+  it('applies onBeforeStartDirectMessage to modify params before the channel is created', async () => {
+    const onBeforeStartDirectMessage = vi.fn((params: GroupChannelCreateParams) => ({
       ...params,
       isDistinct: true,
       data: 'custom-metadata',
     }));
     const onStartDirectMessage = vi.fn();
 
-    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+    renderUserProfile({ onBeforeStartDirectMessage, onStartDirectMessage });
 
     fireEvent.click(screen.getByText('Message'));
 
     await waitFor(() => expect(mockCreateChannel).toHaveBeenCalledTimes(1));
 
     // The callback receives the default params and the target user(s).
-    expect(onBeforeCreateChannel).toHaveBeenCalledWith(
+    expect(onBeforeStartDirectMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         isDistinct: false,
         invitedUserIds: ['other-user'],
@@ -88,19 +88,7 @@ describe('UserProfile - onBeforeCreateChannel', () => {
     ));
   });
 
-  it('supports an async onBeforeCreateChannel', async () => {
-    const onBeforeCreateChannel = vi.fn(async (params: GroupChannelCreateParams) => ({ ...params, isDistinct: true }));
-
-    renderUserProfile({ onBeforeCreateChannel });
-
-    fireEvent.click(screen.getByText('Message'));
-
-    await waitFor(() => expect(mockCreateChannel).toHaveBeenCalledWith(
-      expect.objectContaining({ isDistinct: true }),
-    ));
-  });
-
-  it('falls back to default params (isDistinct:false) when onBeforeCreateChannel is not provided (backward compatibility)', async () => {
+  it('falls back to default params (isDistinct:false) when onBeforeStartDirectMessage is not provided (backward compatibility)', async () => {
     const onStartDirectMessage = vi.fn();
 
     renderUserProfile({ onStartDirectMessage });
@@ -119,37 +107,41 @@ describe('UserProfile - onBeforeCreateChannel', () => {
     await waitFor(() => expect(onStartDirectMessage).toHaveBeenCalled());
   });
 
-  it('logs and creates no channel when a synchronous onBeforeCreateChannel throws', async () => {
-    const onBeforeCreateChannel = vi.fn(() => { throw new Error('boom'); });
+  it('logs onBeforeStartDirectMessage failure distinctly and creates no channel (sync throw)', async () => {
+    const onBeforeStartDirectMessage = vi.fn(() => { throw new Error('boom'); });
     const onStartDirectMessage = vi.fn();
 
-    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+    renderUserProfile({ onBeforeStartDirectMessage, onStartDirectMessage });
 
     fireEvent.click(screen.getByText('Message'));
 
-    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalled());
+    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalledWith(
+      'UserProfile: onBeforeStartDirectMessage failed', expect.any(Error),
+    ));
     expect(mockCreateChannel).not.toHaveBeenCalled();
     expect(onStartDirectMessage).not.toHaveBeenCalled();
   });
 
-  it('logs and creates no channel when an async onBeforeCreateChannel rejects', async () => {
-    const onBeforeCreateChannel = vi.fn(async () => { throw new Error('boom'); });
+  it('logs channel-create failure distinctly when createChannel rejects', async () => {
+    mockCreateChannel.mockRejectedValueOnce(new Error('network'));
+    const onBeforeStartDirectMessage = vi.fn((params: GroupChannelCreateParams) => params);
     const onStartDirectMessage = vi.fn();
 
-    renderUserProfile({ onBeforeCreateChannel, onStartDirectMessage });
+    renderUserProfile({ onBeforeStartDirectMessage, onStartDirectMessage });
 
     fireEvent.click(screen.getByText('Message'));
 
-    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalled());
-    expect(mockCreateChannel).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockState.config.logger.error).toHaveBeenCalledWith(
+      'UserProfile: channel create failed', expect.any(Error),
+    ));
     expect(onStartDirectMessage).not.toHaveBeenCalled();
   });
 
-  it('closes the popup immediately (synchronously) even when onBeforeCreateChannel is set', () => {
-    const onBeforeCreateChannel = vi.fn((params: GroupChannelCreateParams) => params);
+  it('closes the popup immediately (synchronously) even when onBeforeStartDirectMessage is set', () => {
+    const onBeforeStartDirectMessage = vi.fn((params: GroupChannelCreateParams) => params);
     const onSuccess = vi.fn();
 
-    renderUserProfile({ onBeforeCreateChannel }, onSuccess);
+    renderUserProfile({ onBeforeStartDirectMessage }, onSuccess);
 
     fireEvent.click(screen.getByText('Message'));
 

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -67,13 +67,15 @@ function UserProfile({
                 };
                 onSuccess?.();
                 const startDirectMessage = (groupChannel: GroupChannel) => {
-                  logger.info('UserProfile, channel create', groupChannel);
+                  logger.info('UserProfile: channel create', groupChannel);
                   onStartDirectMessage?.(groupChannel);
                 };
                 if (onBeforeCreateChannel) {
-                  Promise.resolve(onBeforeCreateChannel(params, user ? [user] : []))
+                  Promise.resolve()
+                    .then(() => onBeforeCreateChannel(params, user ? [user] : []))
                     .then((processedParams) => createChannel(processedParams))
-                    .then(startDirectMessage);
+                    .then(startDirectMessage)
+                    .catch((error) => logger.error('UserProfile: channel create failed', error));
                 } else {
                   createChannel(params).then(startDirectMessage);
                 }

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -70,20 +70,18 @@ function UserProfile({
                   logger.info('UserProfile: channel create', groupChannel);
                   onStartDirectMessage?.(groupChannel);
                 };
+                let processedParams = params;
                 if (onBeforeStartDirectMessage) {
-                  let processedParams: GroupChannelCreateParams;
                   try {
                     processedParams = onBeforeStartDirectMessage(params, user ? [user] : []);
                   } catch (error) {
                     logger.error('UserProfile: onBeforeStartDirectMessage failed', error);
                     return;
                   }
-                  createChannel(processedParams)
-                    .then(startDirectMessage)
-                    .catch((error) => logger.error('UserProfile: channel create failed', error));
-                } else {
-                  createChannel(params).then(startDirectMessage);
                 }
+                createChannel(processedParams)
+                  .then(startDirectMessage)
+                  .catch((error) => logger.error('UserProfile: channel create failed', error));
               }}
             >
               {stringSet.USER_PROFILE__MESSAGE}

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -35,7 +35,7 @@ function UserProfile({
   const logger = state?.config?.logger;
   const { stringSet } = useContext(LocalizationContext);
   const currentUserId_ = currentUserId || state?.config?.userId;
-  const { onStartDirectMessage, onBeforeCreateChannel } = useUserProfileContext();
+  const { onBeforeStartDirectMessage, onStartDirectMessage } = useUserProfileContext();
   return (
     <div className="sendbird__user-profile">
       <section className="sendbird__user-profile-avatar">
@@ -70,10 +70,15 @@ function UserProfile({
                   logger.info('UserProfile: channel create', groupChannel);
                   onStartDirectMessage?.(groupChannel);
                 };
-                if (onBeforeCreateChannel) {
-                  Promise.resolve()
-                    .then(() => onBeforeCreateChannel(params, user ? [user] : []))
-                    .then((processedParams) => createChannel(processedParams))
+                if (onBeforeStartDirectMessage) {
+                  let processedParams: GroupChannelCreateParams;
+                  try {
+                    processedParams = onBeforeStartDirectMessage(params, user ? [user] : []);
+                  } catch (error) {
+                    logger.error('UserProfile: onBeforeStartDirectMessage failed', error);
+                    return;
+                  }
+                  createChannel(processedParams)
                     .then(startDirectMessage)
                     .catch((error) => logger.error('UserProfile: channel create failed', error));
                 } else {

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -67,7 +67,7 @@ function UserProfile({
                 };
                 onSuccess?.();
                 const startDirectMessage = (groupChannel: GroupChannel) => {
-                  logger.info('UserProfile: channel create', groupChannel);
+                  logger?.info('UserProfile: channel create', groupChannel);
                   onStartDirectMessage?.(groupChannel);
                 };
                 let processedParams = params;
@@ -75,13 +75,13 @@ function UserProfile({
                   try {
                     processedParams = onBeforeStartDirectMessage(params, user ? [user] : []);
                   } catch (error) {
-                    logger.error('UserProfile: onBeforeStartDirectMessage failed', error);
+                    logger?.error('UserProfile: onBeforeStartDirectMessage failed', error);
                     return;
                   }
                 }
                 createChannel(processedParams)
                   .then(startDirectMessage)
-                  .catch((error) => logger.error('UserProfile: channel create failed', error));
+                  .catch((error) => logger?.error('UserProfile: channel create failed', error));
               }}
             >
               {stringSet.USER_PROFILE__MESSAGE}

--- a/src/ui/UserProfile/index.tsx
+++ b/src/ui/UserProfile/index.tsx
@@ -35,7 +35,7 @@ function UserProfile({
   const logger = state?.config?.logger;
   const { stringSet } = useContext(LocalizationContext);
   const currentUserId_ = currentUserId || state?.config?.userId;
-  const { onStartDirectMessage } = useUserProfileContext();
+  const { onStartDirectMessage, onBeforeCreateChannel } = useUserProfileContext();
   return (
     <div className="sendbird__user-profile">
       <section className="sendbird__user-profile-avatar">
@@ -66,11 +66,17 @@ function UserProfile({
                   operatorUserIds: [currentUserId_],
                 };
                 onSuccess?.();
-                createChannel(params)
-                  .then((groupChannel) => {
-                    logger.info('UserProfile, channel create', groupChannel);
-                    onStartDirectMessage?.(groupChannel);
-                  });
+                const startDirectMessage = (groupChannel: GroupChannel) => {
+                  logger.info('UserProfile, channel create', groupChannel);
+                  onStartDirectMessage?.(groupChannel);
+                };
+                if (onBeforeCreateChannel) {
+                  Promise.resolve(onBeforeCreateChannel(params, user ? [user] : []))
+                    .then((processedParams) => createChannel(processedParams))
+                    .then(startDirectMessage);
+                } else {
+                  createChannel(params).then(startDirectMessage);
+                }
               }}
             >
               {stringSet.USER_PROFILE__MESSAGE}


### PR DESCRIPTION
## Changes

### 1. `renderUserProfile` now applies to `@mention` popups
Clicking an `@mention` previously always opened UIKit's default popup, ignoring `renderUserProfile` (unlike avatar clicks). `MentionLabel` now consumes `UserProfileContext` and renders `renderUserProfile` when provided — matching the avatar flow — and falls back to the default popup when the mentioned user cannot be resolved.

### 2. New `onBeforeStartDirectMessage` callback
```ts
onBeforeStartDirectMessage?: (
  channelParams: GroupChannelCreateParams,
  users: User[],
) => GroupChannelCreateParams;
```
Optional prop on `SendbirdProvider` (and `App`). It runs right before the **default** profile popup's **Message** button creates the 1:1 channel, letting apps customize the creation parameters — e.g. `isDistinct: true`, `data`, `customType`.

```tsx
import SendbirdProvider from '@sendbird/uikit-react/SendbirdProvider';

// Keep the default profile popup; customize only the 1:1 channel-creation params
<SendbirdProvider
  appId={APP_ID}
  userId={USER_ID}
  onBeforeStartDirectMessage={(channelParams, users) => ({
    ...channelParams,
    isDistinct: true,
    data: JSON.stringify({ source: 'mention' }),
  })}
>
  {/* ... */}
</SendbirdProvider>
```

> **Note — these two are for different scenarios, not to be combined.** `onBeforeStartDirectMessage` customizes the **default** popup's channel creation. `renderUserProfile` **replaces** the popup entirely, so when it is set the default popup (and its Message button) is not rendered and `onBeforeStartDirectMessage` does not run — a custom popup is expected to implement its own channel creation.

## Backward compatibility
- Both props are additive and optional. When `onBeforeStartDirectMessage` is not set, the original create path is unchanged. Nothing in the existing public API is renamed or removed.
- `onBeforeStartDirectMessage` (profile flow) is a distinct name from the pre-existing list/create-module `onBeforeCreateChannel(users: string[])`, so there is no clash.
- Channel-creation errors are caught and logged via `logger.error`; the popup closes immediately on click (unchanged), which prevents duplicate creation.
- The `@mention` popup is intentionally not gated on `disableUserProfile`, preserving the existing always-open default for mentions.

## Release note
- `renderUserProfile` now also applies to the popup opened by clicking an `@mention` (previously avatar clicks only). This only affects apps that already set `renderUserProfile`.
- New optional `onBeforeStartDirectMessage` callback to customize the 1:1 channel-creation params from the default profile popup's **Message** button.

## Testing
- 17 unit tests across `UserProfile`, `MentionLabel`, `UserProfileContext`, the `SendbirdProvider` migration spec, and `App`; new-behavior tests verified to fail on pre-fix code.
- `yarn typecheck` and `yarn lint` pass.
- Manually verified in the testing playground: mention `renderUserProfile` renders a custom popup; `onBeforeStartDirectMessage` returning `isDistinct: true` reuses the existing channel (no duplicate); a throwing callback is logged via `logger.error` with no uncaught error.
