### PR TITLE
[CLNP-8926][fix]: bump js-yaml to its patched release in every lockfile

### DIFF
--- a/samples/router/package-lock.json
+++ b/samples/router/package-lock.json
@@ -2644,9 +2644,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -5272,9 +5272,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"

--- a/samples/typescript_sample/package-lock.json
+++ b/samples/typescript_sample/package-lock.json
@@ -2343,9 +2343,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -7377,9 +7377,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -10277,9 +10277,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,13 +9291,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 482740e69a1769b355d7182234c0fa197237f02e6a5c8c0b70a763af6a712c9741de350d784a5659e00cf03cedd6ebfa506d59ca45967e3ee50dd4f4df18f2e7
+  checksum: 3c9294448ed83fec340f017f2be056dab05bcba3fc742468a80275d264e982dfd94350a93640eb810e0fdf283bef7c1c810690cc69b7b04a187f781e079d2555
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

js-yaml is present on two version lines in this repository's lockfiles, and both
were below the patched release for the advisory tracked in CLNP-8926. Each line is
now on its fixed version. Lockfiles only — no manifest, config or source changes.

## Root cause

js-yaml is never a direct dependency here. It enters through three paths:

- the workspace, via `eslint`, `@eslint/eslintrc` and the `cosmiconfig` that
  `@svgr` pulls in — all devDependencies
- `samples/router`, through its own `eslint`
- `samples/typescript_sample`, twice: through `eslint`, and directly through
  `react-scripts`, which reaches it via `svgo` and `@istanbuljs/load-nyc-config`

The first three sit on the 4.x line; the last is pinned to `^3.13.1`.

## Changes

Four entries, each moved to the patched release on its own line:

| Lockfile | Before | After |
|---|---|---|
| `yarn.lock` | 4.3.1 | 4.3.2 |
| `samples/router/package-lock.json` | 4.3.1 | 4.3.2 |
| `samples/typescript_sample` (via eslint, ×2) | 4.3.1 | 4.3.2 |
| `samples/typescript_sample` (via react-scripts) | 3.15.1 | 3.15.2 |

**Why the last one is 3.15.2 and not the 4.3.2 named in the ticket.** That copy is
constrained to `^3.13.1` by react-scripts, and 4.x is not reachable there: svgo 1.x
calls `safeLoad`, which was removed in 4, so forcing the major would break the
sample. 3.15.2 is the patched release on the 3.x line, so the existing range
resolves to a fixed version with no dependency-tree surgery. `npm audit` reports no
js-yaml finding afterwards. Moving that sample off react-scripts would drop the 3.x
line entirely — the other three samples are already on Vite — but that is a larger
change and is tracked separately.

The workspace entry was re-resolved on its own rather than through a broad audit
pass, so the diff is the js-yaml entry and nothing else. A wider pass here has
carried unrelated majors before and needed build repairs in the same PR.

## Backward compatibility

No public API changes. js-yaml is a devDependency on every path — it is absent from
`dependencies`, from the built bundle, and from the published package, whose `files`
field covers only `release/`, `dist/`, `LICENSE` and `CHANGELOG.md`.

## Testing

- `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` — all pass
- `npm audit` in `samples/router` and `samples/typescript_sample` — no js-yaml
  finding remains
- Sample runtime behaviour was not exercised; it is unchanged by a lockfile bump and
  is tracked separately

### Changelogs

- Bumped js-yaml to its patched release (internal)
