### PR TITLE
[chore]: Bump @sendbird/chat to 4.22.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.22.10",
+    "@sendbird/chat": "^4.22.12",
     "@sendbird/react-uikit-message-template-view": "^0.1.5",
     "@sendbird/uikit-tools": "^0.1.5",
     "css-vars-ponyfill": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,15 +2891,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat@npm:^4.22.10":
-  version: 4.22.10
-  resolution: "@sendbird/chat@npm:4.22.10"
+"@sendbird/chat@npm:^4.22.12":
+  version: 4.22.12
+  resolution: "@sendbird/chat@npm:4.22.12"
   peerDependencies:
     react-native-mmkv: ">=2.0.0"
   peerDependenciesMeta:
     react-native-mmkv:
       optional: true
-  checksum: 2d3a338f38f21d1c02efa45e55e27d0f3198454f90bd742835c653bb029ff91309102ac5213fc79b10a9b29d01440c0c4b2f2393f8b967d4193124aefa06c728
+  checksum: c092869ddcde829f32b33273472261bf9aa1ad8674dbcce91876364ecc1bc9e16db6adaedb98eb019f320e711554a71dacd002164f161319bb568bbbb865c5d6
   languageName: node
   linkType: hard
 
@@ -2943,7 +2943,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.2.3
     "@rollup/plugin-replace": ^5.0.4
     "@rollup/plugin-typescript": ^11.1.5
-    "@sendbird/chat": ^4.22.10
+    "@sendbird/chat": ^4.22.12
     "@sendbird/react-uikit-message-template-view": ^0.1.5
     "@sendbird/uikit-tools": ^0.1.5
     "@storybook/addon-essentials": ^8.6.17


### PR DESCRIPTION
Raise the `@sendbird/chat` floor to 4.22.12, which carries the CLNP-8908 fix.

A provider remount while the socket was half-open stalled `connect()` until the
TCP timeout, leaving `GroupChannel` with no channels and no messages for about
two and a half minutes. `SendbirdProvider` awaits the previous provider's
`disconnectWebSocket()` teardown before connecting, and that promise never
settled because the SDK waited for a browser `onclose` event the environment may
never deliver. The runtime delta between 4.22.11 and 4.22.12 is that fix alone;
the remaining commits in the range are CI only.

Verified against the published artifact: the remount scenario no longer stalls,
sending and receiving both work with abandoned sockets accumulated, and
typecheck, lint, 980 tests and the build all pass.

Notes for integrators:
- 4.22.12 is the minimum. Forcing an older `@sendbird/chat` through yarn
  `resolutions`, npm `overrides`, or a bundler alias reintroduces the stall.
- `sendbirdSelectors.getDisconnect()` resolves without waiting for the socket
  close handshake.
- After an app-initiated `disconnectWebSocket()`, a session-key refresh no
  longer reconnects on its own.

Fixes [SBISSUE-21964](https://sendbird.atlassian.net/browse/SBISSUE-21964)

### Changelogs

- Fixed a bug where the `GroupChannel` message list could fail to load for
  around two and a half minutes when the provider remounted while the network
  was stalled

## Checklist

- [x] **All tests pass locally with my changes**
- [ ] **I have added tests that prove my fix is effective or that my feature works** (not applicable: dependency bump, no UIKit source change)
- [x] **Public components / utils / props are appropriately exported** (no public surface change)
- [ ] I have added necessary documentation (if appropriate)


[SBISSUE-21964]: https://sendbird.atlassian.net/browse/SBISSUE-21964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ