### PR TITLE
[CLNP-8841][doc]: correct the v3.19.0 @mention changelog note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Features
 - `renderUserProfile` now also applies to the profile popup opened by clicking an `@mention`
 
-  Previously the `@mention` popup always showed the default UI and ignored `renderUserProfile` (unlike avatar clicks). It now honors `renderUserProfile` and `disableUserProfile`, consistent with the other profile popups. This only affects apps that already provide `renderUserProfile`.
+  Previously the `@mention` popup always showed the default UI and ignored `renderUserProfile` (unlike avatar clicks). It now honors `renderUserProfile`, so a custom renderer applies to the mention popup too. This only affects apps that already provide `renderUserProfile`.
 - Added `onBeforeStartDirectMessage` to customize the 1:1 channel created from the profile popup's **Message** button
 
   This optional prop on `SendbirdProvider` (and `App`) runs right before the **default** profile popup creates the channel, so you can adjust the creation parameters — for example set `isDistinct: true` or attach `data` / `customType`. The callback also receives the target `users`.

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -1,7 +1,7 @@
 ### Features
 - `renderUserProfile` now also applies to the profile popup opened by clicking an `@mention`
 
-  Previously the `@mention` popup always showed the default UI and ignored `renderUserProfile` (unlike avatar clicks). It now honors `renderUserProfile` and `disableUserProfile`, consistent with the other profile popups. This only affects apps that already provide `renderUserProfile`.
+  Previously the `@mention` popup always showed the default UI and ignored `renderUserProfile` (unlike avatar clicks). It now honors `renderUserProfile`, so a custom renderer applies to the mention popup too. This only affects apps that already provide `renderUserProfile`.
 - Added `onBeforeStartDirectMessage` to customize the 1:1 channel created from the profile popup's **Message** button
 
   This optional prop on `SendbirdProvider` (and `App`) runs right before the **default** profile popup creates the channel, so you can adjust the creation parameters — for example set `isDistinct: true` or attach `data` / `customType`. The callback also receives the target `users`.


### PR DESCRIPTION
## Summary
Docs-only fix, flagged in review of the v3.19.0 release PR. The v3.19.0 changelog note for the `@mention` feature stated that the mention popup now honors both `renderUserProfile` and `disableUserProfile`, but the mention popup intentionally does **not** gate on `disableUserProfile` — it only applies `renderUserProfile`.

## Why the code is not changed
The `@mention` popup has always opened regardless of `disableUserProfile`. Gating it on `disableUserProfile` would stop the popup from opening for apps that set `disableUserProfile: true` — a behavior change deliberately avoided for backward compatibility (`MessageProfile`/avatar flow gates on it; `MentionLabel` intentionally does not). The code is correct as shipped; only the release note overstated it.

## Changes
- `CHANGELOG.md` — corrected the published v3.19.0 `@mention` note.
- `CHANGELOG_DRAFT.md` — same correction.

**Before:** It now honors `renderUserProfile` and `disableUserProfile`, consistent with the other profile popups.
**After:** It now honors `renderUserProfile`, so a custom renderer applies to the mention popup too.

No code changes; ships with the next release (v3.19.0 is already published).

